### PR TITLE
Remove app_icon

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -51,7 +51,6 @@ public class AppCenter.App : Granite.Application {
         Intl.textdomain (Build.GETTEXT_PACKAGE);
 
         program_name = _(Build.APP_NAME);
-        app_icon = Build.DESKTOP_ICON;
 
         build_data_dir = Build.DATADIR;
         build_pkg_data_dir = Build.PKGDATADIR;


### PR DESCRIPTION
Removes app_icon that was previously used for the about dialog and is now deprecated in Granite.