### PR TITLE
Fix get_style_valist crashes

### DIFF
--- a/src/Widgets/HumbleButton.vala
+++ b/src/Widgets/HumbleButton.vala
@@ -27,7 +27,7 @@ public class AppCenter.Widgets.HumbleButton : Gtk.Grid {
 
     private Gtk.ToggleButton arrow_button;
 
-    private int _amount;
+    private int _amount = 1;
     public int amount {
         get {
             return _amount;
@@ -75,10 +75,6 @@ public class AppCenter.Widgets.HumbleButton : Gtk.Grid {
                 arrow_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             }
         }
-    }
-
-    public HumbleButton () {
-        Object (amount: 1);
     }
 
     construct {
@@ -168,4 +164,3 @@ public class AppCenter.Widgets.HumbleButton : Gtk.Grid {
         return button;
     }
 }
-


### PR DESCRIPTION
The amount shouldn't be set using `Object ()` since it's not a construct property, it now has only a default value of 1.

This should fix 
`#11 0x00007ffff6e869e7 in gtk_style_context_get_style_valist () from /usr/lib/x86_64-linux-gnu/libgtk-3.so.0` crashes when closing the AppCenter.