### PR TITLE
Add prev/next arrows for screenshots

### DIFF
--- a/data/io.elementary.appcenter.gresource.xml
+++ b/data/io.elementary.appcenter.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/io/elementary/appcenter">
     <file alias="application.css" compressed="true">styles/application.css</file>
+    <file alias="arrow.css" compressed="true">styles/arrow.css</file>
     <file alias="categories.css" compressed="true">styles/categories.css</file>
   </gresource>
 </gresources>

--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -130,20 +130,3 @@
 .switcher:checked {
     opacity: 1;
 }
-
-.arrow {
-    background: linear-gradient(@SILVER_100, mix(@SILVER_100, @SILVER_300, 0.25));
-    border: 1px solid @SILVER_300;
-    box-shadow:
-        0 1px 1px rgba(0, 0, 0, 0.25),
-        0 1px 4px rgba(0, 0, 0, 0.125);
-    margin: 8px;
-    padding: 8px;
-    color: #333;
-}
-
-.arrow:active {
-    background: linear-gradient(@SILVER_100, @SILVER_100);
-    box-shadow: 0 0px 0px rgba(0, 0, 0, 0.125);
-}
-

--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -130,3 +130,20 @@
 .switcher:checked {
     opacity: 1;
 }
+
+.arrow {
+    background: linear-gradient(@SILVER_100, mix(@SILVER_100, @SILVER_300, 0.25));
+    border: 1px solid @SILVER_300;
+    box-shadow:
+        0 1px 1px rgba(0, 0, 0, 0.25),
+        0 1px 4px rgba(0, 0, 0, 0.125);
+    margin: 8px;
+    padding: 8px;
+    color: #333;
+}
+
+.arrow:active {
+    background: linear-gradient(@SILVER_100, @SILVER_100);
+    box-shadow: 0 0px 0px rgba(0, 0, 0, 0.125);
+}
+

