### PR TITLE
Shadow on home banner

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -68,6 +68,15 @@
         0 3px 5px alpha (shade (@banner_bg_color, 0.5), 0.15);
 }
 
+.banner.home:hover {
+    box-shadow:
+        inset 0 0 0 1px alpha (shade (@banner_bg_color, 1.7), 0.05),
+        inset 0 1px 0 0 alpha (shade (@banner_bg_color, 1.7), 0.45),
+        inset 0 -1px 0 0 alpha (shade (@banner_bg_color, 1.7), 0.15),
+        0 10px 8px -11px alpha (shade (@banner_bg_color, 0.6), 0.8),
+        0 8px 12px alpha (shade (@banner_bg_color, 0.8), 0.6);
+}
+
 .banner button,
 .banner .button {
     background-color: alpha (@banner_fg_color, 0.6);


### PR DESCRIPTION
Simpler, smaller implementation of #692. Just sets a hover shadow on the big banner without affecting margins.