### PR TITLE
Mouse back button

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -79,7 +79,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         button_release_event.connect ((event) => {
             // On back mouse button pressed
             if (event.button == 8) {
-                return_button.clicked ();
+                view_return ();
                 return true;
             }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -80,6 +80,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             // On back mouse button pressed
             if (event.button == 8) {
                 return_button.clicked ();
+                return true;
             }
 
             return false;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -74,7 +74,16 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         var go_back = new SimpleAction ("go-back", null);
         go_back.activate.connect (view_return);
         add_action (go_back);
-        app.set_accels_for_action ("win.go-back", {"<Alt>Left"});
+        app.set_accels_for_action ("win.go-back", {"<Alt>Left", "Back"});
+
+        button_release_event.connect ((event) => {
+            // On back mouse button pressed
+            if (event.button == 8) {
+                return_button.clicked ();
+            }
+
+            return false;
+        });
 
         search_entry.search_changed.connect (() => trigger_search ());
 


### PR DESCRIPTION
This PR implements support for back buttons on the mouse. Thus, when you press the back button on the mouse (on mice that have this), it will go to the previous view. It also adds an accelerator for GDK_KEY_Back to the same button, for support of keyboard-based back buttons.

Fixes #23 
Fixes pop-os/shop#19