### PR TITLE
Better flatpak transaction error handling

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -606,11 +606,9 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
             if (e is GLib.IOError.CANCELLED) {
                 cb (false, _("Cancelling"), 1.0f, ChangeInformation.Status.CANCELLED);
                 success = true;
-            } else {
-                return false;
             }
 
-            return true;
+            return false;
         });
 
         transaction.operation_done.connect ((operation, commit, details) => {
@@ -792,11 +790,10 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
             if (e is GLib.IOError.CANCELLED) {
                 cb (false, _("Cancelling"), 1.0f, ChangeInformation.Status.CANCELLED);
                 success = true;
-            } else {
                 return false;
+            } else {
+                return true;
             }
-
-            return true;
         });
 
         transaction.operation_done.connect ((operation, commit, details) => {

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -608,6 +608,7 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
                 success = true;
             }
 
+            // Any error during the installation of a single package and its deps is probably fatal, don't continue
             return false;
         });
 
@@ -790,8 +791,11 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
             if (e is GLib.IOError.CANCELLED) {
                 cb (false, _("Cancelling"), 1.0f, ChangeInformation.Status.CANCELLED);
                 success = true;
+                // The user hit cancel, don't go any further
                 return false;
             } else {
+                // If there was an error while updating a single package in the transaction, we probably still want
+                // the rest updated, continue.
                 return true;
             }
         });


### PR DESCRIPTION
We're using the concept of flatpak transactions to install and update packages as this allows the dependency runtimes to be installed with the package and allows multiple packages to be updated at once.

The API allows us to decide whether to continue working on other packages in a transaction when an error is caught. I think I previously had the logic a bit backwards here, so this PR fixes and clarifies this.