### PR TITLE
Add several "additional categories" to Science

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2014-2017 elementary LLC. (https://elementary.io)
+  * Copyright (c) 2014-2018 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,7 +36,7 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));
         add (get_category (_("Internet"), "applications-internet", {"Network"}, "internet"));
-        add (get_category (_("Science & Engineering"), "", {"Science"}, "science"));
+        add (get_category (_("Math, Science, & Engineering"), "", {"Science", "Chemistry", "Astronomy", "Electricity", "Math", "Biology", "DataVisualization", "Calculator", "ComputerScience", "Engineering", "Physics", "NumericalAnalysis", "Geology", "Geoscience", "Electronics", "ArtificialIntelligence", "Robotics"}, "science"));
         add (get_category (_("Universal Access"), "applications-accessibility-symbolic", {"Accessibility"}, "accessibility"));
     }
 
@@ -55,3 +55,4 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         return item;
     }
 }
+

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -36,7 +36,7 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));
         add (get_category (_("Internet"), "applications-internet", {"Network"}, "internet"));
-        add (get_category (_("Math, Science, & Engineering"), "", {
+        add (get_category (_("Science & Engineering"), "", {
             "ArtificialIntelligence",
             "Astronomy",
             "Biology",

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -36,7 +36,25 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));
         add (get_category (_("Internet"), "applications-internet", {"Network"}, "internet"));
-        add (get_category (_("Math, Science, & Engineering"), "", {"Science", "Chemistry", "Astronomy", "Electricity", "Math", "Biology", "DataVisualization", "Calculator", "ComputerScience", "Engineering", "Physics", "NumericalAnalysis", "Geology", "Geoscience", "Electronics", "ArtificialIntelligence", "Robotics"}, "science"));
+        add (get_category (_("Math, Science, & Engineering"), "", {
+            "ArtificialIntelligence",
+            "Astronomy",
+            "Biology",
+            "Calculator",
+            "Chemistry",
+            "ComputerScience",
+            "DataVisualization",
+            "Electricity",
+            "Electronics",
+            "Engineering",
+            "Geology",
+            "Geoscience",
+            "Math",
+            "NumericalAnalysis",
+            "Physics",
+            "Robotics",
+            "Science"
+        }, "science"));
         add (get_category (_("Universal Access"), "applications-accessibility-symbolic", {"Accessibility"}, "accessibility"));
     }
 


### PR DESCRIPTION
This is something I was working on for Pop!_Shop, but could also benefit us in AppCenter. Split from #577.

- Update copyright while we're here
- Add the following categories to this category:
  - ArtificialIntelligence
  - Astronomy
  - Biology
  - Calculator
  - Chemistry
  - ComputerScience
  - DataVisualization
  - Electricity
  - Electronics
  - Engineering
  - Geology
  - Geoscience
  - Math
  - NumericalAnalysis
  - Physics
  - Robotics
- ~~Add "Math" to the category title to make it more precise~~ _Omitted due to string freeze #753_

These are added since [FreeDestkop.org Additional Categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html) don't require a relevant primary category. This gives us a bigger pool of software to browse without reverting to search.

This also helps us get away from "Accessories" eventually by getting calculators somewhere else. :wink: 