### PR TITLE
Spelling: mimetype → media type

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -103,7 +103,7 @@ public class AppCenter.App : Gtk.Application {
             if (mimetype != null) {
                 main_window.search (mimetype, true);
             } else {
-                info (_("Could not parse mimetype %s").printf (mimetype));
+                info (_("Could not parse the media type %s").printf (mimetype));
             }
 
             return;


### PR DESCRIPTION
As per https://www.iana.org/assignments/media-types/media-types.xhtml
(It should have been MIME type, so an error is avoided here.)

Similarly: https://github.com/elementary/files/pull/978