### PR TITLE
Add daemon desktop file back

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set (DOLLAR "$")
 include (CTest)
 if (BUILD_TESTING)
     add_test (NAME validate-desktop-file COMMAND desktop-file-validate ${CMAKE_BINARY_DIR}/data/io.elementary.appcenter.desktop)
+    add_test (NAME validate-daemon-desktop-file COMMAND desktop-file-validate ${CMAKE_BINARY_DIR}/data/io.elementary.appcenter-daemon.desktop)
     add_test (NAME validate-appdata COMMAND appstreamcli validate ${CMAKE_BINARY_DIR}/data/io.elementary.appcenter.appdata.xml)
 endif ()
 

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,10 +1,12 @@
 include (Translations)
 configure_file(io.elementary.appcenter.desktop.in.in ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.desktop.in)
+configure_file(io.elementary.appcenter-daemon.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter-daemon.desktop)
 configure_file_translation(${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.desktop ${CMAKE_SOURCE_DIR}/po/)
 configure_file(io.elementary.appcenter.service.in ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.service)
 configure_file_translation(${CMAKE_CURRENT_SOURCE_DIR}/io.elementary.appcenter.appdata.xml.in ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.appdata.xml ${CMAKE_SOURCE_DIR}/po/)
 
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.desktop DESTINATION share/applications)
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter-daemon.desktop DESTINATION share/applications)
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.appdata.xml DESTINATION share/metainfo)
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/io.elementary.appcenter.service DESTINATION share/dbus-1/services)
 install (FILES appcenter.blacklist DESTINATION ${CONFIGDIR})

--- a/data/io.elementary.appcenter-daemon.desktop.in
+++ b/data/io.elementary.appcenter-daemon.desktop.in
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=@APP_NAME@ Daemon
+Comment=@RELEASE_NAME@
+Exec=@EXEC_NAME@ -s
+Icon=@DESKTOP_ICON@
+Terminal=false
+Type=Application
+NoDisplay=true
+X-GNOME-AutoRestart=true
+X-GNOME-Autostart-Phase=Applications


### PR DESCRIPTION
Fixes #471.

Adds the daemon desktop file back. This was my fault and I apologize for that, **the change will require removing the daemon patch in the packaging on LP.**