### PR TITLE
Add is_shareable property

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -95,7 +95,7 @@ public class AppCenterCore.Package : Object {
 
     public bool is_os_updates {
         get {
-            return component.id == "xxx-os-updates";
+            return component.id == OS_UPDATES_ID;
         }
     }
 
@@ -108,6 +108,12 @@ public class AppCenterCore.Package : Object {
     public bool is_local {
         get {
             return component.get_id ().has_suffix (LOCAL_ID_SUFFIX);
+        }
+    }
+
+    public bool is_shareable {
+        get {
+            return !is_driver && !is_os_updates;
         }
     }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -276,7 +276,7 @@ namespace AppCenter.Views {
 
             open_button.get_style_context ().add_class ("h3");
 
-            if (!package.is_os_updates) {
+            if (package.is_shareable) {
                 var body = _("Check out %s on AppCenter:").printf (package.get_name ());
                 var uri = "https://appcenter.elementary.io/%s".printf (package.component.get_id ());
                 var share_popover = new SharePopover (body, uri);


### PR DESCRIPTION
Fixes #383.

Adds `is_shareable` and makes drivers not shareable for now. The `return component.id == OS_UPDATES_ID;` is intentional since that string is already declared in `OS_UPDATES_ID` constant.