### PR TITLE
Implement drivers (AppStream)

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -94,6 +94,13 @@ public class AppCenterCore.Package : Object {
         }
     }
 
+    public bool is_driver {
+        get {
+            var kind = component.get_kind ();
+            return kind == AppStream.ComponentKind.DRIVER || kind == AppStream.ComponentKind.FIRMWARE;
+        }
+    }
+
     private string? name = null;
     private string? description = null;
     private string? summary = null;

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -197,7 +197,6 @@ namespace AppCenter.Views {
         private void row_update_header (Widgets.AppListRow row, Widgets.AppListRow? before) {
             bool update_available = row.get_update_available ();            
             bool is_driver = row.get_is_driver ();
-            bool different = before == null || (update_available != before.get_update_available () || is_driver != before.get_is_driver ());
 
             if (update_available) {
                 if (before != null && update_available == before.get_update_available ()) {

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -183,18 +183,28 @@ namespace AppCenter.Views {
                 return a_has_updates ? -1 : 1;
             }
 
+            bool a_is_driver = row1.get_is_driver ();
+            bool b_is_driver = row2.get_is_driver ();
+
+            if ((a_is_driver && !b_is_driver) || (!a_is_driver && b_is_driver)) {
+                return a_is_driver ? - 1 : 1;
+            }
+
             return row1.get_name_label ().collate (row2.get_name_label ()); /* Else sort in name order */
         }
 
         [CCode (instance_pos = -1)]
         private void row_update_header (Widgets.AppListRow row, Widgets.AppListRow? before) {
             bool update_available = row.get_update_available ();            
-            if (before != null && update_available == before.get_update_available ()) {
-                row.set_header (null);
-                return;
-            }
+            bool is_driver = row.get_is_driver ();
+            bool different = before == null || (update_available != before.get_update_available () || is_driver != before.get_is_driver ());
 
             if (update_available) {
+                if (before != null && update_available == before.get_update_available ()) {
+                    row.set_header (null);
+                    return;
+                }
+
                 var header = new Widgets.UpdatesGrid ();
 
                 uint update_numbers = 0U;
@@ -220,8 +230,22 @@ namespace AppCenter.Views {
                 }
 
                 header.show_all ();
-                row.set_header (header);                
+                row.set_header (header);
+            } else if (is_driver) {
+                if (before != null && is_driver == before.get_is_driver ()) {
+                    row.set_header (null);
+                    return;
+                }
+
+                var header = new Widgets.DriverGrid ();
+                header.show_all ();
+                row.set_header (header);
             } else {
+                if (before != null && is_driver == before.get_is_driver () && update_available == before.get_update_available ()) {
+                    row.set_header (null);
+                    return;
+                }
+
                 var header = new Widgets.UpdatedGrid ();
                 header.update (0, 0, updating_cache);
                 header.show_all ();

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -54,6 +54,8 @@ public class AppCenter.Views.InstalledView : View {
     public async void get_apps () {
         unowned Client client = Client.get_default ();
 
+        yield client.get_drivers ();
+        
         var installed_apps = yield client.get_installed_applications ();
         app_list_view.add_packages (installed_apps);
 

--- a/src/Widgets/AbstractAppContainer.vala
+++ b/src/Widgets/AbstractAppContainer.vala
@@ -43,6 +43,12 @@ namespace AppCenter {
             }
         }
 
+        public bool is_driver {
+            get {
+                return package.is_driver;
+            }
+        }
+
         public bool update_available {
             get {
                 return package.update_available || package.is_updating;

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -24,6 +24,7 @@ namespace AppCenter.Widgets {
     public interface AppListRow : Gtk.ListBoxRow {
         public abstract bool get_update_available ();
         public abstract bool get_is_os_updates ();
+        public abstract bool get_is_driver ();
         public abstract bool get_is_updating ();
         public abstract string get_name_label ();
         public abstract bool has_package ();

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -50,6 +50,10 @@ namespace AppCenter.Widgets {
             return grid.is_os_updates;
         }
 
+        public bool get_is_driver () {
+            return grid.is_driver;
+        }
+
         public string get_name_label () {
             return grid.name_label;
         }

--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -114,4 +114,19 @@ namespace AppCenter.Widgets {
             }
         }
     }
+
+    public class DriverGrid : AbstractHeaderGrid {
+        construct {
+            var label = new Gtk.Label (_("Drivers"));
+            label.get_style_context ().add_class ("h4");
+            label.hexpand = true;
+            ((Gtk.Misc)label).xalign = 0;
+
+            add (label);
+        }
+
+        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
+           
+        }
+    }
 }


### PR DESCRIPTION
Implements drivers and fixes #12.

After discussion on the Slack channel I decided to give AppStream implementation of drivers a go. We no longer depend on any Ubuntu / Debian specific code. Everything is based on AppStream and PackageKit, however scanning modaliases on the system is pretty much a Vala version of the UbuntuDrivers component. For more details about the code and it's design, look into the diff, I left some explanation for each driver related method.

Note that currently there is no AppStream data to test this branch with and this is kind of a problem since this feature is being asked by lots of people. So how did I test it?
The way to test this is to fool AppStream that some components are drivers. All of the compiled data is stored in `/usr/share/app-info/yaml/pantheon_xenial-main_amd64.yml.gz` file. Open this file with archive manager (with admin), and edit the .yml file inside of it. Choose some component and change it's `Type` field from `desktop-app` to `driver`. Next you will need a supported modalias by your system. These can be found by e.g: executing `ubuntu-drivers debug` and choosing one of the `modalias` strings. After that you can paste this under the `Provides` field:
```
modaliases:
  - your_modalias
```

and save the file.

Sorry if this is really complicated but this is the only way I found to test this. Perhaps Matthias knows a better way.  

