### PR TITLE
Search by mimetype

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -98,6 +98,11 @@ public class AppCenter.App : Gtk.Application {
             return;
         }
 
+        if (file.has_uri_scheme ("type")) {
+            string? mimetype = mimetype_from_file (file);
+            main_window.search (mimetype);
+        }
+
         if (!file.has_uri_scheme ("appstream")) {
             return;
         }
@@ -306,6 +311,16 @@ public class AppCenter.App : Gtk.Application {
         }
 
         return msg;
+    }
+
+    private static string? mimetype_from_file (File file) {
+        string uri = file.get_uri ();
+        string[] tokens = uri.split (Path.DIR_SEPARATOR_S);
+        if (tokens.length < 2) {
+            return null;
+        }
+
+        return "%s/%s".printf (tokens[tokens.length - 2], tokens[tokens.length - 1]);
     }
 }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -100,7 +100,12 @@ public class AppCenter.App : Gtk.Application {
 
         if (file.has_uri_scheme ("type")) {
             string? mimetype = mimetype_from_file (file);
-            main_window.search (mimetype);
+            if (mimetype != null) {
+                main_window.search (mimetype);
+            } else {
+                info (_("Could not parse mimetype %s").printf (mimetype));
+            }
+            
             return;
         }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -101,7 +101,7 @@ public class AppCenter.App : Gtk.Application {
         if (file.has_uri_scheme ("type")) {
             string? mimetype = mimetype_from_file (file);
             if (mimetype != null) {
-                main_window.search (mimetype);
+                main_window.search (mimetype, true);
             } else {
                 info (_("Could not parse mimetype %s").printf (mimetype));
             }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -101,6 +101,7 @@ public class AppCenter.App : Gtk.Application {
         if (file.has_uri_scheme ("type")) {
             string? mimetype = mimetype_from_file (file);
             main_window.search (mimetype);
+            return;
         }
 
         if (!file.has_uri_scheme ("appstream")) {

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -223,11 +223,11 @@ public class AppCenterCore.Client : Object {
         }
 
         if (exit_status != Pk.Exit.SUCCESS) {
-#if VALA_0_40
-            throw new GLib.IOError.FAILED (exit_status.enum_to_string());
-#else
-            throw new GLib.IOError.FAILED (Pk.Exit.enum_to_string (exit_status));
-#endif
+//  #if VALA_0_40
+//              throw new GLib.IOError.FAILED (exit_status.enum_to_string());
+//  #else
+//              throw new GLib.IOError.FAILED (Pk.Exit.enum_to_string (exit_status));
+//  #endif
         } else {
             package.change_information.clear_update_info ();
         }

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -404,11 +404,10 @@ public class AppCenterCore.Client : Object {
             });
         }
 
-        apps.add_all (search_applications_mime (query));
         return apps;
     }
 
-    private Gee.Collection<AppCenterCore.Package> search_applications_mime (string query) {
+    public Gee.Collection<AppCenterCore.Package> search_applications_mime (string query) {
         var apps = new Gee.TreeSet<AppCenterCore.Package> ();
         foreach (var package in package_list.values) {
             weak AppStream.Provided? provided = package.component.get_provided_for_kind (AppStream.ProvidedKind.MIMETYPE);

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -223,11 +223,11 @@ public class AppCenterCore.Client : Object {
         }
 
         if (exit_status != Pk.Exit.SUCCESS) {
-//  #if VALA_0_40
-//              throw new GLib.IOError.FAILED (exit_status.enum_to_string());
-//  #else
-//              throw new GLib.IOError.FAILED (Pk.Exit.enum_to_string (exit_status));
-//  #endif
+#if VALA_0_40
+            throw new GLib.IOError.FAILED (exit_status.enum_to_string());
+#else
+            throw new GLib.IOError.FAILED (Pk.Exit.enum_to_string (exit_status));
+#endif
         } else {
             package.change_information.clear_update_info ();
         }
@@ -405,7 +405,6 @@ public class AppCenterCore.Client : Object {
         }
 
         apps.add_all (search_applications_mime (query));
-
         return apps;
     }
 

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -404,6 +404,20 @@ public class AppCenterCore.Client : Object {
             });
         }
 
+        apps.add_all (search_applications_mime (query));
+
+        return apps;
+    }
+
+    private Gee.Collection<AppCenterCore.Package> search_applications_mime (string query) {
+        var apps = new Gee.TreeSet<AppCenterCore.Package> ();
+        foreach (var package in package_list.values) {
+            weak AppStream.Provided? provided = package.component.get_provided_for_kind (AppStream.ProvidedKind.MIMETYPE);
+            if (provided != null && provided.has_item (query)) {
+                apps.add (package);
+            }
+        }
+
         return apps;
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -45,6 +45,8 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     private int homepage_view_id;
     private int installed_view_id;
 
+    private bool mimetype;
+
     private const int VALID_QUERY_LENGTH = 3;
 
     public static Views.InstalledView installed_view { get; private set; }
@@ -269,7 +271,8 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         view_mode.selected = installed_view_id;
     }
 
-    public void search (string term) {
+    public void search (string term, bool mimetype = false) {
+        this.mimetype = mimetype;
         search_entry.text = term;
     }
 
@@ -281,7 +284,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         view_mode_revealer.reveal_child = !query_valid;
 
         if (query_valid) {
-            search_view.search (query, homepage.currently_viewed_category);
+            search_view.search (query, homepage.currently_viewed_category, mimetype);
             stack.visible_child = search_view;
         } else {
             if (stack.visible_child == search_view && homepage.currently_viewed_category != null) {
@@ -291,6 +294,10 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
             search_view.reset ();
             stack.visible_child = homepage;
+        }
+        
+        if (mimetype) {
+            mimetype = false;
         }
     }
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -62,15 +62,21 @@ public class AppCenter.Views.SearchView : View {
         }
     }
 
-    public void search (string search_term, AppStream.Category? category) {
+    public void search (string search_term, AppStream.Category? category, bool mimetype = false) {
         current_search_term = search_term;
         current_category = category;
 
         app_list_view.clear ();
         unowned Client client = Client.get_default ();
-        var found_apps = client.search_applications (current_search_term, current_category);
-        app_list_view.add_packages (found_apps);
 
+        if (mimetype) {
+            var found_apps = client.search_applications_mime (current_search_term);
+            app_list_view.add_packages (found_apps);
+        } else {
+            var found_apps = client.search_applications (current_search_term, current_category);
+            app_list_view.add_packages (found_apps);
+        }
+        
         if (current_category != null) {
             subview_entered (_("Search Apps"), true, current_category.name);
         } else {

--- a/src/Widgets/SharePopover.vala
+++ b/src/Widgets/SharePopover.vala
@@ -48,7 +48,7 @@ public class SharePopover : Gtk.Popover {
         twitter_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var reddit_button = new Gtk.Button.from_icon_name ("online-account-reddit", Gtk.IconSize.DND);
-        reddit_button.tooltip_text = _("reddit");
+        reddit_button.tooltip_text = _("Reddit");
         reddit_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var tumblr_button = new Gtk.Button.from_icon_name ("online-account-tumblr", Gtk.IconSize.DND);


### PR DESCRIPTION
Needed for https://github.com/elementary/files/issues/446.

When searching also searches for mimetypes so that e.g Files can invoke AppCenter to search by mimetype.

I've made up a little "type" URI scheme to distinguish the type and appstream URI's, example:
`io.elementary.appcenter type://application/pdf`