### PR TITLE
Add prev/next arrows for screenshots

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -37,6 +37,9 @@ namespace AppCenter.Views {
         private Gtk.ListBox extension_box;
         private Gtk.Grid release_grid;
         private Widgets.ReleaseListBox release_list_box;
+        private Gtk.Button screenshot_next;
+        private Gtk.Button screenshot_previous;
+        private Gtk.Grid screenshot_previous_next;
         private Gtk.Stack screenshot_stack;
         private Gtk.TextView app_description;
         private Widgets.Switcher screenshot_switcher;
@@ -68,6 +71,35 @@ namespace AppCenter.Views {
                 app_screenshots.height_request = 500;
                 app_screenshots.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
                 app_screenshots.halign = Gtk.Align.CENTER;
+
+                screenshot_previous = new Gtk.Button.from_icon_name ("go-previous-symbolic");
+                screenshot_previous.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+                screenshot_previous.clicked.connect (() => {
+                    GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
+                    var index = screenshot_children.index (app_screenshots.visible_child);
+                    if (index > 0) {
+                        app_screenshots.visible_child = screenshot_children.nth_data (index - 1);
+                    } else {
+                        critical ("Can't go back!");
+                    }
+                });
+
+                screenshot_next = new Gtk.Button.from_icon_name ("go-next-symbolic");
+                screenshot_next.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+                screenshot_next.clicked.connect (() => {
+                    GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
+                    var index = screenshot_children.index (app_screenshots.visible_child);
+                    if (index < screenshot_children.length () - 1) {
+                        app_screenshots.visible_child = screenshot_children.nth_data (index + 1);
+                    } else {
+                        critical ("Can't go forward!");
+                    }
+                });
+
+                screenshot_previous_next = new Gtk.Grid ();
+                screenshot_previous_next.add (screenshot_previous);
+                screenshot_previous_next.add (screenshot_next);
+                screenshot_previous_next.no_show_all = true;
 
                 screenshot_switcher = new Widgets.Switcher ();
                 screenshot_switcher.halign = Gtk.Align.CENTER;
@@ -171,6 +203,7 @@ namespace AppCenter.Views {
             content_grid.orientation = Gtk.Orientation.VERTICAL;
 
             if (screenshots.length > 0) {
+                content_grid.add (screenshot_previous_next);
                 content_grid.add (screenshot_stack);
                 content_grid.add (screenshot_switcher);
             }
@@ -627,6 +660,8 @@ namespace AppCenter.Views {
                     if (app_screenshots.get_children ().length () > 0) {
                         screenshot_stack.visible_child = app_screenshots;
                         screenshot_switcher.update_selected ();
+                        screenshot_previous_next.no_show_all = false;
+                        screenshot_previous_next.show_all ();
                     } else {
                         screenshot_stack.visible_child = app_screenshot_not_found;
                     }

--- a/src/Widgets/Switcher.vala
+++ b/src/Widgets/Switcher.vala
@@ -102,6 +102,7 @@ namespace AppCenter.Widgets {
         private void connect_stack_signals () {
             stack.add.connect_after (add_child);
             stack.remove.connect_after (on_stack_child_removed);
+            stack.notify["visible-child"].connect_after (update_selected);
         }
 
         public void clear_children () {


### PR DESCRIPTION
Fixes #365.

- [x] Add arrow buttons that go back/forward
- [ ] Mark them as insensitive when they can't be used
- [ ] Figure out ideal placement/styling