### PR TITLE
Fix blacklist path

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -55,8 +55,6 @@ public class AppCenter.App : Gtk.Application {
 
         add_main_option_entries (APPCENTER_OPTIONS);
 
-        print (Build.CONFIGDIR + "\n");
-
         var quit_action = new SimpleAction ("quit", null);
         quit_action.activate.connect (() => {
             if (main_window != null) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -55,6 +55,8 @@ public class AppCenter.App : Gtk.Application {
 
         add_main_option_entries (APPCENTER_OPTIONS);
 
+        print (Build.CONFIGDIR + "\n");
+
         var quit_action = new SimpleAction ("quit", null);
         quit_action.activate.connect (() => {
             if (main_window != null) {

--- a/src/Core/ComponentValidator.vala
+++ b/src/Core/ComponentValidator.vala
@@ -28,7 +28,7 @@ public class AppCenterCore.ComponentValidator : Object {
     construct {
         blacklist = new Gee.HashSet<string> ();
 
-        string blacklist_path = Path.build_filename (Build.CONFIGDIR, Build.BLACKLIST);
+        string blacklist_path = Path.build_filename (Path.DIR_SEPARATOR_S, Build.CONFIGDIR, Build.BLACKLIST);
 
         try {
             string contents;


### PR DESCRIPTION
The CONFIGDIR meson path definition doesn't contain the slash at the beggining hence it currently fails to read the blacklist file. This fixes it.