### PR TITLE
Check if ubuntu-drivers are present

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -291,7 +291,13 @@ public class AppCenterCore.Client : Object {
             return;
         }
 
-        var command = new Granite.Services.SimpleCommand ("/usr/bin", "ubuntu-drivers list");
+        string? drivers_exec_path = Environment.find_program_in_path ("ubuntu-drivers");
+        if (drivers_exec_path == null) {
+        	task_count--;
+        	return;
+        }
+
+        var command = new Granite.Services.SimpleCommand ("/", "%s list".printf (drivers_exec_path));
         command.done.connect ((command, status) => parse_drivers_output (command.standard_output_str, status));
         command.run ();
     }

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -293,8 +293,8 @@ public class AppCenterCore.Client : Object {
 
         string? drivers_exec_path = Environment.find_program_in_path ("ubuntu-drivers");
         if (drivers_exec_path == null) {
-        	task_count--;
-        	return;
+            task_count--;
+            return;
         }
 
         var command = new Granite.Services.SimpleCommand ("/", "%s list".printf (drivers_exec_path));


### PR DESCRIPTION
Fixes #310.

For non-Ubuntu systems, this check will prevent from crashes, this also removes a hardcoded path to the exec, it's now determined by `find_program_in_path`.