### PR TITLE
Use palette and symbolic for system

### DIFF
--- a/data/styles/categories.css
+++ b/data/styles/categories.css
@@ -421,21 +421,20 @@
 .category.system {
     background-image:
         linear-gradient(
-            to bottom,
-            #69768f,
-            #59687e
+            170deg,
+            @SLATE_100,
+            @SLATE_300
         );
-    border-color: alpha(#454951, 0.8);
+    border-color: alpha(@SLATE_700, 0.8);
     box-shadow:
         inset 0 0 0 1px alpha(white, 0.05),
         inset 0 1px 0 0 alpha(white, 0.25),
         inset 0 -1px 0 0 alpha(white, 0.1),
         0 3px 2px -1px alpha(black, 0.15),
         0 3px 5px alpha(black, 0.1);
-    color: white;
-    text-shadow:
-        0 1px 1px alpha(black, 0.3),
-        0 2px 3px alpha(black, 0.3);
+    color: @SLATE_900;
+    text-shadow: 0 1px alpha(white, 0.4);
+    -gtk-icon-shadow: 0 1px alpha(white, 0.4);
 }
 
 .category.video {

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -112,7 +112,7 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
             "Spreadsheet",
             "WordProcessor"
         }, "office"));
-        add (get_category (_("System"), "applications-system", {
+        add (get_category (_("System"), "applications-system-symbolic", {
             "Monitor",
             "System"
         }, "system"));


### PR DESCRIPTION
Open to feedback/thoughts. Trying to get rid of more magic numbers and use the palette, but the non-symbolic icon looked weird on a background of the exact same colors. And I tried inset on a lighter shade to avoid yet-another-white-on-dark tile.

![image](https://user-images.githubusercontent.com/611168/48154712-89313a80-e286-11e8-80d5-a6d26a09c4f2.png)
