### PR TITLE
AppData: Make compulsory for Pantheon

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -230,6 +230,7 @@
         <content_attribute id="money-purchasing">intense</content_attribute>
         <content_attribute id="money-gambling">none</content_attribute>
     </content_rating>
+    <compulsory_for_desktop>Pantheon</compulsory_for_desktop>
     <developer_name>elementary LLC.</developer_name>
     <url type="homepage">http://elementary.io/</url>
     <url type="bugtracker">https://github.com/elementary/appcenter/issues</url>


### PR DESCRIPTION
As indicated in the spec, this should prevent people from breaking their install by removing their means of installing apps and updates