### PR TITLE
AppInfoView: Set banner style to the banner instead of on the screen

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -241,7 +241,7 @@ namespace AppCenter.Views {
                 }
                 var colored_css = BANNER_STYLE_CSS.printf (color_primary, color_primary_text);
                 provider.load_from_data (colored_css, colored_css.length);
-                Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                header_box.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             } catch (GLib.Error e) {
                 critical (e.message);
             }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -20,6 +20,8 @@
 
 namespace AppCenter.Views {
     public class AppInfoView : AppCenter.AbstractAppContainer {
+        static Gtk.CssProvider? previous_css_provider = null;
+
         Gtk.Grid links_grid;
         Gtk.Box header_box;
         Gtk.Image app_screenshot;
@@ -219,7 +221,7 @@ namespace AppCenter.Views {
             });
         }
 
-        private void reload_css () {
+        public void reload_css () {
             var provider = new Gtk.CssProvider ();
             try {
                 string color_primary;
@@ -241,7 +243,13 @@ namespace AppCenter.Views {
                 }
                 var colored_css = BANNER_STYLE_CSS.printf (color_primary, color_primary_text);
                 provider.load_from_data (colored_css, colored_css.length);
-                header_box.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+                if (previous_css_provider != null) {
+                    Gtk.StyleContext.remove_provider_for_screen (Gdk.Screen.get_default (), previous_css_provider);
+                }
+
+                previous_css_provider = provider;
+                Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             } catch (GLib.Error e) {
                 critical (e.message);
             }

--- a/src/Views/View.vala
+++ b/src/Views/View.vala
@@ -28,8 +28,9 @@ public abstract class AppCenter.View : Gtk.Stack {
     }
 
     public void show_package (AppCenterCore.Package package) {
-        var pk_child = get_child_by_name (package.component.id);
+        var pk_child = get_child_by_name (package.component.id) as Views.AppInfoView;
         if (pk_child != null) {
+            pk_child.reload_css ();
             set_visible_child (pk_child);
             return;
         }


### PR DESCRIPTION
Fixes #201 

It's either doing this, or applying manually the CSS on all the widget's manually. 