### PR TITLE
Fix sorting in AppListView

### DIFF
--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -92,11 +92,11 @@ namespace AppCenter.Views {
         protected override int package_row_compare (Widgets.AppListRow row1, Widgets.AppListRow row2) {
             bool p1_is_elementary_native = row1.get_package ().is_native;
 
-            if (p1_is_elementary_native || row2.get_package ().is_native) {
+            if (p1_is_elementary_native != row2.get_package ().is_native) {
                 return p1_is_elementary_native ? -1 : 1;
             }
 
-            return row1.get_name_label ().collate (row1.get_name_label ());
+            return base.package_row_compare (row1, row2);
         }
 
         [CCode (instance_pos = -1)]


### PR DESCRIPTION
Fixes sorting in `AppListView`. The `if` condition was wrong and assumed that if some package is native then sort them by nativity. This is now changed to compare if the rows are actually different.

There is also a wrong parameter passed to the last `return` line:
return **row1**.get_name_label ().collate (**row1**.get_name_label ());
It compares two same labels which will always return that they are equal. This should be changed to `row2`, but since the same is done in the default `AbstractAppList` class, we will just call the `base`.

Here you go with screenshots what has actually changed:

**Before:**
![before-appcenter](https://user-images.githubusercontent.com/8205284/28757292-8ff7e4a6-757f-11e7-90f5-37c86f7a51d0.png)

**After:**
![after-appcenter](https://user-images.githubusercontent.com/8205284/28757295-a2950fd0-757f-11e7-93e8-2150374e872c.png)

