### PR TITLE
Implements changelog information in AppInfoView

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ vala_precompile(VALA_C ${EXEC_NAME}
     Widgets/HumbleButton.vala
     Widgets/SharePopover.vala
     Widgets/Switcher.vala
+    Widgets/ReleaseRow.vala
     Services/DbusInterfaces.vala
     Services/DBusServer.vala
     ${CMAKE_CURRENT_BINARY_DIR}/config.vala


### PR DESCRIPTION
Fixes #296. Adds changelog information from AppStream to the AppInfoView. The implementation currently limits the number of releases shown to 5 but it can be easily changed in the declared constants.

If the package is not installed, the view shows only 1 package, otherwise, we calculate what index in the release list is the current installed version and add all the releases from the start of the list to the calulated index.