### PR TITLE
Fix crashing issues when cancelling package operations

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -288,9 +288,13 @@ public class AppCenter.App : Gtk.Application {
 
     public void on_updates_available () {
         var client = AppCenterCore.Client.get_default ();
-        if (main_window != null) {
-            main_window.show_update_badge (client.updates_number);
-        }
+        Idle.add (() => {
+            if (main_window != null) {
+                main_window.show_update_badge (client.updates_number);
+            }
+
+            return GLib.Source.REMOVE;
+        });
     }
 
     private void on_cache_update_failed (Error error) {

--- a/src/Core/ChangeInformation.vala
+++ b/src/Core/ChangeInformation.vala
@@ -128,22 +128,22 @@ public class AppCenterCore.ChangeInformation : Object {
 
     public void start () {
         progress = 0.0f;
-        fire_progress_changed ();
+        progress_changed ();
         status = Pk.Status.WAIT;
-        fire_status_changed ();
+        status_changed ();
     }
 
     public void complete () {
         status = Pk.Status.FINISHED;
-        fire_status_changed ();
+        status_changed ();
         reset_progress ();
     }
 
     public void cancel () {
         progress = 0.0f;
-        fire_progress_changed ();
+        progress_changed ();
         status = Pk.Status.CANCEL;
-        fire_status_changed ();
+        status_changed ();
         reset_progress ();
     }
 
@@ -183,28 +183,12 @@ public class AppCenterCore.ChangeInformation : Object {
                 last_progress = progress.percentage;
                 double progress_sum = current_progress + last_progress;
                 this.progress = progress_sum / progress_denom;
-                fire_progress_changed ();
+                progress_changed ();
                 break;
             case Pk.ProgressType.STATUS:
                 status = (Pk.Status) progress.status;
-                fire_status_changed ();
+                status_changed ();
                 break;
         }
-    }
-
-    // We're more than likely being called from a non-main thread, wrap all
-    // signal calls in a Idle.add as UI logic may be triggered from them
-    public void fire_status_changed () {
-        Idle.add (() => {
-            status_changed ();
-            return GLib.Source.REMOVE;
-        });
-    }
-
-    public void fire_progress_changed () {
-        Idle.add (() => {
-            progress_changed ();
-            return GLib.Source.REMOVE;
-        });
     }
 }

--- a/src/Core/ChangeInformation.vala
+++ b/src/Core/ChangeInformation.vala
@@ -128,22 +128,22 @@ public class AppCenterCore.ChangeInformation : Object {
 
     public void start () {
         progress = 0.0f;
-        progress_changed ();
+        fire_progress_changed ();
         status = Pk.Status.WAIT;
-        status_changed ();
+        fire_status_changed ();
     }
 
     public void complete () {
         status = Pk.Status.FINISHED;
-        status_changed ();
+        fire_status_changed ();
         reset_progress ();
     }
 
     public void cancel () {
         progress = 0.0f;
-        progress_changed ();
+        fire_progress_changed ();
         status = Pk.Status.CANCEL;
-        status_changed ();
+        fire_status_changed ();
         reset_progress ();
     }
 
@@ -183,12 +183,28 @@ public class AppCenterCore.ChangeInformation : Object {
                 last_progress = progress.percentage;
                 double progress_sum = current_progress + last_progress;
                 this.progress = progress_sum / progress_denom;
-                progress_changed ();
+                fire_progress_changed ();
                 break;
             case Pk.ProgressType.STATUS:
                 status = (Pk.Status) progress.status;
-                status_changed ();
+                fire_status_changed ();
                 break;
         }
+    }
+
+    // We're more than likely being called from a non-main thread, wrap all
+    // signal calls in a Idle.add as UI logic may be triggered from them
+    public void fire_status_changed () {
+        Idle.add (() => {
+            status_changed ();
+            return GLib.Source.REMOVE;
+        });
+    }
+
+    public void fire_progress_changed () {
+        Idle.add (() => {
+            progress_changed ();
+            return GLib.Source.REMOVE;
+        });
     }
 }

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -17,6 +17,10 @@
 public class AppCenterCore.Client : Object {
     public signal void operation_finished (Package package, Package.State operation, Error? error);
     public signal void cache_update_failed (Error error);
+    /**
+     * This signal is likely to be fired from a non-main thread. Ensure any UI
+     * logic driven from this runs on the GTK thread
+     */
     public signal void installed_apps_changed ();
 
     public Gee.ArrayList<unowned Backend> backends;
@@ -108,12 +112,7 @@ public class AppCenterCore.Client : Object {
         launcher_entry.count_visible = updates_number != 0U;
 #endif
 
-        // Probably being called from a different thread, ensure any UI logic
-        // driven from this signal doesn't cause crashses
-        Idle.add (() => {
-            installed_apps_changed ();
-            return GLib.Source.REMOVE;
-        });
+        installed_apps_changed ();
     }
 
     public void cancel_updates (bool cancel_timeout) {

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -108,7 +108,12 @@ public class AppCenterCore.Client : Object {
         launcher_entry.count_visible = updates_number != 0U;
 #endif
 
-        installed_apps_changed ();
+        // Probably being called from a different thread, ensure any UI logic
+        // driven from this signal doesn't cause crashses
+        Idle.add (() => {
+            installed_apps_changed ();
+            return GLib.Source.REMOVE;
+        });
     }
 
     public void cancel_updates (bool cancel_timeout) {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -40,7 +40,10 @@ public class AppCenter.Views.InstalledView : View {
         get_apps.begin ();
 
         client.installed_apps_changed.connect (() => {
-            get_apps.begin ();
+            Idle.add (() => {
+                get_apps.begin ();
+                return GLib.Source.REMOVE;
+            });
         });
 
         destroy.connect (() => {


### PR DESCRIPTION
During testing downstream, @isantop and @mmstick found and were able to reproduce some crashing issues when cancelling package operations:
https://github.com/pop-os/shop/pull/117#pullrequestreview-219171652

Since moving more of the backend logic into threads, some of the signals being fired back to the UI were now running in non-UI threads causing issues. If we wrap the firing of these signals in an `Idle.add` we can ensure they run on the main GTK thread.