### PR TITLE
Fix resolving packages for other architectures

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -124,7 +124,7 @@ public class AppCenterCore.Client : Object {
             }
 
             packages_ids = {};
-            results.get_package_array ().foreach ((package) => {
+            package_array.foreach ((package) => {
                 packages_ids += package.package_id;
             });
 

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -111,8 +111,19 @@ public class AppCenterCore.Client : Object {
 
         try {
             var results = yield client.resolve_async (Pk.Bitfield.from_enums (Pk.Filter.NEWEST, Pk.Filter.ARCH), packages_ids, cancellable, () => {});
-            packages_ids = {};
 
+            /*
+             * If there were no packages found for the requested architecture,
+             * try to resolve IDs by not searching for this architecture
+             * e.g: filtering 32 bit only package on a 64 bit system
+             */ 
+            GenericArray<weak Pk.Package> package_array = results.get_package_array ();
+            if (package_array.length == 0) {
+                results = yield client.resolve_async (Pk.Bitfield.from_enums (Pk.Filter.NEWEST, Pk.Filter.NOT_ARCH), packages_ids, cancellable, () => {});
+                package_array = results.get_package_array ();
+            }
+
+            packages_ids = {};
             results.get_package_array ().foreach ((package) => {
                 packages_ids += package.package_id;
             });


### PR DESCRIPTION
Adds a check if the package array returned by PackageKit is empty, resolve packages again but this time using `NOT_ARCH` filter to find the same package for other architecture. I left a comment in the code briefly explaining why the change to avoid any confusion when dealing with it in the future. This should solve installation of e.g: Steam 