### PR TITLE
Remove my public information from "About" dialog

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -54,8 +54,7 @@ public class AppCenter.App : Granite.Application {
         bug_url = "https://github.com/elementary/appcenter/issues";
         help_url = "https://elementary.io/support";
         translate_url = "https://l10n.elementary.io/projects/desktop/appcenter/";
-        about_authors = { "Marvin Beckers <beckersmarvin@gmail.com>",
-                          "Corentin Noël <corentin@elementary.io>" };
+        about_authors = { "Corentin Noël <corentin@elementary.io>" };
         about_comments = "";
         about_translators = _("translator-credits");
         about_license_type = Gtk.License.GPL_3_0;


### PR DESCRIPTION
I keep getting emails to beckersmarvin@gmail.com about issues or general questions with AppCenter although I dropped out some time ago. This isn't really annoying me (I rarely check my gmail inbox anyway), but it leads people into a dead end. Therefore I'd like to propose the removal of my email address from AppCenter's "About" dialog to reflect on the fact I'm no longer associated with the project and AppCenter development. Thanks!