### PR TITLE
Move banner button text size to prevent leakage

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -83,6 +83,7 @@
     background-image: none;
     border-color: alpha(@banner_fg_color, 0.7);
     box-shadow: none;
+    font-size: 11pt;
     font-weight: 600;
 }
 

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -203,8 +203,6 @@ namespace AppCenter {
             progress_bar.width_request = 250;
 
             cancel_button = new Gtk.Button.with_label (_("Cancel"));
-            /* Match button text size with that of HumbleButton */
-            cancel_button.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
             cancel_button.valign = Gtk.Align.END;
             cancel_button.halign = Gtk.Align.END;
             cancel_button.clicked.connect (() => action_cancelled ());

--- a/src/Widgets/HumbleButton.vala
+++ b/src/Widgets/HumbleButton.vala
@@ -91,7 +91,6 @@ public class AppCenter.Widgets.HumbleButton : Gtk.Grid {
     public bool suggested_action {
         set {
             if (value) {
-                amount_button.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
                 amount_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
                 arrow_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             }


### PR DESCRIPTION
Prevent an issue where `h3` styles were being applied in the updates view

Before:
![Screenshot from 2019-06-24 14 19 03@2x](https://user-images.githubusercontent.com/7277719/60052787-0af59d00-968b-11e9-93e2-e676c9ba885c.png)

After:
![Screenshot from 2019-06-24 14 16 37@2x](https://user-images.githubusercontent.com/7277719/60052735-e6012a00-968a-11e9-8f2a-ae5cc8733648.png)
