### PR TITLE
Add additional categories to Office

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -29,7 +29,13 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Audio"), "applications-audio-symbolic", {"Audio"}, "audio"));
         add (get_category (_("Development"), "", {"IDE", "Development"}, "development"));
         add (get_category (_("Accessories"), "applications-accessories", {"Utility"}, "accessories"));
-        add (get_category (_("Office"), "applications-office-symbolic", {"Office", "Publishing"}, "office"));
+        add (get_category (_("Office"), "applications-office-symbolic", {
+            "Office",
+            "Presentation",
+            "Publishing",
+            "Spreadsheet",
+            "WordProcessor"
+        }, "office"));
         add (get_category (_("System"), "applications-system", {"System"}, "system"));
         add (get_category (_("Video"), "applications-video-symbolic", {"Video"}, "video"));
         add (get_category (_("Graphics"), "", {"Graphics"}, "graphics"));


### PR DESCRIPTION
Split from #577. Added since [FreeDestkop.org Additional Categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html) don't require a relevant primary category. This gives us a bigger pool of software to browse without reverting to search.