### PR TITLE
Don't show spinner if packages are being updated

### DIFF
--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -85,7 +85,6 @@ namespace AppCenter.Views {
     /** AppList for the Updates View.  Sorts update_available first and shows headers.
       * Does not show Uninstall Button **/
     public class AppListUpdateView : AbstractAppList {
-        private bool updates_on_top;
         private Gtk.Button? update_all_button;
         private bool updating_all_apps = false;
         private bool apps_remaining_started = false;
@@ -98,6 +97,9 @@ namespace AppCenter.Views {
         private bool _updating_cache;
         public bool updating_cache {
             get {
+                if (packages_changing > 0) {
+                    return false;
+                }
                 return _updating_cache;
             }
             set {
@@ -109,8 +111,6 @@ namespace AppCenter.Views {
         }
 
         construct {
-            updates_on_top = true;
-
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
 
             update_mutex = GLib.Mutex ();


### PR DESCRIPTION
Fixes #218 .

The property that decides whether to show the headers or the "Searching for updates" spinner is bound to the `updating_cache` property of `Client.vala`.

This sometimes causes the spinner to come back when we're doing updates if PackageKit decides to refresh its cache as part of the update process. To prevent this, we return false in our local copy of `updating_cache` if we know that there are some updates happening in the list. This ensures that we always show the headers while updates are happening in the list, but the spinner functions as normal outside of those cases.

Also removed an `updates_on_top` variable that wasn't used anywhere while I was in that part of the code.