### PR TITLE
Use destroy instead of remove

### DIFF
--- a/src/Widgets/Banner.vala
+++ b/src/Widgets/Banner.vala
@@ -226,7 +226,7 @@ namespace AppCenter.Widgets {
             set_background (package);
 
             if (brand_widget != null) {
-                stack.remove (brand_widget);
+                brand_widget.destroy ();
                 brand_widget = null;
             }
         }

--- a/src/Widgets/Switcher.vala
+++ b/src/Widgets/Switcher.vala
@@ -119,7 +119,7 @@ namespace AppCenter.Widgets {
 
         private void on_stack_child_removed (Gtk.Widget widget) {
             var button = buttons.get (widget);
-            remove (button);
+            button.destroy ();
             buttons.unset (widget);
         }
 
@@ -129,13 +129,11 @@ namespace AppCenter.Widgets {
         }
 
         public void clear_children () {
-            foreach (weak Gtk.Widget button in get_children ()) {
-                button.hide ();
-                if (button.get_parent () != null)
-                    remove (button);
-            }
+            get_children ().foreach ((child) => {
+                child.destroy ();
+            });
         }
-        
+
         public void update_selected () {
             foreach (var entry in buttons.entries) {
                 if (entry.key == stack.get_visible_child ()) {


### PR DESCRIPTION
ported from #332 

> Replaced some parent.remove(child) with child.destroy(), the destroy signal is watched by parents so it's safer