--- a/data/styles/arrow.css
+++ b/data/styles/arrow.css
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.arrow {
+    background: @base_color;
+    box-shadow:
+        inset 0 0 0 1px alpha (@bg_highlight_color, 0.05),
+        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.45),
+        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.15),
+        0 0 0 1px alpha (#000, 0.05),
+        0 1px 3px rgba(0,0,0,0.12),
+        0 1px 2px rgba(0,0,0,0.24);
+    margin: 6px;
+    padding: 6px;
+    color: #333;
+}
+
+.arrow:active,
+.arrow:disabled {
+    background-color: @bg_color;
+    box-shadow:
+        0 0 0 1px alpha (#000, 0.05),
+        0 1px 2px alpha (#000, 0.22);
+    box-shadow:
+        inset 0 0 0 1px alpha (@bg_highlight_color, 0.05),
+        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.45),
+        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.15),
+        0 0 0 1px alpha (#000, 0.05),
+        0 1px 2px alpha (#000, 0.22);
+}

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -131,13 +131,11 @@ namespace AppCenter.Views {
 
                 screenshot_overlay.enter_notify_event.connect (() => {
                     screenshot_arrows_revealer.reveal_child = true;
-                    critical ("Mouse entering!");
                     return false;
                 });
 
                 screenshot_overlay.leave_notify_event.connect (() => {
                     screenshot_arrows_revealer.reveal_child = false;
-                    critical ("Mouse leaving!");
                     return false;
                 });
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -37,9 +37,9 @@ namespace AppCenter.Views {
         private Gtk.ListBox extension_box;
         private Gtk.Grid release_grid;
         private Widgets.ReleaseListBox release_list_box;
+        private Gtk.Grid screenshot_arrows;
         private Gtk.Button screenshot_next;
         private Gtk.Button screenshot_previous;
-        private Gtk.Grid screenshot_arrows;
         private Gtk.Stack screenshot_stack;
         private Gtk.TextView app_description;
         private Widgets.Switcher screenshot_switcher;
@@ -104,6 +104,20 @@ namespace AppCenter.Views {
                 screenshot_switcher = new Widgets.Switcher ();
                 screenshot_switcher.halign = Gtk.Align.CENTER;
                 screenshot_switcher.set_stack (app_screenshots);
+
+                app_screenshots.notify["visible-child"].connect (() => {
+                    screenshot_previous.sensitive = true;
+                    screenshot_next.sensitive = true;
+
+                    GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
+                    var index = screenshot_children.index (app_screenshots.visible_child);
+
+                    if (index == 0) {
+                        screenshot_previous.sensitive = false;
+                    } else if (index == screenshot_children.length () - 1) {
+                        screenshot_next.sensitive = false;
+                    }
+                });
 
                 var app_screenshot_spinner = new Gtk.Spinner ();
                 app_screenshot_spinner.halign = Gtk.Align.CENTER;

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -77,7 +77,12 @@ namespace AppCenter.Views {
                 screenshot_previous = new Gtk.Button.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
                 screenshot_previous.expand = true;
                 screenshot_previous.halign = Gtk.Align.START;
-                screenshot_previous.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+                screenshot_previous.valign = Gtk.Align.CENTER;
+
+                var previous_context = screenshot_previous.get_style_context ();
+                previous_context.add_class (Gtk.STYLE_CLASS_FLAT);
+                previous_context.add_class ("circular");
+                previous_context.add_class ("arrow");
 
                 screenshot_previous.clicked.connect (() => {
                     GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
@@ -90,7 +95,12 @@ namespace AppCenter.Views {
                 screenshot_next = new Gtk.Button.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
                 screenshot_next.expand = true;
                 screenshot_next.halign = Gtk.Align.END;
-                screenshot_next.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+                screenshot_next.valign = Gtk.Align.CENTER;
+
+                var next_context = screenshot_next.get_style_context ();
+                next_context.add_class (Gtk.STYLE_CLASS_FLAT);
+                next_context.add_class ("circular");
+                next_context.add_class ("arrow");
 
                 screenshot_next.clicked.connect (() => {
                     GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -111,8 +111,7 @@ namespace AppCenter.Views {
                 });
 
                 app_screenshots.notify["visible-child"].connect (() => {
-                    screenshot_previous.sensitive = true;
-                    screenshot_next.sensitive = true;
+                    screenshot_previous.sensitive = screenshot_next.sensitive = true;
 
                     GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
                     var index = screenshot_children.index (app_screenshots.visible_child);
@@ -140,12 +139,17 @@ namespace AppCenter.Views {
                 screenshot_overlay.add_overlay (screenshot_arrows_revealer);
 
                 screenshot_overlay.enter_notify_event.connect (() => {
+                    critical ("ENTERING");
                     screenshot_arrows_revealer.reveal_child = true;
                     return false;
                 });
 
-                screenshot_overlay.leave_notify_event.connect (() => {
-                    screenshot_arrows_revealer.reveal_child = false;
+                screenshot_overlay.leave_notify_event.connect ((event) => {
+                    // Prevent hiding prev/next button when they're marked as insensitive
+                    if (event.mode != Gdk.CrossingMode.STATE_CHANGED) {
+                        screenshot_arrows_revealer.reveal_child = false;
+                    }
+
                     return false;
                 });
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -26,7 +26,8 @@ namespace AppCenter.Views {
             Gtk.StackTransitionType transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT
         );
 
-        static Gtk.CssProvider? previous_css_provider = null;
+        private static Gtk.CssProvider arrow_provider;
+        private static Gtk.CssProvider? previous_css_provider = null;
 
         GenericArray<AppStream.Screenshot> screenshots;
 
@@ -51,6 +52,11 @@ namespace AppCenter.Views {
 
         public AppInfoView (AppCenterCore.Package package) {
             Object (package: package);
+        }
+
+        static construct {
+            arrow_provider = new Gtk.CssProvider ();
+            arrow_provider.load_from_resource ("io/elementary/appcenter/arrow.css");
         }
 
         construct {
@@ -83,6 +89,7 @@ namespace AppCenter.Views {
                 previous_context.add_class (Gtk.STYLE_CLASS_FLAT);
                 previous_context.add_class ("circular");
                 previous_context.add_class ("arrow");
+                previous_context.add_provider (arrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
                 screenshot_previous.clicked.connect (() => {
                     GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
@@ -101,6 +108,7 @@ namespace AppCenter.Views {
                 next_context.add_class (Gtk.STYLE_CLASS_FLAT);
                 next_context.add_class ("circular");
                 next_context.add_class ("arrow");
+                next_context.add_provider (arrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
                 screenshot_next.clicked.connect (() => {
                     GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -125,6 +125,7 @@ namespace AppCenter.Views {
 
                 screenshot_overlay = new Gtk.Overlay ();
                 screenshot_overlay.add_events (Gdk.EventMask.ENTER_NOTIFY_MASK);
+                screenshot_overlay.add_events (Gdk.EventMask.LEAVE_NOTIFY_MASK);
                 screenshot_overlay.add (app_screenshots);
                 screenshot_overlay.add_overlay (screenshot_arrows_revealer);
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -37,6 +37,9 @@ namespace AppCenter.Views {
         private Gtk.ListBox extension_box;
         private Gtk.Grid release_grid;
         private Widgets.ReleaseListBox release_list_box;
+        private Gtk.Button screenshot_next;
+        private Gtk.Button screenshot_previous;
+        private Gtk.Grid screenshot_previous_next;
         private Gtk.Stack screenshot_stack;
         private Gtk.TextView app_description;
         private Widgets.Switcher screenshot_switcher;
@@ -68,6 +71,35 @@ namespace AppCenter.Views {
                 app_screenshots.height_request = 500;
                 app_screenshots.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
                 app_screenshots.halign = Gtk.Align.CENTER;
+
+                screenshot_previous = new Gtk.Button.from_icon_name ("go-previous-symbolic");
+                screenshot_previous.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+                screenshot_previous.clicked.connect (() => {
+                    GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
+                    var index = screenshot_children.index (app_screenshots.visible_child);
+                    if (index > 0) {
+                        app_screenshots.visible_child = screenshot_children.nth_data (index - 1);
+                    } else {
+                        critical ("Can't go back!");
+                    }
+                });
+
+                screenshot_next = new Gtk.Button.from_icon_name ("go-next-symbolic");
+                screenshot_next.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+                screenshot_next.clicked.connect (() => {
+                    GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
+                    var index = screenshot_children.index (app_screenshots.visible_child);
+                    if (index < screenshot_children.length () - 1) {
+                        app_screenshots.visible_child = screenshot_children.nth_data (index + 1);
+                    } else {
+                        critical ("Can't go forward!");
+                    }
+                });
+
+                screenshot_previous_next = new Gtk.Grid ();
+                screenshot_previous_next.add (screenshot_previous);
+                screenshot_previous_next.add (screenshot_next);
+                screenshot_previous_next.no_show_all = true;
 
                 screenshot_switcher = new Widgets.Switcher ();
                 screenshot_switcher.halign = Gtk.Align.CENTER;
@@ -171,6 +203,7 @@ namespace AppCenter.Views {
             content_grid.orientation = Gtk.Orientation.VERTICAL;
 
             if (screenshots.length > 0) {
+                content_grid.add (screenshot_previous_next);
                 content_grid.add (screenshot_stack);
                 content_grid.add (screenshot_switcher);
             }
@@ -627,6 +660,8 @@ namespace AppCenter.Views {
                     if (app_screenshots.get_children ().length () > 0) {
                         screenshot_stack.visible_child = app_screenshots;
                         screenshot_switcher.update_selected ();
+                        screenshot_previous_next.no_show_all = false;
+                        screenshot_previous_next.show_all ();
                     } else {
                         screenshot_stack.visible_child = app_screenshot_not_found;
                     }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -39,7 +39,7 @@ namespace AppCenter.Views {
         private Widgets.ReleaseListBox release_list_box;
         private Gtk.Button screenshot_next;
         private Gtk.Button screenshot_previous;
-        private Gtk.Grid screenshot_previous_next;
+        private Gtk.Grid screenshot_arrows;
         private Gtk.Stack screenshot_stack;
         private Gtk.TextView app_description;
         private Widgets.Switcher screenshot_switcher;
@@ -96,10 +96,10 @@ namespace AppCenter.Views {
                     }
                 });
 
-                screenshot_previous_next = new Gtk.Grid ();
-                screenshot_previous_next.add (screenshot_previous);
-                screenshot_previous_next.add (screenshot_next);
-                screenshot_previous_next.no_show_all = true;
+                screenshot_arrows = new Gtk.Grid ();
+                screenshot_arrows.add (screenshot_previous);
+                screenshot_arrows.add (screenshot_next);
+                screenshot_arrows.no_show_all = true;
 
                 screenshot_switcher = new Widgets.Switcher ();
                 screenshot_switcher.halign = Gtk.Align.CENTER;
@@ -203,7 +203,7 @@ namespace AppCenter.Views {
             content_grid.orientation = Gtk.Orientation.VERTICAL;
 
             if (screenshots.length > 0) {
-                content_grid.add (screenshot_previous_next);
+                content_grid.add (screenshot_arrows);
                 content_grid.add (screenshot_stack);
                 content_grid.add (screenshot_switcher);
             }
@@ -660,8 +660,8 @@ namespace AppCenter.Views {
                     if (app_screenshots.get_children ().length () > 0) {
                         screenshot_stack.visible_child = app_screenshots;
                         screenshot_switcher.update_selected ();
-                        screenshot_previous_next.no_show_all = false;
-                        screenshot_previous_next.show_all ();
+                        screenshot_arrows.no_show_all = false;
+                        screenshot_arrows.show_all ();
                     } else {
                         screenshot_stack.visible_child = app_screenshot_not_found;
                     }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -92,15 +92,6 @@ namespace AppCenter.Views {
                     }
                 });
 
-                screenshot_arrows = new Gtk.Grid ();
-                screenshot_arrows.add (screenshot_previous);
-                screenshot_arrows.add (screenshot_next);
-                screenshot_arrows.no_show_all = true;
-
-                screenshot_switcher = new Widgets.Switcher ();
-                screenshot_switcher.halign = Gtk.Align.CENTER;
-                screenshot_switcher.set_stack (app_screenshots);
-
                 app_screenshots.notify["visible-child"].connect (() => {
                     screenshot_previous.sensitive = true;
                     screenshot_next.sensitive = true;
@@ -114,6 +105,15 @@ namespace AppCenter.Views {
                         screenshot_next.sensitive = false;
                     }
                 });
+
+                screenshot_arrows = new Gtk.Grid ();
+                screenshot_arrows.add (screenshot_previous);
+                screenshot_arrows.add (screenshot_next);
+                screenshot_arrows.no_show_all = true;
+
+                screenshot_switcher = new Widgets.Switcher ();
+                screenshot_switcher.halign = Gtk.Align.CENTER;
+                screenshot_switcher.set_stack (app_screenshots);
 
                 var app_screenshot_spinner = new Gtk.Spinner ();
                 app_screenshot_spinner.halign = Gtk.Align.CENTER;

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -139,7 +139,6 @@ namespace AppCenter.Views {
                 screenshot_overlay.add_overlay (screenshot_arrows_revealer);
 
                 screenshot_overlay.enter_notify_event.connect (() => {
-                    critical ("ENTERING");
                     screenshot_arrows_revealer.reveal_child = true;
                     return false;
                 });

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -79,8 +79,6 @@ namespace AppCenter.Views {
                     var index = screenshot_children.index (app_screenshots.visible_child);
                     if (index > 0) {
                         app_screenshots.visible_child = screenshot_children.nth_data (index - 1);
-                    } else {
-                        critical ("Can't go back!");
                     }
                 });
 
@@ -91,8 +89,6 @@ namespace AppCenter.Views {
                     var index = screenshot_children.index (app_screenshots.visible_child);
                     if (index < screenshot_children.length () - 1) {
                         app_screenshots.visible_child = screenshot_children.nth_data (index + 1);
-                    } else {
-                        critical ("Can't go forward!");
                     }
                 });
 

--- a/src/Widgets/Switcher.vala
+++ b/src/Widgets/Switcher.vala
@@ -102,6 +102,7 @@ namespace AppCenter.Widgets {
         private void connect_stack_signals () {
             stack.add.connect_after (add_child);
             stack.remove.connect_after (on_stack_child_removed);
+            stack.notify["visible-child"].connect_after (update_selected);
         }
 
         public void clear_children () {


### PR DESCRIPTION
Show previous/next arrows to control the screenshots on hover:

![image](https://user-images.githubusercontent.com/611168/60924651-f5719d00-a25e-11e9-954c-65a91bb0b588.png)

Fixes #365.

- [x] Add arrow buttons that go back/forward
- [x] Mark them as insensitive when they can't be used
- [x] Figure out placement/styling
- [x] Show on hover
- [x] Fix the `leave` event triggering when hitting the end of the stack