### PR TITLE
Fix homepage banner

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -132,6 +132,9 @@ namespace AppCenter {
                         }
 
                         var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (package);
+                        if (candidate_package == null) {
+                            candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (package + ".desktop");
+                        }
 
                         if (candidate_package != null) {
                             candidate_package.update_state ();
@@ -166,8 +169,10 @@ namespace AppCenter {
                             break;
                         }
 
-                        var candidate = package + ".desktop";
-                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (candidate);
+                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (package);
+                        if (candidate_package == null) {
+                            candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (package + ".desktop");
+                        }
 
                         if (candidate_package != null) {
                             candidate_package.update_state ();
@@ -200,8 +205,10 @@ namespace AppCenter {
                             break;
                         }
 
-                        var candidate = package + ".desktop";
-                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (candidate);
+                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (package);
+                        if (candidate_package == null) {
+                            candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (package + ".desktop");
+                        }
 
                         if (candidate_package != null) {
                             candidate_package.update_state ();

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -131,8 +131,7 @@ namespace AppCenter {
                             break;
                         }
 
-                        var candidate = package + ".desktop";
-                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (candidate);
+                        var candidate_package = AppCenterCore.Client.get_default ().get_package_for_component_id (package);
 
                         if (candidate_package != null) {
                             candidate_package.update_state ();


### PR DESCRIPTION
Fixes #795. Right now it just stops appending `.desktop` when looking for IDs, which fixes it for new apps but doesn't display any apps with the legacy format (like Clairvoyant and Taxi).