### PR TITLE
Package: Rename repos

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -293,19 +293,19 @@ public class AppCenterCore.Package : Object {
         owned get {
             if (backend is PackageKitBackend) {
                 if (component.get_origin () == APPCENTER_PACKAGE_ORIGIN) {
-                    return _("AppCenter Curated");
+                    return _("AppCenter");
                 } else if (component.get_origin () == ELEMENTARY_STABLE_PACKAGE_ORIGIN || component.get_origin () == ELEMENTARY_DAILY_PACKAGE_ORIGIN) {
-                    return _("elementary Repository");
+                    return _("elementary Updates");
                 } else if (component.get_origin ().has_prefix ("ubuntu-")) {
-                    return _("Ubuntu Repository (non-curated)");
+                    return _("Ubuntu (non-curated)");
                 }
             } else if (backend is FlatpakBackend) {
-                return _("%s Flatpak Repository").printf (component.get_origin ());
+                return _("%s (non-curated)").printf (component.get_origin ());
             } else if (backend is UbuntuDriversBackend) {
-                return _("Ubuntu Repository Drivers");
+                return _("Ubuntu Drivers");
             }
 
-            return _("Unknown Origin");
+            return _("Unknown Origin (non-curated)");
         }
     }
 


### PR DESCRIPTION
Some string suggestions with the following goals in mind:

* I don't think we need to point out that AppCenter is curated. In the list view, we only point out non-curated apps.
* The word "Repository" probably doesn't mean much to regular people, and I think the distinction of "Flatpak" is probably lost as well. If someone adds a source like "Flathub" that's probably already more meaningful to them than pointing out that it's a Flatpak repo.
* I would like to point out any repo that is non-curated so that we're warning users that these apps have not been vetted.

Interested in feedback from UX team :) 