### PR TITLE
Don't give up loading packages when there's an invalid appstream file

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -80,7 +80,9 @@ public class AppCenterCore.Client : Object {
 
         try {
             appstream_pool.load ();
-
+        } catch (Error e) {
+            critical (e.message);
+        } finally {
             var comp_validator = ComponentValidator.get_default ();
             appstream_pool.get_components ().foreach ((comp) => {
                 if (!comp_validator.validate (comp)) {
@@ -92,8 +94,6 @@ public class AppCenterCore.Client : Object {
                     package_list[pkg_name] = package;
                 }
             });
-        } catch (Error e) {
-            critical (e.message);
         }
 
         var icon = new AppStream.Icon ();


### PR DESCRIPTION
I've just been doing some testing of AppCenter on Fedora where I have some better tools to try and find memory leaks and it basically doesn't work at all in the sense that no packages are loaded on my install. It seems Fedora ships some invalid appstream metadata for Google Chrome which is another problem in itself, but because of that, AppCenter refuses to load any metadata for any packages, which seems wrong.

According to [the documentation](https://valadoc.org/appstream/AppStream.Pool.load.html) the `load` method loads as much data as possible. It throws an error about the Google Chrome file (seems a little odd to throw an error instead of just returning false), but the pool is still populated with all the other packages, so we should carry on after than by using `finally`, rather than just giving up.