### PR TITLE
Add additional categories to Development

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -27,7 +27,16 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
 
     construct {
         add (get_category (_("Audio"), "applications-audio-symbolic", {"Audio"}, "audio"));
-        add (get_category (_("Development"), "", {"IDE", "Development"}, "development"));
+        add (get_category (_("Development"), "", {
+            "Database",
+            "Debugger",
+            "Development",
+            "GUIDesigner",
+            "IDE",
+            "RevisionControl",
+            "TerminalEmulator",
+            "WebDevelopment"
+        }, "development"));
         add (get_category (_("Accessories"), "applications-accessories", {"Utility"}, "accessories"));
         add (get_category (_("Office"), "applications-office-symbolic", {"Office", "Publishing"}, "office"));
         add (get_category (_("System"), "applications-system", {"System"}, "system"));


### PR DESCRIPTION
Split from #577. Added since [FreeDestkop.org Additional Categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html) don't require a relevant primary category. This gives us a bigger pool of software to browse without reverting to search.