### PR TITLE
Show newest changelog in the updates view

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -488,8 +488,12 @@ public class AppCenterCore.Package : Object {
     }
 
     public AppStream.Release? get_newest_release () {
-        var releases = get_newest_releases (1, 1);
-        if (releases.size > 0) {
+        var releases = component.get_releases ();
+        releases.sort_with_data ((a, b) => {
+            return b.vercmp (a);
+        });
+
+        if (releases.length > 0) {
             return releases[0];
         }
 

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -448,6 +448,54 @@ public class AppCenterCore.Package : Object {
         return app_info != null;
     }
 
+    public Gee.ArrayList<AppStream.Release> get_newest_releases (int min_releases, int max_releases) {
+        var list = new Gee.ArrayList<AppStream.Release> ();
+
+        var releases = component.get_releases ();
+        if (releases.length < min_releases) {
+            return list;
+        }
+
+        releases.sort_with_data ((a, b) => {
+            return b.vercmp (a);
+        });
+
+        string installed_version = get_version ();
+        
+        int start_index = 0;
+        int end_index = min_releases;
+
+        if (installed) {
+            for (int i = 0; i < releases.length; i++) {
+                var release = releases.@get (i);
+                unowned string release_version = release.get_version ();
+                if (release_version == null) {
+                    continue;
+                }
+
+                if (AppStream.utils_compare_versions (release_version, installed_version) == 0) {
+                    end_index = i.clamp (min_releases, max_releases);
+                    break;
+                }
+            }
+        }
+
+        for (int j = start_index; j < end_index; j++) {
+            list.add (releases.get (j));
+        }
+
+        return list;
+    }
+
+    public AppStream.Release? get_newest_release () {
+        var releases = get_newest_releases (1, 1);
+        if (releases.size > 0) {
+            return releases[0];
+        }
+
+        return null;
+    }
+
     public Pk.Package? find_package () {
         if (component.id == OS_UPDATES_ID || is_local) {
             return null;

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -322,7 +322,7 @@ namespace AppCenter.Views {
 
         private async void load_extensions () {
             package.component.get_addons ().@foreach ((extension) => {
-                var row = new Widgets.PackageRow.list (new AppCenterCore.Package (extension), null, false);
+                var row = new Widgets.PackageRow.list (new AppCenterCore.Package (extension), null, null, false);
                 if (extension_box != null) {
                     extension_box.add (row);
                 }

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -85,7 +85,7 @@ namespace AppCenter.Views {
         }
 
         protected override Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.installed (package, action_button_group, false);
+            return new Widgets.PackageRow.installed (package, info_grid_group, action_button_group, false);
         }
 
         protected override void on_package_changing (AppCenterCore.Package package, bool is_changing) {

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -59,7 +59,7 @@ namespace AppCenter.Views {
         }
 
         protected override Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package)  {
-            return new Widgets.PackageRow.list (package, action_button_group, false);
+            return new Widgets.PackageRow.list (package, info_grid_group, action_button_group, false);
         }
 
         // Show 20 more apps on the listbox

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -59,7 +59,7 @@ namespace AppCenter.Views {
         }
 
         protected override Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package)  {
-            return new Widgets.PackageRow.list (package, info_grid_group, action_button_group, false);
+            return new Widgets.PackageRow.list (package, null, action_button_group, false);
         }
 
         // Show 20 more apps on the listbox

--- a/src/Widgets/AbstractAppContainer.vala
+++ b/src/Widgets/AbstractAppContainer.vala
@@ -141,6 +141,7 @@ namespace AppCenter {
             action_button_group.add_widget (open_button);
 
             action_stack = new Gtk.Stack ();
+            action_stack.hexpand = true;
             action_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
             action_stack.add_named (button_grid, "buttons");
             action_stack.add_named (progress_grid, "progress");

--- a/src/Widgets/AbstractAppContainer.vala
+++ b/src/Widgets/AbstractAppContainer.vala
@@ -30,6 +30,7 @@ namespace AppCenter {
         protected Gtk.Button uninstall_button;
         protected Gtk.Button open_button;
 
+        protected Gtk.Grid progress_grid;
         protected Gtk.ProgressBar progress_bar;
         protected Gtk.Button cancel_button;
         protected Gtk.SizeGroup action_button_group;
@@ -126,7 +127,7 @@ namespace AppCenter {
             cancel_button = new Gtk.Button.with_label (_("Cancel"));
             cancel_button.clicked.connect (() => action_cancelled ());
 
-            var progress_grid = new Gtk.Grid ();
+            progress_grid = new Gtk.Grid ();
             progress_grid.halign = Gtk.Align.END;
             progress_grid.valign = Gtk.Align.CENTER;
             progress_grid.column_spacing = 12;
@@ -202,12 +203,14 @@ namespace AppCenter {
                     set_widget_visibility (uninstall_button, false);
                     set_widget_visibility (action_button, true);
                     set_widget_visibility (open_button, false);
+                    set_widget_visibility (progress_grid, false);
 
                     break;
                 case AppCenterCore.Package.State.INSTALLED:
                     set_widget_visibility (uninstall_button, show_uninstall && !is_os_updates);
                     set_widget_visibility (action_button, false);
                     set_widget_visibility (open_button, show_open && package.get_can_launch ());
+                    set_widget_visibility (progress_grid, false);
 
                     break;
                 case AppCenterCore.Package.State.UPDATE_AVAILABLE:
@@ -216,6 +219,7 @@ namespace AppCenter {
                     set_widget_visibility (uninstall_button, show_uninstall && !is_os_updates);
                     set_widget_visibility (action_button, true);
                     set_widget_visibility (open_button, false);
+                    set_widget_visibility (progress_grid, false);
 
                     break;
                 case AppCenterCore.Package.State.INSTALLING:
@@ -224,6 +228,7 @@ namespace AppCenter {
                     set_widget_visibility (uninstall_button, false);
                     set_widget_visibility (action_button, false);
                     set_widget_visibility (open_button, false);
+                    set_widget_visibility (progress_grid, true);
 
                     action_stack.set_visible_child_name ("progress");
                     break;
@@ -233,9 +238,14 @@ namespace AppCenter {
             }
         }
 
-        private static void set_widget_visibility (Gtk.Widget widget, bool show) {
-            widget.no_show_all = !show;
-            widget.visible = show;
+        protected static void set_widget_visibility (Gtk.Widget widget, bool show) {
+            if (show) {
+                widget.no_show_all = false;
+                widget.show_all ();
+            } else {
+                widget.no_show_all = true;
+                widget.hide ();
+            }
         }
 
         protected void update_progress () {

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -24,6 +24,7 @@ namespace AppCenter {
         protected Gtk.ScrolledWindow scrolled;
         protected Gtk.ListBox list_box;
         protected Gtk.SizeGroup action_button_group;
+        protected Gtk.SizeGroup info_grid_group;
         protected uint packages_changing = 0;
 
         construct {
@@ -47,6 +48,7 @@ namespace AppCenter {
             scrolled.add (list_box);
 
             action_button_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
+            info_grid_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
         }
 
         protected abstract Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package);

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -22,16 +22,16 @@ namespace AppCenter.Widgets {
     public class PackageRow : Gtk.ListBoxRow, AppListRow {
         AbstractPackageRowGrid grid;
 
-        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? size_group, bool show_uninstall = true) {
-            grid = new InstalledPackageRowGrid (package, size_group, show_uninstall);
+        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
+            grid = new InstalledPackageRowGrid (package, info_size_group, action_size_group, show_uninstall);
             add (grid);
             grid.changed.connect (() => {
                 changed ();
             });
         }
 
-        public PackageRow.list (AppCenterCore.Package package, Gtk.SizeGroup? size_group, bool show_uninstall = true) {
-            grid = new ListPackageRowGrid (package, size_group, show_uninstall);
+        public PackageRow.list (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
+            grid = new ListPackageRowGrid (package, info_size_group, action_size_group, show_uninstall);
             add (grid);
             grid.changed.connect (() => {
                 changed ();
@@ -72,7 +72,6 @@ namespace AppCenter.Widgets {
 
         private abstract class AbstractPackageRowGrid : AbstractAppContainer {
             public signal void changed ();
-
             protected Gtk.Grid info_grid;
 
             construct {
@@ -106,15 +105,19 @@ namespace AppCenter.Widgets {
                 attach (action_stack, 2, 0, 1, 1);
             }
 
-            public AbstractPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? size_group, bool show_uninstall = true) {
+            public AbstractPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
                 this.package = package;
                 this.show_uninstall = show_uninstall;
                 this.show_open = false;
 
-                if (size_group != null) {
-                    size_group.add_widget (action_button);
-                    size_group.add_widget (cancel_button);
-                    size_group.add_widget (uninstall_button);
+                if (action_size_group != null) {
+                    action_size_group.add_widget (action_button);
+                    action_size_group.add_widget (cancel_button);
+                    action_size_group.add_widget (uninstall_button);
+                }
+
+                if (info_size_group != null) {
+                    info_size_group.add_widget (info_grid);
                 }
             }
         }
@@ -151,8 +154,8 @@ namespace AppCenter.Widgets {
                 attach (release_expander, 2, 0, 1, 2);
             }
 
-            public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? size_group, bool show_uninstall = true) {
-                base (package, size_group, show_uninstall);
+            public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
+                base (package, info_size_group, action_size_group, show_uninstall);
                 set_up_package ();
             }
 
@@ -222,8 +225,8 @@ namespace AppCenter.Widgets {
                 info_grid.attach (package_summary, 1, 1, 1, 1);
             }
 
-            public ListPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? size_group, bool show_uninstall = true) {
-                base (package, size_group, show_uninstall);
+            public ListPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
+                base (package, info_size_group, action_size_group, show_uninstall);
                 set_up_package ();
             }
 

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -79,26 +79,29 @@ namespace AppCenter.Widgets {
                 margin = 6;
                 margin_start = 12;
                 margin_end = 12;
-                column_homogeneous = true;
+                column_spacing = 12;
+                row_spacing = 6;
 
                 image.icon_size = Gtk.IconSize.DIALOG;
                 /* Needed to enforce size on icons from Filesystem/Remote */
                 image.pixel_size = 48;
 
                 package_name.get_style_context ().add_class ("h3");
-                package_name.hexpand = true;
                 package_name.valign = Gtk.Align.END;
                 ((Gtk.Misc) package_name).xalign = 0;
 
-                action_stack.halign = Gtk.Align.END;
-
                 info_grid = new Gtk.Grid ();
-                info_grid.halign = Gtk.Align.START;
                 info_grid.column_spacing = 12;
                 info_grid.row_spacing = 6;
-
+                info_grid.valign = Gtk.Align.START;
                 info_grid.attach (image, 0, 0, 1, 2);
                 info_grid.attach (package_name, 1, 0, 1, 1);
+
+                action_stack.valign = Gtk.Align.START;
+
+                var sizegroup = new Gtk.SizeGroup (Gtk.SizeGroupMode.VERTICAL);
+                sizegroup.add_widget (info_grid);
+                sizegroup.add_widget (action_stack);
 
                 attach (info_grid, 0, 0, 1, 1);
                 attach (action_stack, 2, 0, 1, 1);
@@ -127,7 +130,6 @@ namespace AppCenter.Widgets {
                 updates_view = true;
                 app_version = new Gtk.Label (null);
                 app_version.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
-                app_version.hexpand = true;
                 app_version.valign = Gtk.Align.START;
                 ((Gtk.Misc) app_version).xalign = 0;
 
@@ -139,7 +141,7 @@ namespace AppCenter.Widgets {
 
                 release_expander = new Gtk.Expander ("");
                 release_expander.use_markup = true;
-                release_expander.halign = release_expander.valign = Gtk.Align.CENTER;
+                release_expander.halign = release_expander.valign = Gtk.Align.START;
                 release_expander.add (release_description);
                 release_expander.button_press_event.connect (() => {
                     release_expander.expanded = !release_expander.expanded;
@@ -147,7 +149,7 @@ namespace AppCenter.Widgets {
                 });
 
                 info_grid.attach (app_version, 1, 1, 1, 1);
-                attach (release_expander, 1, 0, 1, 1);
+                attach (release_expander, 2, 0, 1, 2);
             }
 
             public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? size_group, bool show_uninstall = true) {
@@ -218,7 +220,7 @@ namespace AppCenter.Widgets {
                 package_summary.valign = Gtk.Align.START;
                 ((Gtk.Misc) package_summary).xalign = 0;
 
-                attach (package_summary, 1, 1, 1, 1);
+                info_grid.attach (package_summary, 1, 1, 1, 1);
             }
 
             public ListPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? size_group, bool show_uninstall = true) {

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -138,7 +138,7 @@ namespace AppCenter.Widgets {
                 release_description.selectable = true;
                 release_description.use_markup = true;
                 release_description.wrap = true;
-                release_description.margin_start = 14;
+                release_description.margin_start = 12;
                 release_description.xalign = 0;
 
                 release_expander = new Gtk.Expander ("");

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -95,11 +95,8 @@ namespace AppCenter.Widgets {
                 info_grid.attach (image, 0, 0, 1, 2);
                 info_grid.attach (package_name, 1, 0, 1, 1);
 
+                action_stack.margin_top = 10;
                 action_stack.valign = Gtk.Align.START;
-
-                var sizegroup = new Gtk.SizeGroup (Gtk.SizeGroupMode.VERTICAL);
-                sizegroup.add_widget (info_grid);
-                sizegroup.add_widget (action_stack);
 
                 attach (info_grid, 0, 0, 1, 1);
                 attach (action_stack, 2, 0, 1, 1);

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -79,8 +79,7 @@ namespace AppCenter.Widgets {
                 margin = 6;
                 margin_start = 12;
                 margin_end = 12;
-                column_spacing = 12;
-                row_spacing = 6;
+                column_spacing = 24;
 
                 image.icon_size = Gtk.IconSize.DIALOG;
                 /* Needed to enforce size on icons from Filesystem/Remote */

--- a/src/Widgets/ReleaseListBox.vala
+++ b/src/Widgets/ReleaseListBox.vala
@@ -28,41 +28,12 @@ public class AppCenter.Widgets.ReleaseListBox : Gtk.ListBox {
     }
 
     public bool populate () {
-        var releases = package.component.get_releases ();
-        int length = releases.length;
-        if (length < MIN_RELEASES) {
-            return false;
-        }
-
-        releases.sort_with_data ((a, b) => {
-            return b.vercmp (a);
-        });
-
-        string installed_version = package.get_version ();
-        
-        int start_index = 0;
-        int end_index = MIN_RELEASES;
-
-        if (package.installed) {
-            for (int i = 0; i < length; i++) {
-                unowned string release_version = releases.@get (i).get_version ();
-                if (release_version == null) {
-                    continue;
-                }
-
-                if (AppStream.utils_compare_versions (release_version, installed_version) == 0) {
-                    end_index = i.clamp (MIN_RELEASES, MAX_RELEASES);
-                    break;
-                }
-            }
-        }
-
-        for (int j = start_index; j < end_index; j++) {
-            var release = releases.get (j);
-            var row = new Widgets.ReleaseRow (release);
+        var releases = package.get_newest_releases (MIN_RELEASES, MAX_RELEASES);
+        foreach (var release in releases) {
+            var row = new ReleaseRow (release);
             add (row);
         }
 
-        return true;
+        return releases.size > 0;
     }
 }

--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -28,7 +28,7 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.ListBoxRow {
     }
 
     construct {
-        string header = format_release_header (release);
+        string header = format_release_header (release, true);
         string description = format_release_description (release);
 
         header_label = new Gtk.Label (header);
@@ -51,13 +51,13 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.ListBoxRow {
         add (grid);
     }
 
-    private static string format_release_header (AppStream.Release release) {
+    public static string format_release_header (AppStream.Release release, bool with_date) {
         string label;
 
         unowned string version = release.get_version ();
 
         uint64 timestamp = release.get_timestamp ();
-        if (timestamp != 0) {
+        if (with_date && timestamp != 0) {
             var date_time = new DateTime.from_unix_utc ((int64)timestamp);
             string format = Granite.DateTime.get_default_date_format (false, true, true);
             string date = date_time.format (format);
@@ -76,7 +76,7 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.ListBoxRow {
         return label;
     }
 
-    private static string format_release_description (AppStream.Release release) {
+    public static string format_release_description (AppStream.Release release) {
         string description = release.get_description ();
         if (description != null) {
             try {

--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -84,6 +84,10 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.ListBoxRow {
             } catch (Error e) {
                 warning (e.message);
             }
+
+            if (description.strip () == "") {
+                description = _("No description available");
+            }
         } else {
             description = _("No description available");
         }


### PR DESCRIPTION
Fixes #24.

This is work in progress, but I would still like to get feedback how can I fix some problems with the UI because I just can't get over them:
* The "Update" button stays always in the middle of the package row, even if you expand the version description
* When expanding the version description, the expander changes it's place and so the expander arrow changes it's place so that you can't click it again without moving the mouse.

Some changes in the code to make the PackageRow display the release information is moving some methods from `ReleaseListBox` and `ReleaseRow` to the core `Package` class so they can be used outside of these specific widgets.