### PR TITLE
Rethrow GNOME reboot error

### DIFF
--- a/src/SuspendControl.vala
+++ b/src/SuspendControl.vala
@@ -78,11 +78,12 @@ public class SuspendControl {
         return !inhibited;
     }
 
-    public void reboot () {
+    public void reboot () throws GLib.Error {
         try {
             sm.reboot ();
         } catch (GLib.Error e) {
             critical ("failed to request a reboot from GNOME: %s\n", e.message);
+            throw e;
         }
     }
 


### PR DESCRIPTION
The method call for this `reboot` method is wrapped in a `try/catch` that is supposed to show the built in reboot dialog if it fails. However, since this method couldn't previously throw any exceptions, that never would have worked.