### PR TITLE
Corrected semantically wrong word

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -255,7 +255,7 @@ msgstr "Deinstallieren"
 
 #: ../src/Widgets/AbstractAppContainer.vala:108
 msgid "Open"
-msgstr "frei"
+msgstr "Öffnen"
 
 #: ../src/Widgets/AbstractAppContainer.vala:160
 msgid "The %s Developers"


### PR DESCRIPTION
Open means frei as in freedom if you translate it. But in this context you need the word Öffnen to launch an app.