### PR TITLE
Make the restart button appear in the InfoBar

### DIFF
--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -119,9 +119,12 @@ namespace AppCenter.Views {
             sc = new SuspendControl ();
 
             var infobar = new Gtk.InfoBar ();
-            infobar.message_type = Gtk.MessageType.INFO;
-            infobar.get_content_area ().add (new Gtk.Label (_("Restart required")));
-            infobar.add_button (_("Restart Now"), 0);
+            infobar.message_type = Gtk.MessageType.WARNING;
+            infobar.get_content_area ().add (new Gtk.Label (_("A restart is required to complete the installation of updates")));
+            
+            var restart_button = infobar.add_button (_("Restart Now"), 0);
+            action_button_group.add_widget (restart_button);
+
             infobar.response.connect ((response) => {
                 if (response == 0) {
                     var dialog = new Widgets.RestartDialog ();

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -19,14 +19,19 @@
  */
 
 namespace AppCenter {
-    public abstract class AbstractAppList : Gtk.ScrolledWindow {
+    public abstract class AbstractAppList : Gtk.Box {
         public signal void show_app (AppCenterCore.Package package);
+        protected Gtk.ScrolledWindow scrolled;
         protected Gtk.ListBox list_box;
         protected Gtk.SizeGroup action_button_group;
         protected uint packages_changing = 0;
 
         construct {
-            hscrollbar_policy = Gtk.PolicyType.NEVER;
+            orientation = Gtk.Orientation.VERTICAL;
+
+            scrolled = new Gtk.ScrolledWindow (null, null);
+            scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
+
             var alert_view = new Granite.Widgets.AlertView (_("No Results"), _("No apps could be found. Try changing search terms."), "edit-find-symbolic");
             alert_view.show_all ();
             list_box = new Gtk.ListBox ();
@@ -38,7 +43,8 @@ namespace AppCenter {
                 var row = (Widgets.AppListRow)r;
                 show_app (row.get_package ());
             });
-            add (list_box);
+
+            scrolled.add (list_box);
 
             action_button_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
         }

--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -19,158 +19,98 @@
  */
 
 namespace AppCenter.Widgets {
-    public class UpdateHeaderRow : Gtk.ListBoxRow, AppListRow {
-        AbstractHeaderGrid grid;
-        public bool is_updates_header {get; private set;}
+    /** Base class for Grids in Header Rows **/
+    public abstract class AbstractHeaderGrid : Gtk.Grid {
+        public uint update_numbers { get; protected set; default = 0; }
+        public uint64 update_real_size { get; protected set; default = 0; }
+        public bool is_updating { get; protected set; default = false; }
 
         construct {
-            set_activatable (false);
-            set_selectable (false);
+            margin = 12;
+            column_spacing = 12;
         }
 
-        public UpdateHeaderRow.updates () {
-            grid = new UpdatesGrid ();
-            add (grid);
-            is_updates_header = true;
-        }
-
-        public UpdateHeaderRow.updated () {
-            grid = new UpdatedGrid ();
-            add (grid);
-            is_updates_header = false;
-        }
-
-        /** AppListRow Interface methods **/
-
-        /** Updates header row reports it has updates in order to sort first in list **/
-        /** Updated header reports it has updates when updating in order to sort first in list **/
-        public bool get_update_available () {
-            return is_updates_header || grid.is_updating;
-        }
-
-        public bool get_is_os_updates () {
-            critical ("Must not attempt to get is_os_update from header row");
-            assert_not_reached ();
-        }
-
-        /* This indicates it is a header row, not a package row */
-        public bool has_package () {return false;}
-
-        public AppCenterCore.Package? get_package () {
-            critical ("Must not attempt to get package from header row");
-            assert_not_reached ();
-        }
-
-        public string get_name_label () {
-            critical ("Must not attempt to get package name from header row");
-            assert_not_reached ();
+        protected void store_data (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
+            update_numbers = _update_numbers;
+            update_real_size = _update_real_size;
+            is_updating = _is_updating;
         }
 
         public void add_widget (Gtk.Widget widget) {
-            grid.add (widget);
+            add (widget);
         }
 
-        public void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _restart_required) {
-            grid.update (_update_numbers, _update_real_size, _is_updating, _restart_required);
-            changed (); /* Triggers resort */
-        }
-        /** ---------------- **/
+        public abstract void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating);
+    }
 
-        /** Base class for Grids in Header Rows **/
-        private abstract class AbstractHeaderGrid : Gtk.Grid {
-            public uint update_numbers {get; protected set; default = 0;}
-            public uint64 update_real_size {get; protected set; default = 0;}
-            public bool is_updating {get; protected set; default = false;}
-            public bool restart_required {get; protected set; default = false;}
+    /** Header to show at top of list if there are updates available **/
+    public class UpdatesGrid : AbstractHeaderGrid {
+        private Gtk.Label update_size_label;
+        private Gtk.Label updates_label;
 
-            construct {
-                margin = 12;
-                column_spacing = 12;
-            }
+        construct {
+            margin_top = 18;
+            updates_label = new Gtk.Label (null);
+            ((Gtk.Misc) updates_label).xalign = 0;
+            updates_label.get_style_context ().add_class ("h4");
+            updates_label.hexpand = true;
 
-            protected void store_data (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _restart_required) {
-                update_numbers = _update_numbers;
-                update_real_size = _update_real_size;
-                is_updating = _is_updating;
-                restart_required = _restart_required;
-            }
+            update_size_label = new Gtk.Label (null);
 
-            public abstract void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _restart_required);
+            add (updates_label);
+            add (update_size_label);
         }
 
-        /** Header to show at top of list if there are updates available **/
-        private class UpdatesGrid : AbstractHeaderGrid {
-            private Gtk.Label update_size_label;
-            private Gtk.Label updates_label;
+        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
+            store_data (_update_numbers,  _update_real_size, _is_updating);
 
-            construct {
-                margin_top = 18;
-                updates_label = new Gtk.Label (null);
-                ((Gtk.Misc) updates_label).xalign = 0;
-                updates_label.get_style_context ().add_class ("h4");
-                updates_label.hexpand = true;
-
-                update_size_label = new Gtk.Label (null);
-
-                add (updates_label);
-                add (update_size_label);
-            }
-
-            public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _restart_required) {
-                store_data (_update_numbers,  _update_real_size, _is_updating, _restart_required);
-
-                if (!is_updating) {
-                    updates_label.label = ngettext ("%u Update Available", "%u Updates Available", update_numbers).printf (update_numbers);
-                    update_size_label.label = _("Size: %s").printf (GLib.format_size (update_real_size));
-                    if (update_numbers > 0) {
-                        show_all ();
-                    } else {
-                        hide ();
-                    }
+            if (!is_updating) {
+                updates_label.label = ngettext ("%u Update Available", "%u Updates Available", update_numbers).printf (update_numbers);
+                update_size_label.label = _("Size: %s").printf (GLib.format_size (update_real_size));
+                if (update_numbers > 0) {
+                    show_all ();
                 } else {
-                    hide (); /* Updated header shows updating spinner and message */
+                    hide ();
                 }
+            } else {
+                hide (); /* Updated header shows updating spinner and message */
             }
         }
+    }
 
-        /** Header to show above first package that is up to date, or if the cache is updating **/
-        private class UpdatedGrid : AbstractHeaderGrid {
-            private Gtk.Label label;
-            private Gtk.Spinner spinner;
+    /** Header to show above first package that is up to date, or if the cache is updating **/
+    public class UpdatedGrid : AbstractHeaderGrid {
+        private Gtk.Label label;
+        private Gtk.Spinner spinner;
 
-            construct {
-                label = new Gtk.Label (""); /* Should not be displayed before being updated */
-                label.hexpand = true;
-                ((Gtk.Misc)label).xalign = 0;
+        construct {
+            label = new Gtk.Label (""); /* Should not be displayed before being updated */
+            label.hexpand = true;
+            ((Gtk.Misc)label).xalign = 0;
 
-                spinner = new Gtk.Spinner ();
+            spinner = new Gtk.Spinner ();
 
-                add (label);
-                add (spinner);
-            }
+            add (label);
+            add (spinner);
+        }
 
-            public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _restart_required) {
-                store_data (_update_numbers,  _update_real_size, _is_updating, _restart_required);
+        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
+            store_data (_update_numbers,  _update_real_size, _is_updating);
 
-                if (is_updating) {
-                    halign = Gtk.Align.CENTER;
-                    spinner.start ();
-                    spinner.no_show_all = false;
-                    spinner.show ();
-                    label.label = _("Searching for updates…");
-                    label.get_style_context ().remove_class ("h4");
-                } else {
-                    halign = Gtk.Align.FILL;
-                    spinner.stop ();
-                    spinner.no_show_all = true;
-                    spinner.hide ();
-                    if (restart_required) {
-                        label.label = _("Restart required");
-                    } else {
-                        label.label = _("Up to Date");
-                    }
-                    label.get_style_context ().add_class ("h4");
-                }
+            if (is_updating) {
+                halign = Gtk.Align.CENTER;
+                spinner.start ();
+                spinner.no_show_all = false;
+                spinner.show ();
+                label.label = _("Searching for updates…");
+                label.get_style_context ().remove_class ("h4");
+            } else {
+                halign = Gtk.Align.FILL;
+                spinner.stop ();
+                spinner.no_show_all = true;
+                spinner.hide ();
+                label.label = _("Up to Date");
+                label.get_style_context ().add_class ("h4");
             }
         }
     }


### PR DESCRIPTION
Makes the restart button appear in the InfoBar instead of the header. **This again needed some refactoring how headers work and is in large portion just a port of this branch on LP + a rework how restart is checked:** https://code.launchpad.net/~donadigo/appcenter/sorting-headers/+merge/317787

Previously AppCenter updated the list every 20 milliseconds, but this is now gone with `set_header` method of `Gtk.ListBox`. This was also used to update the restart state, which is why it's now reworked.  Instead of refreshing it's state with fixed interval, we use `FileMonitor` to monitor if the `reboot-required` file is present. The `AppList` only binds the `restart_required` property to it's `InfoBar`.

You can test the restart detection with these commands:
1. Make AppCenter show the restart button:
`sudo touch /var/run/reboot-required`

2. Make AppCenter hide the restart button:
`sudo rm /var/run/reboot-required`