### PR TITLE
Fix HostsManager page crash

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -541,6 +541,12 @@ public class AppCenterCore.Package : Object {
             return list;
         }
 
+        for (uint i = 0; i < releases.length; i++) {
+            if (releases[i].get_version () == null) {
+                releases.remove_index (i);
+            }
+        }
+
         releases.sort_with_data ((a, b) => {
             return b.vercmp (a);
         });


### PR DESCRIPTION
Remove releases with `null` version so that `vercmp` doesn't crash AppCenter.