### PR TITLE
Fix threads crash

### DIFF
--- a/src/Widgets/AbstractAppContainer.vala
+++ b/src/Widgets/AbstractAppContainer.vala
@@ -167,7 +167,12 @@ namespace AppCenter {
 
             image.gicon = package.get_icon (icon_size);
 
-            package.notify["state"].connect (() => update_state ());
+            package.notify["state"].connect (() => {
+                Idle.add (() => {
+                    update_state ();
+                    return false;
+                });
+            });
 
             package.change_information.bind_property ("can-cancel", cancel_button, "sensitive", GLib.BindingFlags.SYNC_CREATE);
             package.change_information.progress_changed.connect (update_progress);
@@ -275,4 +280,3 @@ namespace AppCenter {
         }
     }
 }
-


### PR DESCRIPTION
This crash was caused by having the Homepage fetching the packages from Houston and updating their states in a Thread, hence why this signal and updating UI was also ran in a Thread . This should fix the thread crashes.