### PR TITLE
Move drivers logic to separate class

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -72,7 +72,7 @@ public class AppCenter.App : Gtk.Application {
         var client = AppCenterCore.Client.get_default ();
         client.operation_finished.connect (on_operation_finished);
         client.cache_update_failed.connect (on_cache_update_failed);
-        client.update_check_finished.connect (on_updates_available);
+        client.installed_apps_changed.connect (on_updates_available);
 
         if (AppInfo.get_default_for_uri_scheme ("appstream") == null) {
             var appinfo = new DesktopAppInfo (application_id + ".desktop");

--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -1,0 +1,80 @@
+/*-
+ * Copyright 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
+ */
+
+public class AppCenterCore.UbuntuDriversBackend : Object {
+    private async bool get_drivers_output (out string? output) {
+        output = null;
+        string? drivers_exec_path = Environment.find_program_in_path ("ubuntu-drivers");
+        if (drivers_exec_path == null) {
+            return false;
+        }
+
+        Subprocess command;
+        try {
+            command = new Subprocess (SubprocessFlags.STDOUT_PIPE, drivers_exec_path, "list");
+            yield command.communicate_utf8_async (null, null, out output, null);
+        } catch (Error e) {
+            return false;
+        }
+
+        return command.get_exit_status () == 0;
+    }
+
+    public async Gee.TreeSet<Package> get_drivers () {
+        var driver_list = new Gee.TreeSet<Package> ();
+        string? command_output;
+        var result = yield get_drivers_output (out command_output);
+        if (!result || command_output == null) {
+            return driver_list;
+        }
+
+        string[] tokens = command_output.split ("\n");
+        for (int i = 0; i < tokens.length; i++) {
+            unowned string package_name = tokens[i];
+            if (package_name.strip () == "") {
+                continue;
+            }
+
+            var driver_component = new AppStream.Component ();
+            driver_component.set_kind (AppStream.ComponentKind.DRIVER);
+            driver_component.set_pkgnames ({ package_name });
+            driver_component.set_id (package_name);
+
+            var icon = new AppStream.Icon ();
+            icon.set_name ("application-x-firmware");
+            icon.set_kind (AppStream.IconKind.STOCK);
+            driver_component.add_icon (icon);
+
+            var package = new Package (driver_component);
+            if (package.installed) {
+                package.mark_installed ();
+                package.update_state ();
+            }
+
+            driver_list.add (package);
+        }
+
+        return driver_list;
+    }
+
+    private static GLib.Once<UbuntuDriversBackend> instance;
+    public static unowned UbuntuDriversBackend get_default () {
+        return instance.once (() => { return new UbuntuDriversBackend (); });
+    }
+}

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -140,7 +140,7 @@ namespace AppCenter {
                 }
             });
 
-            AppCenterCore.Client.get_default ().update_check_finished.connect (() => {
+            AppCenterCore.Client.get_default ().installed_apps_changed.connect (() => {
                 // Clear the cached categories when the AppStream pool is updated
                 foreach (weak Gtk.Widget child in category_flow.get_children ()) {
                     if (child is Widgets.CategoryItem) {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -18,12 +18,15 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-using AppCenterCore;
-
 public class AppCenter.Views.InstalledView : View {
-    AppListUpdateView app_list_view;
+    private Cancellable refresh_cancellable;
+    private bool refresh_running = false;
+
+    private AppListUpdateView app_list_view;
 
     construct {
+        refresh_cancellable = new Cancellable ();
+
         app_list_view = new AppListUpdateView ();
         app_list_view.show_app.connect ((package) => {
             subview_entered (C_("view", "Installed"), false, "");
@@ -32,16 +35,11 @@ public class AppCenter.Views.InstalledView : View {
 
         add (app_list_view);
 
-        unowned Client client = Client.get_default ();
+        unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
 
-        client.get_drivers ();
         get_apps.begin ();
 
-        client.update_check_finished.connect (() => {
-            get_apps.begin ();
-        });
-
-        client.drivers_detected.connect (() => {
+        client.installed_apps_changed.connect (() => {
             get_apps.begin ();
         });
 
@@ -61,23 +59,29 @@ public class AppCenter.Views.InstalledView : View {
     }
 
     public async void get_apps () {
-        app_list_view.clear ();
-
-        unowned Client client = Client.get_default ();
-
-        var os_updates = UpdateManager.get_default ().os_updates;
-        app_list_view.add_package (os_updates);
-
-        foreach (var driver in client.driver_list) {
-            app_list_view.add_package (driver);
+        if (refresh_running) {
+            refresh_cancellable.cancel ();
         }
 
+        refresh_running = true;
+        app_list_view.clear ();
+
+        unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
+
+        var os_updates = AppCenterCore.UpdateManager.get_default ().os_updates;
+        app_list_view.add_package (os_updates);
+
         var installed_apps = yield client.get_installed_applications ();
-        app_list_view.add_packages (installed_apps);
+        if (!refresh_cancellable.is_cancelled ()) {
+            app_list_view.add_packages (installed_apps);
+        }
+
+        refresh_cancellable.reset ();
+        refresh_running = false;
     }
 
     public async void add_app (AppCenterCore.Package package) {
-        unowned Client client = Client.get_default ();
+        unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
         var installed_apps = yield client.get_installed_applications ();
         foreach (var app in installed_apps) {
             if (app == package) {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -64,15 +64,15 @@ public class AppCenter.Views.InstalledView : View {
         }
 
         refresh_running = true;
-        app_list_view.clear ();
 
         unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
 
-        var os_updates = AppCenterCore.UpdateManager.get_default ().os_updates;
-        app_list_view.add_package (os_updates);
-
         var installed_apps = yield client.get_installed_applications ();
         if (!refresh_cancellable.is_cancelled ()) {
+            app_list_view.clear ();
+
+            var os_updates = AppCenterCore.UpdateManager.get_default ().os_updates;
+            app_list_view.add_package (os_updates);
             app_list_view.add_packages (installed_apps);
         }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,7 @@ appcenter_files = files(
     'Core/PackageKitJob.vala',
     'Core/ScreenshotCache.vala',
     'Core/Task.vala',
+    'Core/UbuntuDriversBackend.vala',
     'Core/UpdateManager.vala',
     'Dialogs/RestartDialog.vala',
     'Dialogs/ContentWarningDialog.vala',


### PR DESCRIPTION
Start to form the concept of separate backends and move the `ubuntu-drivers` logic into one.

The concept of backends is not complete yet as drivers are still technically part of the "PackageKit" backend. So we abuse the fact that AppCenter only has a PackageKit backend so far to prevent building a load more shims in the new drivers backend.

This will need to be done, but I'll do it as a separate PR to keep things easier to review.

Things to test:
* All things related to drivers
* The installed/update view's list of packages