### PR TITLE
Carousel and Banner widgets refactoring

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ vala_precompile(VALA_C ${EXEC_NAME}
     Core/Client.vala
     Core/Houston.vala
     Core/Package.vala
+    Core/PackageList.vala
     Core/Task.vala
     Core/UpdateManager.vala
     Core/ComponentValidator.vala

--- a/src/Core/PackageList.vala
+++ b/src/Core/PackageList.vala
@@ -1,0 +1,56 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2014-2016 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Gee;
+using AppCenterCore;
+
+// An immutable, signal-able package list container
+public class AppCenterCore.PackageList : Object {
+    public signal void updated ();
+
+    protected Gee.ConcurrentList<AppCenterCore.Package> _packages_backend;
+
+    public PackageList () {
+        _packages_backend = new ConcurrentList<Package> ();
+    }
+
+    public PackageList set_packages (Collection<Package> collection) {
+        _packages_backend.clear ();
+        _packages_backend.add_all (collection);
+        updated ();
+        return this;
+    }
+
+    public PackageList set_from_iterator (Iterator<Package> itor) {
+        _packages_backend.clear ();
+        _packages_backend.add_all_iterator (itor);
+        updated ();
+        return this;
+    }
+
+    public PackageList set_from_array (Package[] arr) {
+        _packages_backend.clear ();
+        _packages_backend.add_all_array (arr);
+        updated ();
+        return this;
+    }
+
+    public Collection<Package> get_packages () {
+        return _packages_backend.read_only_view;
+    }
+ }

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -117,15 +117,15 @@ namespace AppCenter {
 
             add (category_scrolled);
 
-            var local_package = App.local_package;
-            if (local_package != null) {
-                newest_banner.add_package (local_package);
-            }
-
             houston.get_app_ids.begin ("/newest/project", (obj, res) => {
                 var newest_ids = houston.get_app_ids.end (res);
                 new Thread<void*> ("update-banner", () => {
                     var packages_for_banner = new Gee.LinkedList<AppCenterCore.Package> ();
+
+                    if (App.local_package != null) {
+                        packages_for_banner.add(App.local_package);
+                    }
+
                     foreach (var package in newest_ids) {
                         if (packages_for_banner.size >= NUM_PACKAGES_IN_BANNER) {
                             break;
@@ -144,9 +144,8 @@ namespace AppCenter {
                     }
 
                     Idle.add (() => {
-                        foreach (var banner_package in packages_for_banner) {
-                            newest_banner.add_package (banner_package);
-                        }
+                        var package_list = (new AppCenterCore.PackageList()).set_packages(packages_for_banner);
+                        newest_banner.set_package_list(package_list);
                         newest_banner.go_to_first ();
                         switcher.show_all ();
                         switcher_revealer.set_reveal_child (true);
@@ -179,9 +178,8 @@ namespace AppCenter {
 
                     if (!packages_for_carousel.is_empty) {
                         Idle.add (() => {
-                            foreach (var banner_package in packages_for_carousel) {
-                                recently_updated_carousel.add_package (banner_package);
-                            }
+                            var package_list = (new AppCenterCore.PackageList()).set_packages(packages_for_carousel);
+                            recently_updated_carousel.set_package_list(package_list);
                             recently_updated_revealer.reveal_child = true;
                             return false;
                         });
@@ -212,9 +210,8 @@ namespace AppCenter {
 
                     if (!packages_for_carousel.is_empty) {
                         Idle.add (() => {
-                            foreach (var trending_package in packages_for_carousel) {
-                                trending_carousel.add_package (trending_package);
-                            }
+                            var package_list = (new AppCenterCore.PackageList()).set_packages(packages_for_carousel);
+                            trending_carousel.set_package_list(package_list);
                             trending_revealer.reveal_child = true;
                             return false;
                         });

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -117,107 +117,31 @@ namespace AppCenter {
 
             add (category_scrolled);
 
-            houston.get_app_ids.begin ("/newest/project", (obj, res) => {
-                var newest_ids = houston.get_app_ids.end (res);
-                new Thread<void*> ("update-banner", () => {
-                    var packages_for_banner = new Gee.LinkedList<AppCenterCore.Package> ();
-
-                    if (App.local_package != null) {
-                        packages_for_banner.add(App.local_package);
-                    }
-
-                    foreach (var package in newest_ids) {
-                        if (packages_for_banner.size >= NUM_PACKAGES_IN_BANNER) {
-                            break;
-                        }
-
-                        var candidate = package + ".desktop";
-                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (candidate);
-
-                        if (candidate_package != null) {
-                            candidate_package.update_state ();
-
-                            if (candidate_package.state == AppCenterCore.Package.State.NOT_INSTALLED) {
-                                packages_for_banner.add (candidate_package);
-                            }
-                        }
-                    }
-
-                    Idle.add (() => {
-                        var package_list = (new AppCenterCore.PackageList()).set_packages(packages_for_banner);
-                        newest_banner.set_package_list(package_list);
-                        newest_banner.go_to_first ();
-                        switcher.show_all ();
-                        switcher_revealer.set_reveal_child (true);
-                        main_window.homepage_loaded ();
-                        return false;
-                    });
-                    return null;
-                });
+            var newest_package_list = houston.get_promo_package_list("/newest/project");
+            ulong newest_package_list_signal_id = 0;
+            newest_package_list_signal_id = newest_package_list.updated.connect(() => {
+                newest_package_list.disconnect(newest_package_list_signal_id);
+                newest_banner.set_package_list(newest_package_list);
+                newest_banner.go_to_first ();
+                switcher.show_all ();
+                switcher_revealer.set_reveal_child (true);
+                main_window.homepage_loaded ();
             });
 
-            houston.get_app_ids.begin ("/newest/release", (obj, res) => {
-                var updated_ids = houston.get_app_ids.end (res);
-                new Thread<void*> ("update-recent-carousel", () => {
-                    var packages_for_carousel = new Gee.LinkedList<AppCenterCore.Package> ();
-                    foreach (var package in updated_ids) {
-                        if (packages_for_carousel.size >= NUM_PACKAGES_IN_CAROUSEL) {
-                            break;
-                        }
-
-                        var candidate = package + ".desktop";
-                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (candidate);
-
-                        if (candidate_package != null) {
-                            candidate_package.update_state ();
-                            if (candidate_package.state == AppCenterCore.Package.State.NOT_INSTALLED) {
-                                packages_for_carousel.add (candidate_package);
-                            }
-                        }
-                    }
-
-                    if (!packages_for_carousel.is_empty) {
-                        Idle.add (() => {
-                            var package_list = (new AppCenterCore.PackageList()).set_packages(packages_for_carousel);
-                            recently_updated_carousel.set_package_list(package_list);
-                            recently_updated_revealer.reveal_child = true;
-                            return false;
-                        });
-                    }
-                    return null;
-                });
+            var recently_updated_package_list = houston.get_promo_package_list("/newest/release");
+            ulong recently_updated_package_list_signal_id = 0;
+            recently_updated_package_list_signal_id = recently_updated_package_list.updated.connect(() => {
+                recently_updated_package_list.disconnect(recently_updated_package_list_signal_id);
+                recently_updated_carousel.set_package_list(recently_updated_package_list);
+                recently_updated_revealer.reveal_child = true;
             });
 
-            houston.get_app_ids.begin ("/newest/downloads", (obj, res) => {
-                var trending_ids = houston.get_app_ids.end (res);
-                new Thread<void*> ("update-trending-carousel", () => {
-                    var packages_for_carousel = new Gee.LinkedList<AppCenterCore.Package> ();
-                    foreach (var package in trending_ids) {
-                        if (packages_for_carousel.size >= NUM_PACKAGES_IN_CAROUSEL) {
-                            break;
-                        }
-
-                        var candidate = package + ".desktop";
-                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (candidate);
-
-                        if (candidate_package != null) {
-                            candidate_package.update_state ();
-                            if (candidate_package.state == AppCenterCore.Package.State.NOT_INSTALLED) {
-                                packages_for_carousel.add (candidate_package);
-                            }
-                        }
-                    }
-
-                    if (!packages_for_carousel.is_empty) {
-                        Idle.add (() => {
-                            var package_list = (new AppCenterCore.PackageList()).set_packages(packages_for_carousel);
-                            trending_carousel.set_package_list(package_list);
-                            trending_revealer.reveal_child = true;
-                            return false;
-                        });
-                    }
-                    return null;
-                });
+            var trending_package_list = houston.get_promo_package_list("/newest/downloads");
+            ulong trending_package_list_signal_id = 0;
+                trending_package_list_signal_id = trending_package_list.updated.connect(() => {
+                trending_package_list.disconnect(trending_package_list_signal_id);
+                trending_carousel.set_package_list(trending_package_list);
+                trending_revealer.reveal_child = true;
             });
 
             category_flow.child_activated.connect ((child) => {

--- a/src/Widgets/Banner.vala
+++ b/src/Widgets/Banner.vala
@@ -177,6 +177,7 @@ namespace AppCenter.Widgets {
             }
         }
 
+        protected AppCenterCore.PackageList _package_list;
         private BannerWidget? brand_widget;
         private Gtk.Stack stack;
         private Switcher switcher;
@@ -225,18 +226,42 @@ namespace AppCenter.Widgets {
             return null;
         }
 
-        public void add_package (AppCenterCore.Package? package) {
-            var widget = new BannerWidget (package);
-            stack.add_named (widget, next_free_package_index.to_string ());
-            next_free_package_index++;
-            stack.set_visible_child (widget);
-            switcher.update_selected ();
-            set_background (package);
-
-            if (brand_widget != null) {
-                brand_widget.destroy ();
-                brand_widget = null;
+        public void set_package_list(AppCenterCore.PackageList package_list) {
+            if (_package_list != null) {
+                _package_list.updated.disconnect(on_package_list_updated);
             }
+            _package_list = package_list;
+            _package_list.updated.connect(on_package_list_updated);
+            on_package_list_updated();
+        }
+
+        protected void on_package_list_updated() {
+            rebuild_children();
+        }
+   
+        public void rebuild_children() {
+            @foreach ((widget) => {
+                if (widget is BannerWidget) remove (widget);
+            });
+            
+            current_package_index = 1;
+            next_free_package_index = 1;
+            foreach (var package in _package_list.get_packages ()) {
+                var widget = new BannerWidget (package);
+                stack.add_named(widget, next_free_package_index.to_string ());
+                stack.set_visible_child (widget);
+                switcher.update_selected ();
+                set_background (package);
+                
+                if (brand_widget != null) {
+                    brand_widget.destroy ();
+                    brand_widget = null;
+                }
+
+                next_free_package_index++;
+            }
+            
+            show_all();
         }
 
         public void next_package () {

--- a/src/Widgets/Carousel/AuthorCarousel.vala
+++ b/src/Widgets/Carousel/AuthorCarousel.vala
@@ -23,14 +23,11 @@ public class AppCenter.Widgets.AuthorCarousel : Carousel {
     public AppCenterCore.Package target { get; construct; }
 
     construct {
-        var author_packages = AppCenterCore.Client.get_default ().get_packages_by_author (target.author, AUTHOR_OTHER_APPS_MAX);
-        foreach (var author_package in author_packages) {
-            if (author_package.component.get_id () == target.component.get_id ()) {
-                continue;
-            }
-
-            add_package (author_package);
-        }
+        set_package_list((new AppCenterCore.PackageList()).set_from_iterator(
+            AppCenterCore.Client.get_default()
+                .get_packages_by_author(target.author, AUTHOR_OTHER_APPS_MAX)
+                .filter((package) => package.component.get_id() != target.component.get_id())
+        ));
     }
 
     public AuthorCarousel (AppCenterCore.Package target) {

--- a/src/Widgets/Carousel/Carousel.vala
+++ b/src/Widgets/Carousel/Carousel.vala
@@ -20,6 +20,8 @@
 public class AppCenter.Widgets.Carousel : Gtk.FlowBox {
     public signal void package_activated (AppCenterCore.Package package);
 
+    protected AppCenterCore.PackageList _package_list;
+
     public Carousel () {
         Object (activate_on_single_click : true,
                 homogeneous: true);
@@ -35,12 +37,30 @@ public class AppCenter.Widgets.Carousel : Gtk.FlowBox {
         child_activated.connect (on_child_activated);
     }
 
-    public void add_package (AppCenterCore.Package? package) {
-        var carousel_item = new CarouselItem (package);
-        add (carousel_item);
+    public void set_package_list(AppCenterCore.PackageList package_list) {
+        if (_package_list != null) {
+            _package_list.updated.disconnect(on_package_list_updated);
+        }
+        _package_list = package_list;
+        _package_list.updated.connect(on_package_list_updated);
+        on_package_list_updated();
+    }
+
+    protected void on_package_list_updated() {
+        rebuild_children();
+    }
+
+    protected void rebuild_children() {
+        @foreach ((widget) => {
+            if (widget is CarouselItem) remove (widget);
+        });
+
+        foreach (var package in _package_list.get_packages()) {
+            add (new CarouselItem(package));
+        }
         show_all ();
     }
-    
+
     private void on_child_activated (Gtk.FlowBoxChild child) {
         if (child is Widgets.CarouselItem) {
             var package = ((Widgets.CarouselItem)child).package;

--- a/src/Widgets/SharePopover.vala
+++ b/src/Widgets/SharePopover.vala
@@ -35,30 +35,6 @@ public class SharePopover : Gtk.Popover {
         email_button.tooltip_text = _("Email");
         email_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var facebook_button = new Gtk.Button.from_icon_name ("online-account-facebook", Gtk.IconSize.DND);
-        facebook_button.tooltip_text = _("Facebook");
-        facebook_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        var google_button = new Gtk.Button.from_icon_name ("online-account-google-plus", Gtk.IconSize.DND);
-        google_button.tooltip_text = _("Google+");
-        google_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        var twitter_button = new Gtk.Button.from_icon_name ("online-account-twitter", Gtk.IconSize.DND);
-        twitter_button.tooltip_text = _("Twitter");
-        twitter_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        var reddit_button = new Gtk.Button.from_icon_name ("online-account-reddit", Gtk.IconSize.DND);
-        reddit_button.tooltip_text = _("reddit");
-        reddit_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        var tumblr_button = new Gtk.Button.from_icon_name ("online-account-tumblr", Gtk.IconSize.DND);
-        tumblr_button.tooltip_text = _("Tumblr");
-        tumblr_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        var telegram_button = new Gtk.Button.from_icon_name ("online-account-telegram", Gtk.IconSize.DND);
-        telegram_button.tooltip_text = _("Telegram");
-        telegram_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
         var copy_link_button = new Gtk.Button.from_icon_name ("edit-copy-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         copy_link_button.tooltip_text = _("Copy link");
         copy_link_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
@@ -69,14 +45,13 @@ public class SharePopover : Gtk.Popover {
 
         var service_grid = new Gtk.Grid ();
         service_grid.margin = 6;
-        service_grid.add (email_button);
-        service_grid.add (facebook_button);
-        service_grid.add (google_button);
-        service_grid.add (twitter_button);
-        service_grid.add (reddit_button);
-        service_grid.add (tumblr_button);
-        service_grid.add (telegram_button);
 
+        service_grid.add (make_share_button(_("Facebook"), "https://www.facebook.com/sharer/sharer.php?u=%s", "online-account-facebook"));
+        service_grid.add (make_share_button(_("Twitter"), "http://twitter.com/home/?status=%s %s", "online-account-twitter"));
+        service_grid.add (make_share_button(_("reddit"), "http://www.reddit.com/submit?title=%s&url=%s", "online-account-reddit"));
+        service_grid.add (make_share_button(_("Tumblr"), "https://www.tumblr.com/share/link?url=%s", "online-account-tumblr"));
+        service_grid.add (make_share_button(_("Telegram"), "https://t.me/share/url?url=%s", "online-account-telegram"));
+        
         var system_grid = new Gtk.Grid ();
         system_grid.margin = 6;
         system_grid.add (copy_link_button);
@@ -107,59 +82,24 @@ public class SharePopover : Gtk.Popover {
             }
             hide ();
         });
+    }
 
-        facebook_button.clicked.connect (() => {
+    Gtk.Widget make_share_button(string name, string uri_template, string icon_name) {
+        var button = new Gtk.Button.from_icon_name (icon_name, Gtk.IconSize.DND);
+        button.tooltip_text = name;
+        button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button.clicked.connect (() => {
             try {
-                AppInfo.launch_default_for_uri ("https://www.facebook.com/sharer/sharer.php?u=%s".printf (uri), null);
+                if (uri_template.index_of("%s") == uri_template.last_index_of("%s")) {
+                    AppInfo.launch_default_for_uri(uri_template.printf(uri), null);
+                } else {
+                    AppInfo.launch_default_for_uri(uri_template.printf(body, uri), null);
+                }
             } catch (Error e) {
                 warning ("%s", e.message);
             }
-            hide ();
+            hide();
         });
-
-        google_button.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("https://plus.google.com/share?url=%s".printf (uri), null);
-            } catch (Error e) {
-                warning ("%s", e.message);
-            }
-            hide ();
-        });
-
-        twitter_button.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("http://twitter.com/home/?status=%s %s".printf (body, uri), null);
-            } catch (Error e) {
-                warning ("%s", e.message);
-            }
-            hide ();
-        });
-
-        reddit_button.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("http://www.reddit.com/submit?title=%s&url=%s".printf (body, uri), null);
-            } catch (Error e) {
-                warning ("%s", e.message);
-            }
-            hide ();
-        });
-
-        tumblr_button.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("https://www.tumblr.com/share/link?url=%s".printf (uri), null);
-            } catch (Error e) {
-                warning ("%s", e.message);
-            }
-            hide ();
-        });
-
-        telegram_button.clicked.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("https://t.me/share/url?url=%s".printf (uri), null);
-            } catch (Error e) {
-                warning ("%s", e.message);
-            }
-            hide ();
-        });
+        return button;
     }
 }


### PR DESCRIPTION
The main change is the introduction of the AppCenterCore.PackageList class to be used whenever a widget needs a list of packages. Unlike a plain collection of Package objects this allows the originator of the list to retain a reference to it to further update the list, as needed for #210. Once I figure a way to make this a bit less bulky, I plan to refactor all package list widgets the same way.

Other changes:
- Simplified Homepage view by moving promoted apps retrieval out to Houston, where it belongs;
- Simplified SharePopover widget by moving repetitive parts out to a method