### PR TITLE
Reuse package objects on reload

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -74,7 +74,7 @@ public class AppCenterCore.Package : Object {
     public const string LOCAL_ID_SUFFIX = ".appcenter-local";
     public const string DEFAULT_PRICE_DOLLARS = "1";
 
-    public AppStream.Component component { get; construct; }
+    public AppStream.Component component { get; protected set; }
     public ChangeInformation change_information { public get; private set; }
     public GLib.Cancellable action_cancellable { public get; private set; }
     public State state { public get; private set; default = State.NOT_INSTALLED; }
@@ -284,6 +284,23 @@ public class AppCenterCore.Package : Object {
 
     public Package (Backend backend, AppStream.Component component) {
         Object (backend: backend, component: component);
+    }
+
+    public void replace_component (AppStream.Component component) {
+        name = null;
+        description = null;
+        summary = null;
+        color_primary = null;
+        color_primary_text = null;
+        payments_key = null;
+        suggested_amount = null;
+        _latest_version = null;
+        installed_cached = false;
+        _author = null;
+        _author_title = null;
+        backend_details = null;
+
+        this.component = component;
     }
 
     public void update_state () {

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -133,7 +133,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         } catch (Error e) {
             critical (e.message);
         } finally {
-            var modified_packages = new Gee.TreeSet<string> ();
+            var new_package_list = new Gee.HashMap<string, Package> ();
             var comp_validator = ComponentValidator.get_default ();
             appstream_pool.get_components ().foreach ((comp) => {
                 if (!comp_validator.validate (comp)) {
@@ -141,26 +141,18 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
                 }
 
                 foreach (var pkg_name in comp.get_pkgnames ()) {
-                    modified_packages.add (pkg_name);
-                    var existing_package = package_list[pkg_name];
-                    if (existing_package != null) {
-                        existing_package.replace_component (comp);
+                    var package = package_list[pkg_name];
+                    if (package != null) {
+                        package.replace_component (comp);
                     } else {
-                        package_list[pkg_name] = new AppCenterCore.Package (this, comp);
+                        package = new Package (this, comp);
                     }
+
+                    new_package_list[pkg_name] = package;
                 }
             });
 
-            var to_remove = new Gee.ArrayList<string> ();
-            foreach (var key in package_list.keys) {
-                if (!(key in modified_packages)) {
-                    to_remove.add (key);
-                }
-            }
-
-            foreach (var key in to_remove) {
-                package_list.unset (key);
-            }
+            package_list = new_package_list;
         }
     }
 

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -140,7 +140,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
                     return;
                 }
 
-                foreach (var pkg_name in comp.get_pkgnames ()) {
+                foreach (unowned string pkg_name in comp.get_pkgnames ()) {
                     var package = package_list[pkg_name];
                     if (package != null) {
                         package.replace_component (comp);


### PR DESCRIPTION
Instead of clearing out the list of packages in the backend and building it again when we reload the appstream data, we can simply replace the appstream component on the ones that already exist.

This helps with a few things where the package is already referenced in cached AppInfoViews or banners and holds the reference but a newer, updated package has come along.