### PR TITLE
AppInfoView.vala: connect to correct widget for copy link

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -283,7 +283,7 @@ namespace AppCenter.Views {
             add (overlay);
 
             open_button.get_style_context ().add_class ("h3");
-            
+
             copy_link_button.clicked.connect (() => {
                 var clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
                 clipboard.set_text ("https://appcenter.elementary.io/" + this.package.component.get_id (), -1);

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -284,7 +284,7 @@ namespace AppCenter.Views {
 
             open_button.get_style_context ().add_class ("h3");
             
-            share_button.clicked.connect (() => {
+            copy_link_button.clicked.connect (() => {
                 var clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
                 clipboard.set_text ("https://appcenter.elementary.io/" + this.package.component.get_id (), -1);
 


### PR DESCRIPTION
Fix a mistake where we've connected to the wrong signal, likely an issue caused when resolving conflicts between branches