### PR TITLE
Add title to StripeDialog

### DIFF
--- a/src/Dialogs/StripeDialog.vala
+++ b/src/Dialogs/StripeDialog.vala
@@ -66,12 +66,15 @@ public class AppCenter.Widgets.StripeDialog : Gtk.Dialog {
     private bool cvc_valid = false;
 
     public StripeDialog (int _amount, string _app_name, string _app_id, string _stripe_key) {
-        Object (amount: _amount,
-                app_name: _app_name,
-                app_id: _app_id,
-                deletable: false,
-                resizable: false,
-                stripe_key: _stripe_key);
+        Object (
+            amount: _amount,
+            app_name: _app_name,
+            app_id: _app_id,
+            deletable: false,
+            resizable: false,
+            stripe_key: _stripe_key,
+            title: _("Payment")
+        );
     }
 
     construct {


### PR DESCRIPTION
While this is hidden in our stylesheet, it can show up in other stylesheets. The null default is the app ID, which is ugly, and an empty string can look really strange. I figure setting something sane like "Payment" is fine for when it does show up but isn't critical info for us at all since we're hiding it.