### PR TITLE
Add email to houston post data

### DIFF
--- a/src/Dialogs/StripeDialog.vala
+++ b/src/Dialogs/StripeDialog.vala
@@ -20,7 +20,7 @@
 public class AppCenter.Widgets.StripeDialog : Gtk.Dialog {
     public signal void download_requested ();
 
-    private const string HOUSTON_URI =  "https://developer.elementary.io/api/payment/%s?key=%s&token=%s&amount=%s&currency=USD";
+    private const string HOUSTON_URI =  "https://developer.elementary.io/api/payment/%s?key=%s&token=%s&email=%s&amount=%s&currency=USD";
     private const string USER_AGENT = "Stripe checkout";
     private const string STRIPE_URI = "https://api.stripe.com/v1/tokens?email=%s"
                             + "&payment_user_agent=%s&amount=%s&card[number]=%s"
@@ -364,7 +364,7 @@ public class AppCenter.Widgets.StripeDialog : Gtk.Dialog {
 
                 string? houston_data = null;
                 if (token_id != null) {
-                    houston_data = post_to_houston (stripe_key, app_id, token_id, (amount * 100).to_string ());
+                    houston_data = post_to_houston (stripe_key, app_id, token_id, email_entry.text, (amount * 100).to_string ());
                     debug ("Houston data:%s", houston_data);
                 } else {
                     error = true;
@@ -409,8 +409,8 @@ public class AppCenter.Widgets.StripeDialog : Gtk.Dialog {
         return data.str;
     }
 
-    private string post_to_houston (string _app_key, string _app_id, string _purchase_token, string _amount) {
-        var uri = HOUSTON_URI.printf (_app_id, _app_key, _purchase_token, _amount);
+    private string post_to_houston (string _app_key, string _app_id, string _purchase_token, string _email, string _amount) {
+        var uri = HOUSTON_URI.printf (_app_id, _app_key, _purchase_token, _email, _amount);
         var session = new Soup.Session ();
         var message = new Soup.Message ("POST", uri);
         session.send_message (message);


### PR DESCRIPTION
This adds the email value to the houston callback on payment. I edited this all in GitHub so it's untested, but simple enough to probably not break the planet.