### PR TITLE
Add Monitor to System category

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -30,7 +30,10 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Development"), "", {"IDE", "Development"}, "development"));
         add (get_category (_("Accessories"), "applications-accessories", {"Utility"}, "accessories"));
         add (get_category (_("Office"), "applications-office-symbolic", {"Office", "Publishing"}, "office"));
-        add (get_category (_("System"), "applications-system", {"System"}, "system"));
+        add (get_category (_("System"), "applications-system", {
+            "Monitor",
+            "System"
+        }, "system"));
         add (get_category (_("Video"), "applications-video-symbolic", {"Video"}, "video"));
         add (get_category (_("Graphics"), "", {"Graphics"}, "graphics"));
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -35,7 +35,10 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Graphics"), "", {"Graphics"}, "graphics"));
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));
-        add (get_category (_("Internet"), "applications-internet", {"Network"}, "internet"));
+        add (get_category (_("Internet"), "applications-internet", {
+            "Network",
+            "P2P"
+        }, "internet"));
         add (get_category (_("Science & Engineering"), "", {"Science"}, "science"));
         add (get_category (_("Universal Access"), "applications-accessibility-symbolic", {"Accessibility"}, "accessibility"));
     }

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -38,7 +38,7 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Graphics"), "", {"Graphics"}, "graphics"));
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));
-        add (get_category (_("Internet"), "applications-internet", {"Network", "P2P"}, "internet"));
+        add (get_category (_("Internet"), "applications-internet", {"Network"}, "internet"));
         add (get_category (_("Science & Engineering"), "", {"Science"}, "science"));
         add (get_category (_("Universal Access"), "applications-accessibility-symbolic", {"Accessibility"}, "accessibility"));
     }

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -35,10 +35,7 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Graphics"), "", {"Graphics"}, "graphics"));
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));
-        add (get_category (_("Internet"), "applications-internet", {
-            "Network",
-            "P2P"
-        }, "internet"));
+        add (get_category (_("Internet"), "applications-internet", {"Network", "P2P"}, "internet"));
         add (get_category (_("Science & Engineering"), "", {"Science"}, "science"));
         add (get_category (_("Universal Access"), "applications-accessibility-symbolic", {"Accessibility"}, "accessibility"));
     }


### PR DESCRIPTION
Split from #577. According to FD.o:

>Monitor application/applet that monitors some resource or activity

Added since [FreeDestkop.org Additional Categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html) don't require a relevant primary category. This gives us a bigger pool of software to browse without reverting to search.