### PR TITLE
Drop the "The" from fallback author name

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -189,7 +189,7 @@ public class AppCenterCore.Package : Object {
 
             _author_title = author;
             if (_author_title == null) {
-                _author_title = _("The %s Developers").printf (get_name ());
+                _author_title = _("%s Developers").printf (get_name ());
             }
 
             return _author_title;


### PR DESCRIPTION
Simple change, but it shortens up the fallback without removing clarity.