### PR TITLE
Fix incorrect update size

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -217,7 +217,12 @@ public class AppCenterCore.Client : Object {
                 var package = package_list.get (pkg_name);
                 if (package != null) {
                     package.latest_version = pk_package.get_version ();
+                    package.change_information.changes.clear ();
+                    package.change_information.details.clear ();
                 }
+
+                os_updates.change_information.changes.clear ();
+                os_updates.change_information.details.clear ();
             });
 
             // We need a null to show to PackageKit that it's then end of the array.


### PR DESCRIPTION
Fixes the uncorrect update size when reopening appcenter. In some cases, multiple calls to `get_updates ()` results in duplicates being added to the changes and details set. Clearing this set prevents duplicates from being added.

Fixes #75.