### PR TITLE
AppInfoView.vala: What's new styling

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -164,10 +164,9 @@ namespace AppCenter.Views {
 
             content_grid.add (app_description);
 
-            var whats_new_label = new Gtk.Label ("<b>" + _("What's New:") + "</b>");
-            whats_new_label.use_markup = true;
-            whats_new_label.get_style_context ().add_class ("h3");
-            whats_new_label.halign = Gtk.Align.START;
+            var whats_new_label = new Gtk.Label (_("What's New:"));
+            whats_new_label.get_style_context ().add_class ("h2");
+            whats_new_label.xalign = 0;
 
             release_list_box = new Widgets.ReleaseListBox (package);
 
@@ -184,10 +183,9 @@ namespace AppCenter.Views {
                 extension_box = new Gtk.ListBox ();
                 extension_box.selection_mode = Gtk.SelectionMode.NONE;
 
-                var extension_label = new Gtk.Label ("<b>" + _("Extensions:") + "</b>");
+                var extension_label = new Gtk.Label (_("Extensions:"));
                 extension_label.margin_top = 12;
-                extension_label.use_markup = true;
-                extension_label.get_style_context ().add_class ("h3");
+                extension_label.get_style_context ().add_class ("h2");
                 extension_label.halign = Gtk.Align.START;
 
                 content_grid.add (extension_label);

--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -44,6 +44,7 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.ListBoxRow {
         description_label.get_style_context ().add_class ("h3");
 
         var grid = new Gtk.Grid ();
+        grid.margin_bottom = 6;
         grid.attach (header_label, 0, 0, 1, 1);
         grid.attach (description_label, 0, 1, 1, 1);
 

--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -32,20 +32,18 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.ListBoxRow {
         string description = format_release_description (release);
 
         header_label = new Gtk.Label (header);
-        header_label.halign = Gtk.Align.START;
-        header_label.get_style_context ().add_class ("h3");
         header_label.use_markup = true;
+        header_label.xalign = 0;
+        header_label.get_style_context ().add_class ("h3");
 
         description_label = new Gtk.Label (description);
-        description_label.wrap = true;
         description_label.selectable = true;
-        description_label.get_style_context ().add_class ("h3");
-        description_label.halign = Gtk.Align.START;
-        description_label.margin_start = 12;
         description_label.use_markup = true;
+        description_label.wrap = true;
+        description_label.xalign = 0;
+        description_label.get_style_context ().add_class ("h3");
 
         var grid = new Gtk.Grid ();
-        grid.margin_bottom = 6;
         grid.attach (header_label, 0, 0, 1, 1);
         grid.attach (description_label, 0, 1, 1, 1);
 


### PR DESCRIPTION
* All section headers use h2
* xalign instead of halign (it's a bit safer with wraps)
* Remove extra indentation

Before:

![screenshot from 2017-08-07 13 34 06](https://user-images.githubusercontent.com/7277719/29044620-1a0e102a-7b75-11e7-84e4-69c3e0a2a7b2.png)


After:

![screenshot from 2017-08-07 13 33 23](https://user-images.githubusercontent.com/7277719/29044605-0865ef14-7b75-11e7-9dda-f89c08a36a6c.png)
