### PR TITLE
Fix crash when deleting characters out of searches

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -98,6 +98,7 @@ public class AppCenterCore.Package : Object {
     private string? summary = null;
     private string? color_primary = null;
     private string? color_primary_text = null;
+    private string? payments_key = null;
     private string? _latest_version = null;
     public string? latest_version {
         private get { return _latest_version; }
@@ -368,6 +369,15 @@ public class AppCenterCore.Package : Object {
         } else {
             color_primary_text = component.get_custom_value ("x-appcenter-color-primary-text");
             return color_primary_text;
+        }
+    }
+
+    public string? get_payments_key () {
+        if (payments_key != null) {
+            return payments_key;
+        } else {
+            payments_key = component.get_custom_value ("x-appcenter-stripe");
+            return payments_key;
         }
     }
 

--- a/src/Widgets/AbstractAppContainer.vala
+++ b/src/Widgets/AbstractAppContainer.vala
@@ -67,16 +67,13 @@ namespace AppCenter {
             }
         }
 
-        private string? payments_key_ = null;
         public bool payments_enabled {
             get {
                 if (this.package == null || this.package.component == null || updates_view) {
                     return false;
-                } else if (payments_key_ == null) {
-                    payments_key_ = this.package.component.get_custom_value ("x-appcenter-stripe");
                 }
 
-                return payments_key_ != null;
+                return this.package.get_payments_key() != null;
             }
         }
 
@@ -93,7 +90,7 @@ namespace AppCenter {
             action_button.download_requested.connect (() => action_clicked.begin ());
 
             action_button.payment_requested.connect ((amount) => {
-                var stripe = new Widgets.StripeDialog (amount, this.package_name.label, this.package.component.get_desktop_id ().replace (".desktop", ""), payments_key_);
+                var stripe = new Widgets.StripeDialog (amount, this.package_name.label, this.package.component.get_desktop_id ().replace (".desktop", ""), this.package.get_payments_key());
 
                 stripe.download_requested.connect (() => action_clicked.begin ());
                 stripe.show ();


### PR DESCRIPTION
Fixes the bug that occurs when deleting characters out of searches.

It seems to be an issue with appstream where calling `component.get_custom_value (...)` a second time, causes it to return something that was already freed from memory (probably a bug in appstream?). When the component gets deconstructed, it calls free on this object again and crashes.

By moving the `payments_key` into the `Package` class, it will only call that method once and prevent this crash.

Fixes #202.