### PR TITLE
Add additional categories to Video

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -31,7 +31,11 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         add (get_category (_("Accessories"), "applications-accessories", {"Utility"}, "accessories"));
         add (get_category (_("Office"), "applications-office-symbolic", {"Office", "Publishing"}, "office"));
         add (get_category (_("System"), "applications-system", {"System"}, "system"));
-        add (get_category (_("Video"), "applications-video-symbolic", {"Video"}, "video"));
+        add (get_category (_("Video"), "applications-video-symbolic", {
+            "Tuner",
+            "TV",
+            "Video"
+        }, "video"));
         add (get_category (_("Graphics"), "", {"Graphics"}, "graphics"));
         add (get_category (_("Games"), "applications-games-symbolic", {"Game"}, "games"));
         add (get_category (_("Education"), "", {"Education"}, "education"));


### PR DESCRIPTION
Split from #577. Added since [FreeDestkop.org Additional Categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html) don't require a relevant primary category. This gives us a bigger pool of software to browse without reverting to search.