### PR TITLE
More package operation cancellation crash fixes

### DIFF
--- a/src/Core/ChangeInformation.vala
+++ b/src/Core/ChangeInformation.vala
@@ -173,6 +173,7 @@ public class AppCenterCore.ChangeInformation : Object {
         switch (type) {
             case Pk.ProgressType.ALLOW_CANCEL:
                 can_cancel = progress.allow_cancel;
+                status_changed ();
                 break;
             case Pk.ProgressType.ITEM_PROGRESS:
                 if (current_status == Pk.Status.SETUP) {

--- a/src/Core/ChangeInformation.vala
+++ b/src/Core/ChangeInformation.vala
@@ -19,7 +19,15 @@
  */
 
 public class AppCenterCore.ChangeInformation : Object {
+    /**
+     * This signal is likely to be fired from a non-main thread. Ensure any UI
+     * logic driven from this runs on the GTK thread
+     */
     public signal void status_changed ();
+    /**
+     * This signal is likely to be fired from a non-main thread. Ensure any UI
+     * logic driven from this runs on the GTK thread
+     */
     public signal void progress_changed ();
 
     public Gee.TreeSet<string> updatable_ids { public get; private set; }

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -55,6 +55,10 @@ public class AppCenterCore.Package : Object {
     };
 
     public signal void changing (bool is_changing);
+    /**
+     * This signal is likely to be fired from a non-main thread. Ensure any UI
+     * logic driven from this runs on the GTK thread
+     */
     public signal void info_changed (Pk.Status status);
 
     public enum State {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -113,7 +113,10 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
         unowned AppCenterCore.PackageKitBackend client = AppCenterCore.PackageKitBackend.get_default ();
         client.notify["working"].connect (() => {
-            working = client.working;
+            Idle.add (() => {
+                working = client.working;
+                return GLib.Source.REMOVE;
+            });
         });
 
         show.connect (on_view_mode_changed);

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -245,16 +245,20 @@ namespace AppCenter.Views {
             /* Not interested in any future changes for first_package */
             first_package.info_changed.disconnect (after_first_package_info_changed);
 
-            if (status != Pk.Status.CANCEL) { /* must  be running */
-                apps_remaining_started = true;
-                for (int i = 1; i < apps_to_update.size; i++) {
-                    apps_to_update[i].update.begin (() => {
-                        on_app_update_end ();
-                    });
+            Idle.add (() => {
+                if (status != Pk.Status.CANCEL) { /* must  be running */
+                    apps_remaining_started = true;
+                    for (int i = 1; i < apps_to_update.size; i++) {
+                        apps_to_update[i].update.begin (() => {
+                            on_app_update_end ();
+                        });
+                    }
+                } else { /* it was aborted - do not start updating the rest */
+                    finish_updating_all_apps ();
                 }
-            } else { /* it was aborted - do not start updating the rest */
-                finish_updating_all_apps ();
-            }
+
+                return GLib.Source.REMOVE;
+            });
         }
 
         private void on_app_update_end () {

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -352,16 +352,23 @@ namespace AppCenter {
         }
 
         protected void update_progress () {
-             progress_bar.fraction = package.progress;
-         }
+            Idle.add (() => {
+                progress_bar.fraction = package.progress;
+                return GLib.Source.REMOVE;
+            });
+        }
 
         protected virtual void update_progress_status () {
-            progress_bar.text = package.get_progress_description ();
-            /* Ensure progress bar shows complete to match status (lp:1606902) */
-            if (package.changes_finished) {
-                progress_bar.fraction = 1.0f;
-                cancel_button.sensitive = false;
-            }
+            Idle.add (() => {
+                progress_bar.text = package.get_progress_description ();
+                /* Ensure progress bar shows complete to match status (lp:1606902) */
+                if (package.changes_finished) {
+                    progress_bar.fraction = 1.0f;
+                    cancel_button.sensitive = false;
+                }
+
+                return GLib.Source.REMOVE;
+            });
         }
 
         private void action_cancelled () {

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -279,7 +279,6 @@ namespace AppCenter {
                 });
             });
 
-            package.change_information.bind_property ("can-cancel", cancel_button, "sensitive", GLib.BindingFlags.SYNC_CREATE);
             package.change_information.progress_changed.connect (update_progress);
             package.change_information.status_changed.connect (update_progress_status);
 
@@ -361,10 +360,10 @@ namespace AppCenter {
         protected virtual void update_progress_status () {
             Idle.add (() => {
                 progress_bar.text = package.get_progress_description ();
+                cancel_button.sensitive = package.change_information.can_cancel;
                 /* Ensure progress bar shows complete to match status (lp:1606902) */
                 if (package.changes_finished) {
                     progress_bar.fraction = 1.0f;
-                    cancel_button.sensitive = false;
                 }
 
                 return GLib.Source.REMOVE;


### PR DESCRIPTION
Further testing by @mmstick found more crashing issues relating to crashing package operations. I wasn't able to reproduce all of these, but I have cleaned up more instances where UI operations could be called from other threads and this is apparently more stable.