### PR TITLE
Style cache update fail dialog details as Terminal

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -297,3 +297,14 @@
 .switcher:checked {
     opacity: 1;
 }
+
+.terminal {
+    background-color: #252e32;
+    padding: 12px;
+    color: #94a3a5;
+}
+
+.terminal selection {
+    background-color: #93a1a1;
+    color: #252e32; 
+}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -275,9 +275,14 @@ public class AppCenter.App : Granite.Application {
         string message = format_error_message (error.message);
 
         var details_label = new Gtk.Label (message);
+        details_label.margin_top = 12;
+        details_label.max_width_chars = 40;
         details_label.selectable = true;
         details_label.wrap = true;
-        details_label.max_width_chars = 40;
+
+        var details_label_context = details_label.get_style_context ();
+        details_label_context.add_class (Gtk.STYLE_CLASS_MONOSPACE);
+        details_label_context.add_class ("terminal");
 
         var expander = new Gtk.Expander (_("Details"));
         expander.add (details_label);
@@ -287,6 +292,7 @@ public class AppCenter.App : Granite.Application {
             _("This may have been caused by external, manually added software repositories or a corrupted sources file."),
             "dialog-error"
         );
+        dialog.transient_for = main_window;
         dialog.custom_bin.add (expander);
         dialog.add_button (_("Try Again"), TRY_AGAIN_RESPONSE_ID);
         dialog.show_all ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -290,10 +290,12 @@ public class AppCenter.App : Granite.Application {
         var dialog = new Granite.MessageDialog.with_image_from_icon_name (
             _("Failed to Fetch Updates"),
             _("This may have been caused by external, manually added software repositories or a corrupted sources file."),
-            "dialog-error"
+            "dialog-error",
+            Gtk.ButtonsType.NONE
         );
         dialog.transient_for = main_window;
         dialog.custom_bin.add (expander);
+        dialog.add_button (_("Ignore"), Gtk.ResponseType.CLOSE);
         dialog.add_button (_("Try Again"), TRY_AGAIN_RESPONSE_ID);
         dialog.show_all ();
         


### PR DESCRIPTION
Also solves a warning by setting `transient_for` and changes "Close" to "Ignore" while we're here

![screenshot from 2017-11-07 16 25 53](https://user-images.githubusercontent.com/7277719/32525261-72c9b0a6-c3d8-11e7-866e-ba4e6148f64e.png)

