### PR TITLE
Replace deprecated Component.get_desktop_id

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -735,7 +735,7 @@ public class AppCenterCore.Client : Object {
 
     public AppCenterCore.Package? get_package_for_desktop_id (string desktop_id) {
         foreach (var package in package_list.values) {
-            if (package.component.get_desktop_id () == desktop_id) {
+            if (package.component.id == desktop_id) {
                 return package;
             }
         }

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -597,7 +597,21 @@ public class AppCenterCore.Package : Object {
             return app_info != null;
         }
 
-        string? desktop_id = component.get_desktop_id ();
+        var launchables = component.get_launchable (AppStream.LaunchableKind.DESKTOP_ID).get_entries ();
+        for (int i = 0; i < launchables.length; i++) {
+            app_info = new DesktopAppInfo (launchables[i]);
+            if (app_info != null) {
+                break;
+            }
+        }
+
+        if (app_info != null) {
+            app_info_retrieved = true;
+            return true;
+        }
+
+        // Fallback to trying Appstream ID as desktop ID for applications that haven't updated to the newest spec yet
+        string? desktop_id = component.id;
         if (desktop_id != null) {
             app_info = new DesktopAppInfo (desktop_id);
         }

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -600,6 +600,8 @@ public class AppCenterCore.Package : Object {
         var launchables = component.get_launchable (AppStream.LaunchableKind.DESKTOP_ID).get_entries ();
         for (int i = 0; i < launchables.length; i++) {
             app_info = new DesktopAppInfo (launchables[i]);
+            // A bit strange in Vala, but the DesktopAppInfo constructor does indeed return null if the desktop
+            // file isn't found: https://valadoc.org/gio-unix-2.0/GLib.DesktopAppInfo.DesktopAppInfo.html
             if (app_info != null) {
                 break;
             }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -651,7 +651,7 @@ namespace AppCenter.Views {
                 selection.payment_requested.connect ((amount) => {
                     var stripe = new Widgets.StripeDialog (amount,
                                                            package.get_name (),
-                                                           package.component.get_desktop_id ().replace (".desktop", ""),
+                                                           package.component.id.replace (".desktop", ""),
                                                            package.get_payments_key ()
                                                           );
 

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -193,7 +193,13 @@ namespace AppCenter {
         }
 
         private void show_stripe_dialog (int amount) {
-            var stripe = new Widgets.StripeDialog (amount, this.package_name.label, this.package.component.get_desktop_id ().replace (".desktop", ""), this.package.get_payments_key());
+            var stripe = new Widgets.StripeDialog (
+                amount,
+                package_name.label,
+                package.component.id.replace (".desktop", ""),
+                package.get_payments_key ()
+            );
+
             stripe.transient_for = (Gtk.Window) get_toplevel ();
 
             stripe.download_requested.connect (() => {


### PR DESCRIPTION
Fixes #683 

And clean up a little bit of formatting while we're here.

In some cases we still want the `Component.id` field (i.e. the bit that's in the `<id></id>` tags in the appstream file. We use that for matching appstream components uniquely and sending to Houston, but for code that's involved in the launching of appstream applications, we should check if there are any `<launchable>` entries first and use those to construct the desktop app info.

I've left in a fallback to trying to launch based on the `id` field as I don't think all apps will have the `launchable` for the forseeable future.