### PR TITLE
Add margin to bottom of app header

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -136,6 +136,7 @@ namespace AppCenter.Views {
             header_grid.column_spacing = 12;
             header_grid.halign = Gtk.Align.CENTER;
             header_grid.margin = 12;
+            header_grid.margin_bottom = 24;
             header_grid.width_request = 800;
             header_grid.attach (image, 0, 0, 1, 2);
             header_grid.attach (package_name, 1, 0, 1, 1);


### PR DESCRIPTION
This doubles the margin to the bottom of the app view header. This balances the look.