### PR TITLE
Cache list of Ubuntu driver packages

### DIFF
--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -21,7 +21,7 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
 
     public bool working { public get; protected set; }
 
-    public Gee.TreeSet<Package>? cached_packages = null;
+    private Gee.TreeSet<Package>? cached_packages = null;
 
     private async bool get_drivers_output (Cancellable? cancellable = null, out string? output = null) {
         output = null;


### PR DESCRIPTION
This greatly improves issue #975 by keeping a cache of compatible Ubuntu drivers. It takes a while to discover the drivers and associate them to Package objects so doing this each time the installed list needs to load causes it to show the placeholder message for much longer than it needs to.

There will still be a bit of a delay loading the list on a completely cold start, but if AppCenter is running silently in the background (like it normally is), the loading of the installed list should be pretty instant again after opening it.