### PR TITLE
Add additional categories to Graphics

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -32,7 +32,15 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Office"), "applications-office-symbolic", {"Office", "Publishing"}, "office"));
         add (get_category (_("System"), "applications-system", {"System"}, "system"));
         add (get_category (_("Video"), "applications-video-symbolic", {"Video"}, "video"));
-        add (get_category (_("Graphics"), "", {"Graphics"}, "graphics"));
+        add (get_category (_("Graphics"), "", {
+            "2DGraphics",
+            "3DGraphics",
+            "Graphics",
+            "ImageProcessing",
+            "Photography",
+            "RasterGraphics",
+            "VectorGraphics"
+        }, "graphics"));
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));
         add (get_category (_("Internet"), "applications-internet", {"Network"}, "internet"));


### PR DESCRIPTION
Added since [FreeDestkop.org Additional Categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html) don't require a relevant primary category. This gives us a bigger pool of software to browse without reverting to search.