### PR TITLE
Banner CSS Fixes

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -21,8 +21,9 @@
                               shade (@banner_bg_color, 1.05),
                               shade (@banner_bg_color, 0.95)
                               );
-    color: @banner_fg_color;    
-    transition: all %ums ease-in-out;
+    color: @banner_fg_color;
+    icon-shadow: none;
+    text-shadow: none;
 }
 
 .banner.home {

--- a/src/Widgets/Banner.vala
+++ b/src/Widgets/Banner.vala
@@ -21,6 +21,10 @@
 const string BANNER_STYLE_CSS = """
     @define-color banner_bg_color %s;
     @define-color banner_fg_color %s;
+
+    .banner { 
+        transition: all %ums ease-in-out;
+    }
 """;
 
 const string DEFAULT_BANNER_COLOR_PRIMARY = "#68758e";


### PR DESCRIPTION
Fixes a regression in #519 regarding transition duration

Make sure we don't inherit icon-shadow or text-shadow from somewhere else (fixes an issue in gtk 3.22)