### PR TITLE
Remove about dialog from .desktop

### DIFF
--- a/data/org.pantheon.appcenter.desktop.in.in
+++ b/data/org.pantheon.appcenter.desktop.in.in
@@ -11,7 +11,3 @@ Categories=GNOME;GTK;System;PackageManager;
 MimeType=x-scheme-handler/appstream;
 Actions=AboutDialog;
 X-GNOME-UsesNotifications=true
-
-[Desktop Action AboutDialog]
-_Name=About @APP_NAME@
-Exec=@EXEC_NAME@ --about

--- a/data/org.pantheon.appcenter.desktop.in.in
+++ b/data/org.pantheon.appcenter.desktop.in.in
@@ -9,5 +9,4 @@ Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;System;PackageManager;
 MimeType=x-scheme-handler/appstream;
-Actions=AboutDialog;
 X-GNOME-UsesNotifications=true

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -36,8 +36,8 @@ public class AppCenter.App : Granite.Application {
         Intl.setlocale (LocaleCategory.ALL, "");
         Intl.textdomain (Build.GETTEXT_PACKAGE);
 
-        program_name = _("App Center");
-        app_years = "2015-2016";
+        program_name = _("AppCenter");
+        app_years = "2015-2017";
         app_icon = Build.DESKTOP_ICON;
 
         build_data_dir = Build.DATADIR;
@@ -47,10 +47,6 @@ public class AppCenter.App : Granite.Application {
         build_version_info = Build.VERSION_INFO;
 
         app_launcher = "org.pantheon.appcenter.desktop";
-        main_url = "https://launchpad.net/appcenter";
-        bug_url = "https://bugs.launchpad.net/appcenter";
-        help_url = "https://answers.launchpad.net/appcenter";
-        translate_url = "https://translations.launchpad.net/appcenter";
         about_authors = { "Marvin Beckers <beckersmarvin@gmail.com>",
                           "Corentin Noël <corentin@elementary.io>" };
         about_comments = "";


### PR DESCRIPTION
Fixes #167
Fixes #168 

Kills the shortcut to the About dialog in the .desktop and removes outdated info. Bump copyright years since the dialog is still accessible from Terminal.

I don't see any references to creating this dialog in the code. Is this built into Granite.App?