### PR TITLE
Shuffle trending and recently updated

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -1,0 +1,31 @@
+/* Copyright 2018 elementary, Inc. (https://elementary.io)
+*
+* This program is free software: you can redistribute it
+* and/or modify it under the terms of the GNU General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be
+* useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+* Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see http://www.gnu.org/licenses/.
+*/
+
+namespace Utils {
+    public void shuffle_array<T> (T[] array) {
+        var rand = new GLib.Rand ();
+        for (int i = 0; i < array.length * 3; i++) {
+            swap (&array[0], &array[rand.int_range(1, array.length)]);
+        }
+    }
+
+    public void swap<T> (T *x, T *y) {
+        var tmp = *x;
+        *x = *y;
+        *y = tmp;
+    }
+}
+

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -16,6 +16,7 @@
 
 namespace Utils {
     public void shuffle_array<T> (T[] array) {
+        // https://gitlab.gnome.org/GNOME/vala/issues/7
         var rand = new GLib.Rand ();
         for (int i = 0; i < array.length * 3; i++) {
             swap (&array[0], &array[rand.int_range(1, array.length)]);

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -159,6 +159,7 @@ namespace AppCenter {
 
             houston.get_app_ids.begin ("/newest/release", (obj, res) => {
                 var updated_ids = houston.get_app_ids.end (res);
+                Utils.shuffle_array (updated_ids);
                 new Thread<void*> ("update-recent-carousel", () => {
                     var packages_for_carousel = new Gee.LinkedList<AppCenterCore.Package> ();
                     foreach (var package in updated_ids) {
@@ -192,6 +193,7 @@ namespace AppCenter {
 
             houston.get_app_ids.begin ("/newest/downloads", (obj, res) => {
                 var trending_ids = houston.get_app_ids.end (res);
+                Utils.shuffle_array (trending_ids);
                 new Thread<void*> ("update-trending-carousel", () => {
                     var packages_for_carousel = new Gee.LinkedList<AppCenterCore.Package> ();
                     foreach (var package in trending_ids) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ appcenter_files = files(
     'MainWindow.vala',
     'Settings.vala',
     'SuspendControl.vala',
+    'Utils.vala',
     'Core/ChangeInformation.vala',
     'Core/Client.vala',
     'Core/ComponentValidator.vala',


### PR DESCRIPTION
Inspired by changes in Pop!_Shop. Fixes #750. Explicitly doesn't shuffle the homepage banner, as I like the newest apps getting their big debut moment.

- [x] Add a shuffle Util
- [x] Add Utils to meson
- [x] Shuffle on initial load