### PR TITLE
Banners are now saved locally

### DIFF
--- a/src/Core/Houston.vala
+++ b/src/Core/Houston.vala
@@ -17,85 +17,154 @@
 */
 
 public class AppCenterCore.Houston : Object {
+    public signal void refreshed ();
+
     private const string HOUSTON_API_URL = "https://developer.elementary.io/api";
+    private const string NEWEST_CATEGORY = "Newest";
+    private const string UPDATED_CATEGORY = "Updated";
+    private const string APPS_KEY = "apps";
 
     private Soup.Session session;
+    private GLib.KeyFile cache_file = null;
 
     construct {
         session = new Soup.Session ();
     }
 
-    private Json.Object process_response (string res) throws Error {
-        var parser = new Json.Parser ();
-        parser.load_from_data (res, -1);
+    public string[] get_newest () {
+        if (cache_file == null) {
+            init_keyfile ();
+        }
 
-        var root = parser.get_root ().get_object ();
+        try {
+            return cache_file.get_string_list (NEWEST_CATEGORY, APPS_KEY);
+        } catch (Error e) {
+            critical (e.message);
+            return {};
+        }
+    }
 
-        if (root.has_member ("errors") && root.get_array_member ("errors").get_length () > 0) {
-            var err = root.get_array_member ("errors").get_object_element (0).get_string_member ("title");
+    public string[] get_updated () {
+        if (cache_file == null) {
+            init_keyfile ();
+        }
 
-            if (err != null) {
-                throw new Error (0, 0, err);
+        try {
+            return cache_file.get_string_list (UPDATED_CATEGORY, APPS_KEY);
+        } catch (Error e) {
+            critical (e.message);
+            return {};
+        }
+    }
+
+    private void init_keyfile () {
+        cache_file = new GLib.KeyFile ();
+        try {
+            var path = get_cache_file_path ();
+            var file = GLib.File.new_for_path (path);
+            bool need_refresh = true;
+            var parent = file.get_parent ();
+            if (parent != null && !parent.query_exists ()) {
+                parent.make_directory_with_parents ();
+            }
+
+            if (!file.query_exists ()) {
+                file.create (GLib.FileCreateFlags.PRIVATE);
+                cache_file.set_string_list (NEWEST_CATEGORY, APPS_KEY, {});
+                cache_file.set_string_list (UPDATED_CATEGORY, APPS_KEY, {});
+                cache_file.save_to_file (path);
             } else {
-                throw new Error (0, 0, "Error while talking to Houston");
+                var info = file.query_info (GLib.FileAttribute.TIME_MODIFIED, GLib.FileQueryInfoFlags.NONE);
+                var modification_time = info.get_attribute_uint64 (GLib.FileAttribute.TIME_MODIFIED);
+                var modification_date = new GLib.DateTime.from_unix_local ((int64)modification_time);
+                var now = new GLib.DateTime.now_local ();
+                var difference = now.difference (modification_date);
+                if (difference < GLib.TimeSpan.DAY) {
+                    need_refresh = false;
+                    uint timeout = (uint)((GLib.TimeSpan.DAY - difference)/GLib.TimeSpan.MILLISECOND);
+                    GLib.Timeout.add (timeout, () => {
+                        refresh.begin ();
+                        return GLib.Source.REMOVE;
+                    });
+                }
+            }
+
+            cache_file.load_from_file (path, GLib.KeyFileFlags.KEEP_COMMENTS);
+            if (need_refresh) {
+                refresh.begin ();
+            }
+        } catch (Error e) {
+            critical (e.message);
+        }
+    }
+
+    private async void process_apps (string uri, string category) throws Error {
+        var message = new Soup.Message ("GET", uri);
+        try {
+            var parser = new Json.Parser ();
+            var stream = yield session.send_async (message);
+            yield parser.load_from_stream_async (stream);
+            var root_node = parser.get_root ();
+            if (root_node.get_node_type () != Json.NodeType.OBJECT) {
+                return;
+            }
+
+            unowned Json.Object root = root_node.get_object ();
+            if (root.has_member ("errors") && root.get_array_member ("errors").get_length () > 0) {
+                unowned string err = root.get_array_member ("errors").get_object_element (0).get_string_member ("title");
+                throw new GLib.IOError.FAILED (err ?? "Error while talking to Houston");
+            }
+
+            if (root.has_member ("data")) {
+                var data = root.get_array_member ("data");
+                string[] app_ids = {};
+                data.get_elements ().foreach ((id) => {
+                    app_ids += id.get_string ();
+                });
+
+                cache_file.set_string_list (category, APPS_KEY, app_ids);
+            }
+
+        } catch (Error e) {
+            throw e;
+        }
+    }
+
+    private async void refresh () {
+        var uri = HOUSTON_API_URL + "/newest/project";
+        debug ("Requesting newest applications from %s", uri);
+        try {
+            yield process_apps (uri, NEWEST_CATEGORY);
+        } catch (Error e) {
+            critical (e.message);
+        }
+
+        uri = HOUSTON_API_URL + "/newest/release";
+        debug ("Requesting recently updated applications from %s", uri);
+        try {
+            yield process_apps (uri, UPDATED_CATEGORY);
+        } catch (Error e) {
+            critical (e.message);
+        }
+
+        lock (cache_file) {
+            try {
+                cache_file.save_to_file (get_cache_file_path ());
+            } catch (Error e) {
+                critical (e.message);
             }
         }
 
-        return root;
+        refreshed ();
+        uint timeout = (uint)(GLib.TimeSpan.DAY/GLib.TimeSpan.MILLISECOND);
+        GLib.Timeout.add (timeout, () => {
+            refresh.begin ();
+            return GLib.Source.REMOVE;
+        });
     }
 
-    public async string[] get_newest () {
-        var uri = HOUSTON_API_URL + "/newest/project";
-        string[] app_ids = {};
-
-        debug ("Requesting newest applications from %s", uri);
-
-        var message = new Soup.Message ("GET", uri);
-        session.queue_message (message, (sess, mess) => {
-            try {
-                var res = process_response ((string) mess.response_body.data);
-                if (res.has_member ("data")) {
-                    var data = res.get_array_member ("data");
-
-                    foreach (var id in data.get_elements ()) {
-                        app_ids += ((string) id.get_value ());
-                    }
-                }
-            } catch (Error e) {
-                stderr.printf ("Houston: %s\n", e.message);
-            }
-            Idle.add (get_newest.callback);
-        });
-
-        yield;
-        return app_ids;
-    }
-
-    public async string[] get_updated () {
-        var uri = HOUSTON_API_URL + "/newest/release";
-        string[] app_ids = {};
-
-        debug ("Requesting recently updated applications from %s", uri);
-
-        var message = new Soup.Message ("GET", uri);
-        session.queue_message (message, (sess, mess) => {
-            try {
-                var res = process_response ((string) mess.response_body.data);
-                if (res.has_member ("data")) {
-                    var data = res.get_array_member ("data");
-
-                    foreach (var id in data.get_elements ()) {
-                        app_ids += ((string) id.get_value ());
-                    }
-                }
-            } catch (Error e) {
-                stderr.printf ("Houston: %s\n", e.message);
-            }
-            Idle.add (get_updated.callback);
-        });
-
-        yield;
-        return app_ids;
+    private static string get_cache_file_path () {
+        return GLib.Path.build_filename (GLib.Environment.get_user_cache_dir (), "io.elementary.appcenter", "houston.conf");
     }
 
     private static GLib.Once<Houston> instance;

--- a/src/Core/Houston.vala
+++ b/src/Core/Houston.vala
@@ -25,7 +25,7 @@ public class AppCenterCore.Houston : Object {
     private const string APPS_KEY = "apps";
 
     private Soup.Session session;
-    private GLib.KeyFile cache_file = null;
+    private GLib.KeyFile? cache_file = null;
 
     construct {
         session = new Soup.Session ();
@@ -164,7 +164,7 @@ public class AppCenterCore.Houston : Object {
     }
 
     private static string get_cache_file_path () {
-        return GLib.Path.build_filename (GLib.Environment.get_user_cache_dir (), "io.elementary.appcenter", "houston.conf");
+        return GLib.Path.build_filename (GLib.Environment.get_user_cache_dir (), "io.elementary.appcenter", "houston");
     }
 
     private static GLib.Once<Houston> instance;

--- a/src/Widgets/Banner.vala
+++ b/src/Widgets/Banner.vala
@@ -172,8 +172,7 @@ namespace AppCenter.Widgets {
         private BannerWidget? brand_widget;
         private Gtk.Stack stack;
         private Switcher switcher;
-        private int current_package_index;
-        private int next_free_package_index = 1;
+        private uint current_package_index;
         private uint timer_id;
 
         construct {
@@ -219,6 +218,7 @@ namespace AppCenter.Widgets {
 
         public void add_package (AppCenterCore.Package? package) {
             var widget = new BannerWidget (package);
+            var next_free_package_index = stack.get_children ().length ();
             stack.add_named (widget, next_free_package_index.to_string ());
             next_free_package_index++;
             stack.set_visible_child (widget);
@@ -226,18 +226,19 @@ namespace AppCenter.Widgets {
             set_background (package);
 
             if (brand_widget != null) {
-                stack.remove (brand_widget);
+                brand_widget.destroy ();
                 brand_widget = null;
             }
         }
 
         public void next_package () {
-            if (next_free_package_index <= 1) {
+            var next_free_package_index = stack.get_children ().length ();
+            if (next_free_package_index <= 0) {
                 return;
             }
 
-            if (++current_package_index >= next_free_package_index) {
-                current_package_index = 1;
+            if (current_package_index >= next_free_package_index) {
+                current_package_index = 0;
             }
 
             stack.set_visible_child_name (current_package_index.to_string ());
@@ -245,12 +246,19 @@ namespace AppCenter.Widgets {
             switcher.update_selected ();
         }
 
+        public void clear () {
+            stack.get_children ().foreach ((child) => {
+                child.destroy ();
+            });
+        }
+
         public void go_to_first () {
-            if (next_free_package_index <= 1) {
+            var next_free_package_index = stack.get_children ().length ();
+            if (next_free_package_index <= 0) {
                 return;
             }
 
-            current_package_index = 1;
+            current_package_index = 0;
             stack.set_visible_child_name (current_package_index.to_string ());
             set_background ((stack.visible_child as BannerWidget).package);
             switcher.update_selected ();

--- a/src/Widgets/Carousel/Carousel.vala
+++ b/src/Widgets/Carousel/Carousel.vala
@@ -30,7 +30,13 @@ public class AppCenter.Widgets.Carousel : Gtk.FlowBox {
 
         public void add_package (AppCenterCore.Package? package) {
             var carousel_item = new CarouselItem (package);
-            add (carousel_item);    
+            add (carousel_item);
             show_all ();
+        }
+
+        public void clear () {
+            get_children ().foreach ((child) => {
+                child.destroy ();
+            });
         }
 }

--- a/src/Widgets/Switcher.vala
+++ b/src/Widgets/Switcher.vala
@@ -119,7 +119,7 @@ namespace AppCenter.Widgets {
 
         private void on_stack_child_removed (Gtk.Widget widget) {
             var button = buttons.get (widget);
-            remove (button);
+            button.destroy ();
             buttons.unset (widget);
         }
 
@@ -129,13 +129,11 @@ namespace AppCenter.Widgets {
         }
 
         public void clear_children () {
-            foreach (weak Gtk.Widget button in get_children ()) {
-                button.hide ();
-                if (button.get_parent () != null)
-                    remove (button);
-            }
+            get_children ().foreach ((child) => {
+                child.destroy ();
+            });
         }
-        
+
         public void update_selected () {
             foreach (var entry in buttons.entries) {
                 if (entry.key == stack.get_visible_child ()) {


### PR DESCRIPTION
Fixes #210
Please not that the banners aren't loaded directly because it spends a real huge amount of time in `candidate_package.update_state ();` at startup

# What does this branch do
 - Houston cache is loaded every day
 - The cache is stored in a KeyFile
 - Add a `clear ()` function to `Carousel` and `Banner` containers in order to update them
 - Replaced some `parent.remove(child)` with `child.destroy()`, the destroy signal is watched by parents so it's safer
 - Houston fetching is now completely asynchronous

# How to test
Launch AppCenter, it launches normally
Disconnect to your network
Re-launch AppCenter, everything should be back again