### PR TITLE
Use io.elementary.appcenter as dbus name

### DIFF
--- a/data/io.elementary.appcenter.service.in
+++ b/data/io.elementary.appcenter.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
-Name=@APP_NAME@
+Name=io.elementary.appcenter
 Exec=@EXEC_PATH@ -s


### PR DESCRIPTION
Fixes #983 

Since this has to match the well-known name that the DBusServer registers on, which is hardcoded here:
https://github.com/elementary/appcenter/blob/26b60a1b572ea29a1ffed01b0330bbcb29d1ffa0/src/Services/DBusServer.vala#L21

The `DBus` annotation doesn't support using a constant here, it only supports string literals. So we can't use the `Build.PROJECT_NAME` constant from `config.vala`. Or we could use meson to reconfigure `DBusServer.vala`, but this is easier for now.