### PR TITLE
Comment out the banner refresh hack

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -160,10 +160,10 @@ namespace AppCenter {
                     }
                 }
 
-                // If the banners weren't populated, try again to populate them
-                if (!recently_updated_revealer.reveal_child || !trending_revealer.reveal_child) {
-                    refresh_banners ();
-                }
+                //  // If the banners weren't populated, try again to populate them
+                //  if (!recently_updated_revealer.reveal_child || !trending_revealer.reveal_child) {
+                //      refresh_banners ();
+                //  }
             });
 
             recently_updated_carousel.package_activated.connect (show_package);


### PR DESCRIPTION
This is a quick fix for #939. There was a hack to trigger a refresh of banners if they failed to load at the first time, but it didn't give them any time to load. I guess the code was rewritten to be asynchronous at some point, but the hack wasn't updated to accomodate this. Handling network issues properly will require some refactoring, as the banner code doesn't even have a method to clear the banners list, so I've just commented the hack out to remain as a reminder.