### PR TITLE
Only show progress bar for updating apps

### DIFF
--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -159,6 +159,13 @@ namespace AppCenter.Views {
 
         [CCode (instance_pos = -1)]
         protected override int package_row_compare (Widgets.AppListRow row1, Widgets.AppListRow row2) {
+            bool a_is_updating = row1.get_is_updating ();
+            bool b_is_updating = row2.get_is_updating ();
+
+            if (a_is_updating || b_is_updating) {
+                return a_is_updating ? -1 : 1;
+            }
+
             bool a_is_os = row1.get_is_os_updates ();
             bool b_is_os = row2.get_is_os_updates ();
 

--- a/src/Widgets/AbstractAppContainer.vala
+++ b/src/Widgets/AbstractAppContainer.vala
@@ -270,7 +270,7 @@ namespace AppCenter {
              progress_bar.fraction = package.progress;
          }
 
-        protected void update_progress_status () {
+        protected virtual void update_progress_status () {
             progress_bar.text = package.get_progress_description ();
             /* Ensure progress bar shows complete to match status (lp:1606902) */
             if (package.changes_finished) {

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -24,6 +24,7 @@ namespace AppCenter.Widgets {
     public interface AppListRow : Gtk.ListBoxRow {
         public abstract bool get_update_available ();
         public abstract bool get_is_os_updates ();
+        public abstract bool get_is_updating ();
         public abstract string get_name_label ();
         public abstract bool has_package ();
         public abstract AppCenterCore.Package? get_package ();

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -138,18 +138,22 @@ namespace AppCenter.Widgets {
                 changed ();
             }
 
-             protected override void update_progress_status () {
-                 base.update_progress_status ();
-                 var status = package.change_information.status;
-                 if (status == Pk.Status.WAIT || status == Pk.Status.FINISHED) {
-                     progress_bar.no_show_all = true;
-                     progress_bar.hide ();
-                 } else {
-                     progress_bar.no_show_all = false;
-                     progress_bar.show_all ();
-                 }
-             }
-
+            protected override void update_progress_status () {
+                base.update_progress_status ();
+                var status = package.change_information.status;
+                switch (status) {
+                    case Pk.Status.WAIT:
+                    case Pk.Status.FINISHED:
+                    case Pk.Status.WAITING_FOR_AUTH:
+                        progress_bar.no_show_all = true;
+                        progress_bar.hide ();
+                        break;
+                    default:
+                        progress_bar.no_show_all = false;
+                        progress_bar.show_all ();
+                        break;
+                }
+            }
         }
 
         private class ListPackageRowGrid : AbstractPackageRowGrid {

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -137,6 +137,19 @@ namespace AppCenter.Widgets {
                 update_action ();
                 changed ();
             }
+
+             protected override void update_progress_status () {
+                 base.update_progress_status ();
+                 var status = package.change_information.status;
+                 if (status == Pk.Status.WAIT || status == Pk.Status.FINISHED) {
+                     progress_bar.no_show_all = true;
+                     progress_bar.hide ();
+                 } else {
+                     progress_bar.no_show_all = false;
+                     progress_bar.show_all ();
+                 }
+             }
+
         }
 
         private class ListPackageRowGrid : AbstractPackageRowGrid {


### PR DESCRIPTION
Fixes #166.

Hide the progress bar for apps that are in waiting or complete status on the update screen.

Also changes the sorting order so that the apps in the list are displayed in the order they are going to be updated in after clicking "Update All". This allows the user to follow the progress of multiple updates down the screen rather than it jumping about due to the previous alphabetical order and the apps not being updated alphabetically.