### PR TITLE
Core/Client.vala: adapt to vala 0.40 / PackageKit changes (Fixes #619)

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -223,7 +223,11 @@ public class AppCenterCore.Client : Object {
         }
 
         if (exit_status != Pk.Exit.SUCCESS) {
+#if VALA_0_40
             throw new GLib.IOError.FAILED (exit_status.enum_to_string());
+#else
+            Pk.Exit.enum_to_string (exit_status);
+#endif
         } else {
             package.change_information.clear_update_info ();
         }

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -223,7 +223,7 @@ public class AppCenterCore.Client : Object {
         }
 
         if (exit_status != Pk.Exit.SUCCESS) {
-            throw new GLib.IOError.FAILED (Pk.Exit.enum_to_string (exit_status));
+            throw new GLib.IOError.FAILED (exit_status.enum_to_string());
         } else {
             package.change_information.clear_update_info ();
         }

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -226,7 +226,7 @@ public class AppCenterCore.Client : Object {
 #if VALA_0_40
             throw new GLib.IOError.FAILED (exit_status.enum_to_string());
 #else
-            Pk.Exit.enum_to_string (exit_status);
+            throw new GLib.IOError.FAILED (Pk.Exit.enum_to_string (exit_status));
 #endif
         } else {
             package.change_information.clear_update_info ();


### PR DESCRIPTION
This fixes compilation against a PackageKit that was built with the latest vala (0.40 branch).

WARNING: This breaks compilation with older versions of vala (and PackageKit that hasn't been rebuilt with the new vala), so you will only want to merge this after those updated packages are available for you.