### PR TITLE
Add side margins to AppInfoView

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -148,8 +148,7 @@ namespace AppCenter.Views {
             var content_grid = new Gtk.Grid ();
             content_grid.width_request = 800;
             content_grid.halign = Gtk.Align.CENTER;
-            content_grid.margin_bottom = 48;
-            content_grid.margin_top = 48;
+            content_grid.margin = 48;
             content_grid.row_spacing = 24;
             content_grid.orientation = Gtk.Orientation.VERTICAL;
 


### PR DESCRIPTION
Fixes #441.

There are no side margins in `AppInfoView` class which leads pages like Vocal page to not have any margin on the sides due to long labels. This fixes it.