### PR TITLE
Check for updates when -Dhomepage=false

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -166,9 +166,13 @@ public class AppCenter.App : Gtk.Application {
         if (main_window == null) {
             main_window = new MainWindow (this);
 
+#if HOMEPAGE
             main_window.homepage_loaded.connect (() => {
                 client.update_cache.begin ();
             });
+#else
+            client.update_cache.begin ();
+#endif
 
             main_window.destroy.connect (() => {
                 main_window = null;


### PR DESCRIPTION
Because of the complex mess of conditionals in Homepage.vala, it's very difficult to fire the signal that instructs the package cache to be refreshed, which triggers an update check. So currently, when `-Dhomepage=false` is set during compilation, you end up with an AppCenter that doesn't check for package updates. This fixes that.