### PR TITLE
StripeDialog: Fix CC validation false negatives

### DIFF
--- a/src/Dialogs/StripeDialog.vala
+++ b/src/Dialogs/StripeDialog.vala
@@ -326,7 +326,7 @@ public class AppCenter.Widgets.StripeDialog : Gtk.Dialog {
             sum += number;
         }
 
-        return 10 - (sum % 10) == hash;
+        return (10 - (sum % 10)) % 10 == hash;
     }
 
     private void on_response (Gtk.Dialog source, int response_id) {


### PR DESCRIPTION
Fixes #162


Reason of the bug: Just take the last digit at the end. A 10 was causing it to fail since it was comparing it to a 0