### PR TITLE
Add logic to update badge

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -27,6 +27,8 @@ public class AppCenter.App : Granite.Application {
         { null }
     };
 
+    public uint updates_number = 0U;
+
     private const int SECONDS_AFTER_NETWORK_UP = 60;
     private const int TRY_AGAIN_RESPONSE_ID = 1;
 
@@ -40,7 +42,7 @@ public class AppCenter.App : Granite.Application {
 
     [CCode (array_length = false, array_null_terminated = true)]
     public static string[]? fake_update_packages = null;
-    private MainWindow? main_window;
+    public MainWindow? main_window;
 
     private uint registration_id = 0;
 
@@ -61,6 +63,8 @@ public class AppCenter.App : Granite.Application {
         app_launcher = Build.DESKTOP_FILE;
         add_main_option_entries (APPCENTER_OPTIONS);
 
+        updates_number = 0U;
+
         var quit_action = new SimpleAction ("quit", null);
         quit_action.activate.connect (() => {
             if (main_window != null) {
@@ -78,6 +82,7 @@ public class AppCenter.App : Granite.Application {
         var client = AppCenterCore.Client.get_default ();
         client.operation_finished.connect (on_operation_finished);
         client.cache_update_failed.connect (on_cache_update_failed);
+        client.updates_available.connect (on_updates_available);
 
         if (AppInfo.get_default_for_uri_scheme ("appstream") == null) {
             var appinfo = new DesktopAppInfo (app_launcher);
@@ -266,6 +271,13 @@ public class AppCenter.App : Granite.Application {
         }
     }
     
+    public void on_updates_available () {
+        var client = AppCenterCore.Client.get_default ();
+        updates_number = client.get_updates_number ();
+        main_window.show_update_badge(updates_number);
+    }
+
+
     private void on_cache_update_failed (Error error) {
         if (main_window == null) {
             return;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -274,7 +274,7 @@ public class AppCenter.App : Granite.Application {
     public void on_updates_available () {
         var client = AppCenterCore.Client.get_default ();
         updates_number = client.get_updates_number ();
-        main_window.show_update_badge(updates_number);
+        main_window.show_update_badge (updates_number);
     }
 
 

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -124,6 +124,10 @@ public class AppCenterCore.Client : Object {
         }
     }
 
+    public uint get_updates_number () {
+        return updates_number;
+    }
+
     public bool has_tasks () {
         return task_count > 0;
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -40,6 +40,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     private Gee.LinkedList<string> return_button_history;
     private Granite.Widgets.AlertView network_alert_view;
     private Gtk.Grid network_view;
+    private Gtk.Label updates_badge;
 
     private int homepage_view_id;
     private int installed_view_id;
@@ -143,10 +144,11 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         homepage_view_id = view_mode.append_text (_("Home"));
         installed_view_id = view_mode.append_text (C_("view", "Updates"));
 
-        var updates_badge = new Gtk.Label ("5");
+        updates_badge = new Gtk.Label ("5");
         updates_badge.halign = Gtk.Align.END;
         updates_badge.valign = Gtk.Align.START;
         updates_badge.get_style_context ().add_class ("badge");
+        set_widget_visibility(updates_badge, false);
 
         var view_mode_overlay = new Gtk.Overlay ();
         view_mode_overlay.add (view_mode);
@@ -236,6 +238,15 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         }
 
         return false;
+    }
+
+    public void show_update_badge(uint updates_number){
+        if (updates_number == 0U) {
+            set_widget_visibility(updates_badge, false);
+        } else {
+            updates_badge.label = updates_number.to_string ();
+            set_widget_visibility(updates_badge, true);
+        }
     }
 
     public void show_package (AppCenterCore.Package package) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -148,7 +148,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         updates_badge.halign = Gtk.Align.END;
         updates_badge.valign = Gtk.Align.START;
         updates_badge.get_style_context ().add_class ("badge");
-        set_widget_visibility(updates_badge, false);
+        set_widget_visibility (updates_badge, false);
 
         var view_mode_overlay = new Gtk.Overlay ();
         view_mode_overlay.add (view_mode);
@@ -240,12 +240,12 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         return false;
     }
 
-    public void show_update_badge(uint updates_number){
+    public void show_update_badge (uint updates_number) {
         if (updates_number == 0U) {
-            set_widget_visibility(updates_badge, false);
+            set_widget_visibility (updates_badge, false);
         } else {
             updates_badge.label = updates_number.to_string ();
-            set_widget_visibility(updates_badge, true);
+            set_widget_visibility (updates_badge, true);
         }
     }
 


### PR DESCRIPTION
This hooks up @danrabbit 's update badge to the logic behind the client, which allows it to be shown and hidden based on whether updates are available or not. It also updates the label text with the correct number of updates available.

This is the fixed PR.