### PR TITLE
Remove maximum window size restriction

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -45,11 +45,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         unowned Settings saved_state = Settings.get_default ();
         set_default_size (saved_state.window_width, saved_state.window_height);
 
-        Gdk.Geometry hints = Gdk.Geometry ();
-        hints.max_width = 1500;
-        hints.max_height = 1080;
-        set_geometry_hints (null, hints, Gdk.WindowHints.MAX_SIZE);
-
         // Maximize window if necessary
         switch (saved_state.window_state) {
             case Settings.WindowState.MAXIMIZED:


### PR DESCRIPTION
I don't think this code should be there, ever. It makes the main window being restricted to a certain size. This should be a possible fix for https://github.com/elementary/appcenter/issues/367.