### PR TITLE
Hide switcher when only 1 item

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -87,6 +87,7 @@ namespace AppCenter {
                             newest_banner.add_package (banner_package);
                         }
                         newest_banner.go_to_first ();
+                        switcher.show_all ();
                         switcher_revealer.set_reveal_child (true);
                         return false;
                     });


### PR DESCRIPTION
Fixes #225 

Seems a bit counter-intuitive to show something when you're trying to hide it, but the Switcher class has built in logic to hide itself when there's only 1 item. So just trigger that after we've added the items.