### PR TITLE
Track paid-for applications in GSettings

### DIFF
--- a/schemas/io.elementary.appcenter.gschema.xml
+++ b/schemas/io.elementary.appcenter.gschema.xml
@@ -25,5 +25,15 @@
       <summary>The user is a developer</summary>
       <description>Mode that allows the user to see more packages with development purposes</description>
     </key>
+    <key type="b" name="reset-paid-apps">
+      <default>true</default>
+      <summary>Reset/rescan the paid apps list</summary>
+      <description>Whether to clear the paid applications list and regenerate</description>
+    </key>
+    <key type="as" name="paid-apps">
+      <default>[]</default>
+      <summary>List of paid-for applications</summary>
+      <description>A list of appstream IDs which have been paid for</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -31,12 +31,22 @@ public class AppCenter.Settings : Granite.Services.Settings {
     public int window_height { get; set; }
     public WindowState window_state { get; set; }
     public bool developer_mode { get; set; }
+    public bool reset_paid_apps { get; set; }
+    public string[] paid_apps { get; set; }
 
     private static Settings main_settings;
     public static unowned Settings get_default () {
         if (main_settings == null)
             main_settings = new Settings ();
         return main_settings;
+    }
+
+    public void add_paid_app (string id) {
+        if (!(id in paid_apps)) {
+            var apps_copy = paid_apps;
+            apps_copy += id;
+            paid_apps = apps_copy;
+        }
     }
 
     private Settings ()  {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -60,6 +60,19 @@ public class AppCenter.Views.InstalledView : View {
         app_list_view.add_packages (installed_apps);
 
         client.get_drivers ();
+
+        var settings = Settings.get_default ();
+
+        if (settings.reset_paid_apps) {
+            settings.paid_apps = new string[] {};
+            foreach (var app in installed_apps) {
+                if (app.component.get_origin () == AppCenterCore.Package.APPCENTER_PACKAGE_ORIGIN) {
+                    settings.add_paid_app (app.component.get_id ());
+                }
+            }
+
+            settings.reset_paid_apps = false;
+        }
     }
 
     public async void add_app (AppCenterCore.Package package) {

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -48,6 +48,8 @@ namespace AppCenter {
         protected Gtk.SizeGroup action_button_group;
         protected Gtk.Stack action_stack;
 
+        private Settings settings;
+
         public bool is_os_updates {
             get {
                 return package.is_os_updates;
@@ -99,6 +101,8 @@ namespace AppCenter {
         construct {
             image = new Gtk.Image ();
 
+            settings = Settings.get_default ();
+
             package_author = new Gtk.Label ("");
             package_name = new Gtk.Label ("");
             image = new Gtk.Image ();
@@ -109,7 +113,12 @@ namespace AppCenter {
             action_button.payment_requested.connect ((amount) => {
                 var stripe = new Widgets.StripeDialog (amount, this.package_name.label, this.package.component.get_desktop_id ().replace (".desktop", ""), this.package.get_payments_key());
 
-                stripe.download_requested.connect (() => action_clicked.begin ());
+                stripe.download_requested.connect (() => {
+                    action_clicked.begin ();
+
+                    settings.add_paid_app (package.component.get_id ());
+                });
+
                 stripe.show ();
             });
 


### PR DESCRIPTION
This is the first step on the road to #502 

I decided to track applications that had been paid for rather than ones that hadn't for a number of reasons:
* Tracking not paid is more complicated since you can "not pay" for an application a number of times by updating it. So that would need more tracking to make sure it didn't get re-added to the not paid list. Once it's been paid for once, we can consider it no longer naggable, which is easier.
* It will be marginally harder for people to manually fiddle with GSettings and make it stop asking since they'll have to put a desktop ID in rather than take one out.
* Adding stuff to arrays is easier than taking stuff out? Maybe that's an excuse... :woman_shrugging: 

Also, I've stuck some code in there that initially populates the list with all the stuff you've already downloaded from the appcenter repo. We don't have any data on whether they were paid or not, so I thought best to add everything the user currently has to the list so they don't get nagged about everything they may or may not have already paid for. But let me know if that's the wrong assumption.

Only future $0 downloads will not get added to the list and hence nagged about when I write the update nagging code. That auto-populate code can come out again once enough people have had their lists populated.