### PR TITLE
Pack action_stack after release stack

### DIFF
--- a/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
@@ -65,6 +65,6 @@ public abstract class AppCenter.Widgets.AbstractPackageRowGrid : AbstractAppCont
         action_stack.valign = Gtk.Align.START;
 
         attach (info_grid, 0, 0, 1, 1);
-        attach (action_stack, 2, 0, 1, 1);
+        attach (action_stack, 3, 0, 1, 1);
     }
 }


### PR DESCRIPTION
Fixes #535 

I can't test this right now because I don't have any updates with a changelog but it appears that currently both the action_stack and the releases stack are being attached to the grid at `2, 0`. This should theoretically resolve the issue.

Please test thoroughly on a system that is experiencing the problem. Also check that this doesn't break other views since this is an abstract widget that is presumably used in other places.