### PR TITLE
Fix release info wrapping

### DIFF
--- a/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
@@ -61,6 +61,7 @@ public abstract class AppCenter.Widgets.AbstractPackageRowGrid : AbstractAppCont
         info_grid.attach (image, 0, 0, 1, 2);
         info_grid.attach (package_name, 1, 0, 1, 1);
 
+        action_stack.homogeneous = false;
         action_stack.margin_top = 10;
         action_stack.valign = Gtk.Align.START;
 

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -47,7 +47,6 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         release_description.xalign = 0;
 
         release_expander = new Gtk.Expander ("");
-        release_expander.use_markup = true;
         release_expander.halign = release_expander.valign = Gtk.Align.START;
         release_expander.add (release_description);
         release_expander.visible = true;

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -22,6 +22,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
     Gtk.Label app_version;
     Gtk.Stack release_stack;
     Gtk.Expander release_expander;
+    Gtk.Label release_expander_label;
     Gtk.Label release_description;
     Gtk.Label release_single_label;
     AppStream.Release? newest = null;
@@ -55,6 +56,11 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
             release_expander.expanded = !release_expander.expanded;
             return true;
         });
+
+        release_expander_label = new Gtk.Label ("");
+        release_expander_label.wrap = true;
+        release_expander_label.use_markup = true;
+        release_expander.set_label_widget (release_expander_label);
 
         release_single_label = new Gtk.Label (null);
         release_single_label.selectable = true;
@@ -105,7 +111,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
                     string description = ReleaseRow.format_release_description (newest);
                     string[] lines = description.split ("\n", 2);
                     if (lines.length > 1) {
-                        release_expander.label = lines[0];
+                        release_expander_label.label = lines[0];
                         release_description.set_text (lines[1]);
                         release_stack.visible_child = release_expander;
                         set_widget_visibility (release_stack, true);


### PR DESCRIPTION
Fixes #1023 

## Before:

![image](https://user-images.githubusercontent.com/611168/60130560-b4549580-9754-11e9-9e5e-debb7eb49998.png)

## After:

![Screenshot from 2019-06-25 16 34 44@2x](https://user-images.githubusercontent.com/611168/60138381-5bdac380-9767-11e9-8baa-0c70fcf932fd.png)
