### PR TITLE
AppInfoView: strip extra spaces and line breaks

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -663,9 +663,10 @@ namespace AppCenter.Views {
         private void parse_description (string? description) {
             if (description != null) {
                 try {
-                    var stripped_description = description.replace ("\n", "");
-                    while (stripped_description.contains ("  ")) {
-                        stripped_description = stripped_description.replace ("  ", " ");
+                    string[] lines = description.split ("\n");
+                    string stripped_description = lines[0].strip ();
+                    for (int i = 1; i < lines.length; i++) {
+                        stripped_description += " " + lines[i].strip ();
                     }
                     app_description.buffer.text = AppStream.markup_convert_simple (stripped_description);
                 } catch (Error e) {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -663,7 +663,11 @@ namespace AppCenter.Views {
         private void parse_description (string? description) {
             if (description != null) {
                 try {
-                    app_description.buffer.text = AppStream.markup_convert_simple (description);
+                    var stripped_description = description.replace ("\n", "");
+                    while (stripped_description.contains ("  ")) {
+                        stripped_description = stripped_description.replace ("  ", " ");
+                    }
+                    app_description.buffer.text = AppStream.markup_convert_simple (stripped_description);
                 } catch (Error e) {
                     critical (e.message);
                 }


### PR DESCRIPTION
It seems common that developers assume that we'll only respect line breaks from `<p>` tags and that they can maintain their own indentation in their xml files. This makes sure we strip out line breaks and extra spaces before we pass markup to appstream to be parsed. This addresses issues like #249 but for the appinfoview instead of the banner