### PR TITLE
Ensure the category view is open before showing anything in it

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -209,6 +209,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     }
 
     public void show_package (AppCenterCore.Package package) {
+        stack.set_visible_child (homepage.category_view);
         homepage.category_view.show_package (package);
         view_opened (_("Categories"), false, null);
     }


### PR DESCRIPTION
Fixes a regression that prevents appstream:// uri's being opened properly.

To test:
`appcenter appstream://maya-calendar.desktop`