### PR TITLE
UpdateHeaderRow: Remove duplicate public method

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -165,7 +165,7 @@ namespace AppCenter.Views {
                     update_all_button.clicked.connect (on_update_all);
                     action_button_group.add_widget (update_all_button);
 
-                    header.add_widget (update_all_button);
+                    header.add (update_all_button);
                 }
 
                 header.show_all ();

--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -36,10 +36,6 @@ namespace AppCenter.Widgets {
             is_updating = _is_updating;
         }
 
-        public void add_widget (Gtk.Widget widget) {
-            add (widget);
-        }
-
         public abstract void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating);
     }
 


### PR DESCRIPTION
Seems kind of silly to duplicate an existing public method