### PR TITLE
Load more screenshots

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -29,7 +29,6 @@ namespace AppCenter.Views {
         Gtk.Stack app_screenshots;
         Widgets.Switcher screenshot_switcher;
         Gtk.Stack screenshot_stack;
-        Gtk.Label app_screenshot_not_found;
         Gtk.Label app_version;
         Gtk.TextView app_description;
         Gtk.ListBox extension_box;
@@ -59,16 +58,11 @@ namespace AppCenter.Views {
                 app_screenshot_spinner.valign = Gtk.Align.CENTER;
                 app_screenshot_spinner.active = true;
 
-                app_screenshot_not_found = new Gtk.Label (_("Screenshot Not Available"));
-                app_screenshot_not_found.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
-                app_screenshot_not_found.get_style_context ().add_class ("h2");
-
                 screenshot_stack = new Gtk.Stack ();
                 screenshot_stack.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
                 screenshot_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
                 screenshot_stack.add (app_screenshot_spinner);
                 screenshot_stack.add (app_screenshots);
-                screenshot_stack.add (app_screenshot_not_found);
             }
 
             package_name = new Gtk.Label (null);
@@ -342,7 +336,7 @@ namespace AppCenter.Views {
                 } catch (Error e) {
                     debug (e.message);
                     // The file is likely to not being found.
-                    return app_screenshot_not_found;
+                    return screenshot_load_error_label ();
                 }
 
                 GLib.FileUtils.close (fd);
@@ -350,7 +344,7 @@ namespace AppCenter.Views {
                 critical ("Error create the temporary file: GFileError #%d", GLib.FileUtils.error_from_errno (GLib.errno));
                 fileimage = File.new_for_uri (url);
                 if (fileimage.query_exists () == false) {
-                    return app_screenshot_not_found;
+                    return screenshot_load_error_label ();
                 }
             }
 
@@ -365,8 +359,16 @@ namespace AppCenter.Views {
                 return image;
             } catch (Error e) {
                 critical (e.message);
-                return app_screenshot_not_found;
+                return screenshot_load_error_label ();
             }
+        }
+
+        private Gtk.Label screenshot_load_error_label () {
+            var app_screenshot_not_found = new Gtk.Label (_("Screenshot Not Available"));
+            app_screenshot_not_found.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+            app_screenshot_not_found.get_style_context ().add_class ("h2");
+
+            return app_screenshot_not_found;
         }
 
         private void parse_description (string? description) {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -26,8 +26,9 @@ namespace AppCenter.Views {
 
         Gtk.Grid links_grid;
         Gtk.Box header_box;
-        Gtk.Image app_screenshot;
+        Gtk.Stack app_screenshots;
         Gtk.Stack screenshot_stack;
+        Widgets.Switcher screenshot_switcher;
         Gtk.Label app_screenshot_not_found;
         Gtk.Label app_version;
         Gtk.TextView app_description;
@@ -43,11 +44,15 @@ namespace AppCenter.Views {
             screenshots = package.component.get_screenshots ();
 
             if (screenshots.length > 0) {
-                app_screenshot = new Gtk.Image ();
-                app_screenshot.width_request = 800;
-                app_screenshot.height_request = 500;
-                app_screenshot.icon_name = "image-x-generic";
-                app_screenshot.halign = Gtk.Align.CENTER;
+                app_screenshots = new Gtk.Stack ();
+                app_screenshots.width_request = 800;
+                app_screenshots.height_request = 500;
+                app_screenshots.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
+                app_screenshots.halign = Gtk.Align.CENTER;
+
+                screenshot_switcher = new Widgets.Switcher ();
+                screenshot_switcher.halign = Gtk.Align.CENTER;
+                screenshot_switcher.set_stack (app_screenshots);
 
                 var app_screenshot_spinner = new Gtk.Spinner ();
                 app_screenshot_spinner.halign = Gtk.Align.CENTER;
@@ -62,7 +67,7 @@ namespace AppCenter.Views {
                 screenshot_stack.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
                 screenshot_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
                 screenshot_stack.add (app_screenshot_spinner);
-                screenshot_stack.add (app_screenshot);
+                screenshot_stack.add (app_screenshots);
                 screenshot_stack.add (app_screenshot_not_found);
             }
 
@@ -115,6 +120,7 @@ namespace AppCenter.Views {
 
             if (screenshots.length > 0) {
                 content_grid.add (screenshot_stack);
+                content_grid.add (screenshot_switcher);
             }
 
             if (!package.is_os_updates) {
@@ -339,8 +345,18 @@ namespace AppCenter.Views {
 
             Idle.add (() => {
                 try {
-                    app_screenshot.pixbuf = new Gdk.Pixbuf.from_file_at_scale (fileimage.get_path (), 800, 600, true);
-                    screenshot_stack.visible_child = app_screenshot;
+                    var image = new Gtk.Image ();
+                    image.width_request = 800;
+                    image.height_request = 500;
+                    image.icon_name = "image-x-generic";
+                    image.halign = Gtk.Align.CENTER;
+                    image.pixbuf = new Gdk.Pixbuf.from_file_at_scale (fileimage.get_path (), 800, 600, true);
+                    image.show ();
+
+                    app_screenshots.add (image);
+                    app_screenshots.visible_child = image;
+                    screenshot_stack.visible_child = app_screenshots;
+                    screenshot_switcher.update_selected ();
                 } catch (Error e) {
                     critical (e.message);
                 }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -285,7 +285,7 @@ namespace AppCenter.Views {
                     return null;
                 }
 
-                Gtk.Widget default_widget = null;
+                Gee.Deque<Gtk.Widget> screenshot_widgets = new Gee.LinkedList<Gtk.Widget> ();
 
                 screenshots.foreach ((screenshot) => {
                     Gtk.Widget screenshot_widget = null;
@@ -302,16 +302,19 @@ namespace AppCenter.Views {
                         ++index;
                     }
 
-                    app_screenshots.add (screenshot_widget);
-
-                    if (default_widget == null || screenshot.get_kind () == AppStream.ScreenshotKind.DEFAULT) {
-                        default_widget = screenshot_widget;
+                    if (screenshot.get_kind () == AppStream.ScreenshotKind.DEFAULT) {
+                        screenshot_widgets.offer_head (screenshot_widget);
+                    } else {
+                        screenshot_widgets.offer_tail (screenshot_widget);
                     }
                 });
 
-                app_screenshots.visible_child = default_widget;
-                screenshot_stack.visible_child = app_screenshots;
+                foreach (var widget in screenshot_widgets) {
+                    app_screenshots.add (widget);
+                }
+
                 screenshot_stack.show_all ();
+                screenshot_stack.visible_child = app_screenshots;
                 screenshot_switcher.update_selected ();
 
                 return null;


### PR DESCRIPTION
Loads all the available screenshots when viewing package info. The screenshots are added to a stack and navigation is made possible with a switcher.

Screenshots marked as `DEFAULT` will be shown before other screenshots and the image with source quality is used. When one or more screenshot cannot be loaded it will place the error label in the stack instead of the image.

Closes #228.