### PR TITLE
Add info icon and tooltip for download size

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -36,6 +36,7 @@ src/Widgets/PackageRow.vala
 src/Widgets/ReleaseListBox.vala
 src/Widgets/ReleaseRow.vala
 src/Widgets/SharePopover.vala
+src/Widgets/SizeLabel.vala
 src/Widgets/Switcher.vala
 src/Widgets/UpdateHeaderRow.vala
 src/Widgets/AppContainers/AbstractAppContainer.vala

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -254,6 +254,12 @@ public class AppCenterCore.Package : Object {
         }
     }
 
+    public bool is_flatpak {
+        get {
+            return (backend is FlatpakBackend) || change_information.updatable_packages.contains (FlatpakBackend.get_default ());
+        }
+    }
+
     private string? _author = null;
     public string author {
         get {

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -256,7 +256,8 @@ public class AppCenterCore.Package : Object {
 
     public bool is_flatpak {
         get {
-            return (backend is FlatpakBackend) || change_information.updatable_packages.contains (FlatpakBackend.get_default ());
+            return (backend is FlatpakBackend)
+                || change_information.updatable_packages.contains (FlatpakBackend.get_default ());
         }
     }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -40,7 +40,6 @@ namespace AppCenter.Views {
         private Gtk.Stack screenshot_stack;
         private Gtk.TextView app_description;
         private Widgets.Switcher screenshot_switcher;
-        private Gtk.Stack app_download_stack;
         private Gtk.ListStore version_liststore;
         private Gtk.ComboBox version_combo;
 
@@ -266,19 +265,11 @@ namespace AppCenter.Views {
             if (!package.is_local) {
                 size_label = new Widgets.SizeLabel ();
                 size_label.halign = Gtk.Align.END;
-                size_label.margin_end = open_button.margin_end;
                 size_label.valign = Gtk.Align.START;
 
                 action_button_group.add_widget (size_label);
 
-                /* We hide the label with a stack in order to stop the size requisition changing */
-                app_download_stack = new Gtk.Stack ();
-                // app_download_stack.margin_end = 6;
-                app_download_stack.add_named (size_label, "CHILD");
-                app_download_stack.add_named (new Gtk.EventBox (), "NONE");
-                app_download_stack.hhomogeneous = false;
-                app_download_stack.set_visible_child_name ("NONE");
-                header_grid.attach (app_download_stack, 3, 1, 1, 1);
+                header_grid.attach (size_label, 3, 1, 1, 2);
             }
 
             var header_box = new Gtk.Grid ();
@@ -462,8 +453,6 @@ namespace AppCenter.Views {
                 app_version.label = package.get_version ();
             }
 
-            app_download_stack.set_visible_child_name (package.state == AppCenterCore.Package.State.NOT_INSTALLED ?
-                                                       "CHILD" : "NONE");
             size_label.update ();
             if (package.state == AppCenterCore.Package.State.NOT_INSTALLED) {
                 get_app_download_size.begin ();
@@ -489,7 +478,6 @@ namespace AppCenter.Views {
             var size = yield package.get_download_size_including_deps ();
 
             size_label.update (size);
-            app_download_stack.set_visible_child_name ("CHILD");
         }
 
         public void view_entered () {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -33,7 +33,7 @@ namespace AppCenter.Views {
         private Gtk.Label app_screenshot_not_found;
         private Gtk.Stack app_screenshots;
         private Gtk.Label app_version;
-        private Gtk.Label app_download_size_label;
+        private Widgets.SizeLabel size_label;
         private Gtk.ListBox extension_box;
         private Gtk.Grid release_grid;
         private Widgets.ReleaseListBox release_list_box;
@@ -264,17 +264,17 @@ namespace AppCenter.Views {
             header_grid.attach (action_stack, 3, 0, 1, 1);
 
             if (!package.is_local) {
-                app_download_size_label = new Gtk.Label (null);
-                app_download_size_label.halign = Gtk.Align.END;
-                app_download_size_label.valign = Gtk.Align.START;
-                app_download_size_label.xalign = 1;
-                app_download_size_label.margin_end = open_button.margin_end;
-                action_button_group.add_widget (app_download_size_label);
-                app_download_size_label.selectable = true;
+                size_label = new Widgets.SizeLabel ();
+                size_label.halign = Gtk.Align.END;
+                size_label.margin_end = open_button.margin_end;
+                size_label.valign = Gtk.Align.START;
+
+                action_button_group.add_widget (size_label);
+
                 /* We hide the label with a stack in order to stop the size requisition changing */
                 app_download_stack = new Gtk.Stack ();
-                app_download_stack.margin_end = 6;
-                app_download_stack.add_named (app_download_size_label, "CHILD");
+                // app_download_stack.margin_end = 6;
+                app_download_stack.add_named (size_label, "CHILD");
                 app_download_stack.add_named (new Gtk.EventBox (), "NONE");
                 app_download_stack.hhomogeneous = false;
                 app_download_stack.set_visible_child_name ("NONE");
@@ -464,7 +464,7 @@ namespace AppCenter.Views {
 
             app_download_stack.set_visible_child_name (package.state == AppCenterCore.Package.State.NOT_INSTALLED ?
                                                        "CHILD" : "NONE");
-            app_download_size_label.label = "";
+            size_label.update ();
             if (package.state == AppCenterCore.Package.State.NOT_INSTALLED) {
                 get_app_download_size.begin ();
             }
@@ -488,7 +488,7 @@ namespace AppCenter.Views {
 
             var size = yield package.get_download_size_including_deps ();
 
-            app_download_size_label.label = GLib.format_size (size);
+            size_label.update (size);
             app_download_stack.set_visible_child_name ("CHILD");
         }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -275,7 +275,6 @@ namespace AppCenter.Views {
             var header_box = new Gtk.Grid ();
             header_box.get_style_context ().add_class ("banner");
             header_box.hexpand = true;
-            header_box.hexpand = true;
             header_box.add (header_grid);
 
             var footer_grid = new Gtk.Grid ();

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -476,8 +476,6 @@ namespace AppCenter.Views {
             }
 
             var size = yield package.get_download_size_including_deps ();
-
-            // TODO: pass in bool whether or not using Flatpak as second param
             size_label.update (size, package.is_flatpak);
         }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -275,6 +275,7 @@ namespace AppCenter.Views {
             var header_box = new Gtk.Grid ();
             header_box.get_style_context ().add_class ("banner");
             header_box.hexpand = true;
+            header_box.hexpand = true;
             header_box.add (header_grid);
 
             var footer_grid = new Gtk.Grid ();
@@ -477,6 +478,7 @@ namespace AppCenter.Views {
 
             var size = yield package.get_download_size_including_deps ();
 
+            // TODO: pass in bool whether or not using Flatpak as second param
             size_label.update (size);
         }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -266,6 +266,7 @@ namespace AppCenter.Views {
                 size_label = new Widgets.SizeLabel ();
                 size_label.halign = Gtk.Align.END;
                 size_label.valign = Gtk.Align.START;
+                size_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
                 action_button_group.add_widget (size_label);
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -478,7 +478,7 @@ namespace AppCenter.Views {
             var size = yield package.get_download_size_including_deps ();
 
             // TODO: pass in bool whether or not using Flatpak as second param
-            size_label.update (size);
+            size_label.update (size, package.is_flatpak);
         }
 
         public void view_entered () {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -157,10 +157,17 @@ namespace AppCenter.Views {
                 uint update_numbers = 0U;
                 uint nag_numbers = 0U;
                 uint64 update_real_size = 0ULL;
+                bool _check_flatpak = true;
+                bool using_flatpak = false;
                 foreach (var package in get_packages ()) {
                     if (package.update_available || package.is_updating) {
                         if (package.should_nag_update) {
                             nag_numbers++;
+                        }
+
+                        if (_check_flatpak && package.is_flatpak) {
+                            _check_flatpak = false;
+                            using_flatpak = true;
                         }
 
                         update_numbers++;
@@ -168,7 +175,7 @@ namespace AppCenter.Views {
                     }
                 }
 
-                header.update (update_numbers, update_real_size, updating_cache);
+                header.update (update_numbers, update_real_size, updating_cache, using_flatpak);
 
                 // Unfortunately the update all button needs to be recreated everytime the header needs to be updated
                 if (!updating_cache && update_numbers > 0) {
@@ -203,7 +210,7 @@ namespace AppCenter.Views {
                 }
 
                 var header = new Widgets.UpdatedGrid ();
-                header.update (0, 0, updating_cache);
+                header.update (0, 0, updating_cache, false);
                 header.show_all ();
                 row.set_header (header);
             }

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -157,7 +157,6 @@ namespace AppCenter.Views {
                 uint update_numbers = 0U;
                 uint nag_numbers = 0U;
                 uint64 update_real_size = 0ULL;
-                bool _check_flatpak = true;
                 bool using_flatpak = false;
                 foreach (var package in get_packages ()) {
                     if (package.update_available || package.is_updating) {
@@ -165,8 +164,7 @@ namespace AppCenter.Views {
                             nag_numbers++;
                         }
 
-                        if (_check_flatpak && package.is_flatpak) {
-                            _check_flatpak = false;
+                        if (!using_flatpak && package.is_flatpak) {
                             using_flatpak = true;
                         }
 

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -18,16 +18,16 @@
 
 namespace AppCenter.Widgets {
     public class SizeLabel : Gtk.Grid {
-        public bool downloading_flatpak { get; construct set; }
+        public bool using_flatpak { get; construct set; }
         public uint64 size { get; construct set; }
 
         private Gtk.Label size_label;
         private Gtk.Revealer icon_revealer;
 
-        public SizeLabel (uint64 _size = 0, bool _downloading_flatpak = false) {
+        public SizeLabel (uint64 _size = 0, bool _using_flatpak = false) {
             Object (
-                downloading_flatpak: _downloading_flatpak,
-                size: _size
+                size: _size,
+                using_flatpak: _using_flatpak
             );
         }
 
@@ -55,13 +55,13 @@ namespace AppCenter.Widgets {
             add (size_label);
             add (icon_revealer);
 
-            update (size, downloading_flatpak);
+            update (size, using_flatpak);
         }
 
-        public void update (uint64 size = 0, bool downloading_flatpak = false) {
+        public void update (uint64 size = 0, bool using_flatpak = false) {
             string human_size = GLib.format_size (size);
 
-            if (downloading_flatpak) {
+            if (using_flatpak) {
                 size_label.label = _("Up to %s").printf (human_size);
                 has_tooltip = true;
                 icon_revealer.reveal_child = true;

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -34,7 +34,7 @@ namespace AppCenter.Widgets {
         construct {
             tooltip_markup = "<b>%s</b>\n%s".printf (
                 _("Actual download size likely to be smaller."),
-                _("AppCenter only downloads the parts of apps and updates that are needed.")
+                _("AppCenter will only download the parts of apps and updates that are needed.")
             );
             size_label = new Gtk.Label (null);
             size_label.hexpand = true;

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -38,7 +38,6 @@ namespace AppCenter.Widgets {
             );
             size_label = new Gtk.Label (null);
             size_label.hexpand = true;
-            size_label.use_markup = true;
             size_label.vexpand = true;
             size_label.xalign = 1;
             size_label.show ();

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -39,19 +39,17 @@ public class AppCenter.Widgets.SizeLabel : Gtk.Grid {
         size_label.hexpand = true;
         size_label.vexpand = true;
         size_label.xalign = 1;
-        size_label.show ();
 
         var icon = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.BUTTON);
         icon.margin_start = 6;
-        icon.show ();
 
         icon_revealer = new Gtk.Revealer ();
         icon_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
         icon_revealer.add (icon);
-        icon_revealer.show ();
 
         add (size_label);
         add (icon_revealer);
+        show_all ();
 
         update (size, using_flatpak);
     }

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -57,16 +57,15 @@ public class AppCenter.Widgets.SizeLabel : Gtk.Grid {
     }
 
     public void update (uint64 size = 0, bool using_flatpak = false) {
+        has_tooltip = using_flatpak;
+        icon_revealer.reveal_child = using_flatpak;
+
         string human_size = GLib.format_size (size);
 
         if (using_flatpak) {
             size_label.label = _("Up to %s").printf (human_size);
-            has_tooltip = true;
-            icon_revealer.reveal_child = true;
         } else {
             size_label.label = "%s".printf (human_size);
-            has_tooltip = false;
-            icon_revealer.reveal_child = false;
         }
 
         if (size > 0) {

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -33,7 +33,7 @@ namespace AppCenter.Widgets {
 
         construct {
             tooltip_markup = "<b>%s</b>\n%s".printf (
-                _("Actual download size likely to be smaller."),
+                _("Actual Download Size Likely to Be Smaller"),
                 _("Only the parts of apps and updates that are needed will be downloaded.")
             );
             size_label = new Gtk.Label (null);

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -43,7 +43,7 @@ namespace AppCenter.Widgets {
             size_label.xalign = 1;
             size_label.show ();
 
-            var icon = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+            var icon = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.BUTTON);
             icon.margin_start = 6;
             icon.show ();
 

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -1,82 +1,80 @@
 /*
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+* Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
 
-namespace AppCenter.Widgets {
-    public class SizeLabel : Gtk.Grid {
-        public bool using_flatpak { get; construct set; }
-        public uint64 size { get; construct set; }
+public class AppCenter.Widgets.SizeLabel : Gtk.Grid {
+    public bool using_flatpak { get; construct set; }
+    public uint64 size { get; construct set; }
 
-        private Gtk.Label size_label;
-        private Gtk.Revealer icon_revealer;
+    private Gtk.Label size_label;
+    private Gtk.Revealer icon_revealer;
 
-        public SizeLabel (uint64 _size = 0, bool _using_flatpak = false) {
-            Object (
-                size: _size,
-                using_flatpak: _using_flatpak
-            );
+    public SizeLabel (uint64 _size = 0, bool _using_flatpak = false) {
+        Object (
+            size: _size,
+            using_flatpak: _using_flatpak
+        );
+    }
+
+    construct {
+        tooltip_markup = "<b>%s</b>\n%s".printf (
+            _("Actual Download Size Likely to Be Smaller"),
+            _("Only the parts of apps and updates that are needed will be downloaded.")
+        );
+        size_label = new Gtk.Label (null);
+        size_label.hexpand = true;
+        size_label.vexpand = true;
+        size_label.xalign = 1;
+        size_label.show ();
+
+        var icon = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.BUTTON);
+        icon.margin_start = 6;
+        icon.show ();
+
+        icon_revealer = new Gtk.Revealer ();
+        icon_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
+        icon_revealer.add (icon);
+        icon_revealer.show ();
+
+        add (size_label);
+        add (icon_revealer);
+
+        update (size, using_flatpak);
+    }
+
+    public void update (uint64 size = 0, bool using_flatpak = false) {
+        string human_size = GLib.format_size (size);
+
+        if (using_flatpak) {
+            size_label.label = _("Up to %s").printf (human_size);
+            has_tooltip = true;
+            icon_revealer.reveal_child = true;
+        } else {
+            size_label.label = "%s".printf (human_size);
+            has_tooltip = false;
+            icon_revealer.reveal_child = false;
         }
 
-        construct {
-            tooltip_markup = "<b>%s</b>\n%s".printf (
-                _("Actual Download Size Likely to Be Smaller"),
-                _("Only the parts of apps and updates that are needed will be downloaded.")
-            );
-            size_label = new Gtk.Label (null);
-            size_label.hexpand = true;
-            size_label.vexpand = true;
-            size_label.xalign = 1;
-            size_label.show ();
-
-            var icon = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.BUTTON);
-            icon.margin_start = 6;
-            icon.show ();
-
-            icon_revealer = new Gtk.Revealer ();
-            icon_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
-            icon_revealer.add (icon);
-            icon_revealer.show ();
-
-            add (size_label);
-            add (icon_revealer);
-
-            update (size, using_flatpak);
-        }
-
-        public void update (uint64 size = 0, bool using_flatpak = false) {
-            string human_size = GLib.format_size (size);
-
-            if (using_flatpak) {
-                size_label.label = _("Up to %s").printf (human_size);
-                has_tooltip = true;
-                icon_revealer.reveal_child = true;
-            } else {
-                size_label.label = "%s".printf (human_size);
-                has_tooltip = false;
-                icon_revealer.reveal_child = false;
-            }
-
-            if (size > 0) {
-                no_show_all = false;
-                show ();
-            } else {
-                no_show_all = true;
-                hide ();
-            }
+        if (size > 0) {
+            no_show_all = false;
+            show ();
+        } else {
+            no_show_all = true;
+            hide ();
         }
     }
 }

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace AppCenter.Widgets {
+    public class SizeLabel : Gtk.Grid {
+        public uint64 size { get; construct set; }
+
+        private Gtk.Label size_label;
+
+        public SizeLabel (uint64 _size = 0) {
+            Object (
+                column_spacing: 6,
+                size: _size
+            );
+        }
+
+        construct {
+            // TODO: Only show "Up to", info icon, and tooltip if using Flatpak
+            tooltip_markup = "<b>%s</b>\n%s".printf (
+                _("Actual download size likely to be smaller."),
+                _("AppCenter only downloads the parts of apps and updates that are needed.")
+            );
+            size_label = new Gtk.Label (null);
+            size_label.use_markup = true;
+
+            add (size_label);
+            add (new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
+
+            update (size);
+        }
+
+        public void update (uint64 size = 0) {
+            size_label.label = _("Up to <b>%s</b>").printf (GLib.format_size (size));
+
+            if (size > 0) {
+                no_show_all = false;
+                show_all ();
+            } else {
+                no_show_all = true;
+                hide ();
+            }
+        }
+    }
+}
+

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -34,7 +34,7 @@ namespace AppCenter.Widgets {
         construct {
             tooltip_markup = "<b>%s</b>\n%s".printf (
                 _("Actual download size likely to be smaller."),
-                _("AppCenter will only download the parts of apps and updates that are needed.")
+                _("Only the parts of apps and updates that are needed will be downloaded.")
             );
             size_label = new Gtk.Label (null);
             size_label.hexpand = true;

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -32,7 +32,6 @@ namespace AppCenter.Widgets {
         }
 
         construct {
-            // TODO: Only show "Up to", info icon, and tooltip if using Flatpak
             tooltip_markup = "<b>%s</b>\n%s".printf (
                 _("Actual download size likely to be smaller."),
                 _("AppCenter only downloads the parts of apps and updates that are needed.")

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -18,13 +18,15 @@
 
 namespace AppCenter.Widgets {
     public class SizeLabel : Gtk.Grid {
+        public bool downloading_flatpak { get; construct set; }
         public uint64 size { get; construct set; }
 
         private Gtk.Label size_label;
+        private Gtk.Revealer icon_revealer;
 
-        public SizeLabel (uint64 _size = 0) {
+        public SizeLabel (uint64 _size = 0, bool _downloading_flatpak = false) {
             Object (
-                column_spacing: 6,
+                downloading_flatpak: _downloading_flatpak,
                 size: _size
             );
         }
@@ -36,20 +38,43 @@ namespace AppCenter.Widgets {
                 _("AppCenter only downloads the parts of apps and updates that are needed.")
             );
             size_label = new Gtk.Label (null);
+            size_label.hexpand = true;
             size_label.use_markup = true;
+            size_label.vexpand = true;
+            size_label.xalign = 1;
+            size_label.show ();
+
+            var icon = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+            icon.margin_start = 6;
+            icon.show ();
+
+            icon_revealer = new Gtk.Revealer ();
+            icon_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
+            icon_revealer.add (icon);
+            icon_revealer.show ();
 
             add (size_label);
-            add (new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
+            add (icon_revealer);
 
-            update (size);
+            update (size, downloading_flatpak);
         }
 
-        public void update (uint64 size = 0) {
-            size_label.label = _("Up to <b>%s</b>").printf (GLib.format_size (size));
+        public void update (uint64 size = 0, bool downloading_flatpak = false) {
+            string human_size = GLib.format_size (size);
+
+            if (downloading_flatpak) {
+                size_label.label = _("Up to %s").printf (human_size);
+                has_tooltip = true;
+                icon_revealer.reveal_child = true;
+            } else {
+                size_label.label = "%s".printf (human_size);
+                has_tooltip = false;
+                icon_revealer.reveal_child = false;
+            }
 
             if (size > 0) {
                 no_show_all = false;
-                show_all ();
+                show ();
             } else {
                 no_show_all = true;
                 hide ();

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -17,8 +17,8 @@
 */
 
 public class AppCenter.Widgets.SizeLabel : Gtk.Grid {
-    public bool using_flatpak { get; construct set; }
-    public uint64 size { get; construct set; }
+    public bool using_flatpak { get; construct; }
+    public uint64 size { get; construct; }
 
     private Gtk.Label size_label;
     private Gtk.Revealer icon_revealer;

--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -24,19 +24,21 @@ namespace AppCenter.Widgets {
         public uint update_numbers { get; protected set; default = 0; }
         public uint64 update_real_size { get; protected set; default = 0; }
         public bool is_updating { get; protected set; default = false; }
+        public bool using_flatpak { get; protected set; default = false; }
 
         construct {
             margin = 12;
             column_spacing = 12;
         }
 
-        protected void store_data (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
+        protected void store_data (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _using_flatpak) {
             update_numbers = _update_numbers;
             update_real_size = _update_real_size;
             is_updating = _is_updating;
+            using_flatpak = _using_flatpak;
         }
 
-        public abstract void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating);
+        public abstract void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _using_flatpak);
     }
 
     /** Header to show at top of list if there are updates available **/
@@ -53,18 +55,18 @@ namespace AppCenter.Widgets {
             updates_label.hexpand = true;
 
             size_label = new SizeLabel ();
+            size_label.halign = Gtk.Align.END;
 
             add (updates_label);
             add (size_label);
         }
 
-        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
-            store_data (_update_numbers,  _update_real_size, _is_updating);
+        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _using_flatpak) {
+            store_data (_update_numbers,  _update_real_size, _is_updating, _using_flatpak);
 
             if (!is_updating) {
                 updates_label.label = ngettext ("%u Update Available", "%u Updates Available", update_numbers).printf (update_numbers);
-                // TODO: pass in bool whether or not using Flatpak as second param
-                size_label.update (update_real_size);
+                size_label.update (update_real_size, using_flatpak);
 
                 if (update_numbers > 0) {
                     show_all ();
@@ -93,8 +95,8 @@ namespace AppCenter.Widgets {
             add (spinner);
         }
 
-        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
-            store_data (_update_numbers,  _update_real_size, _is_updating);
+        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _using_flatpak) {
+            store_data (_update_numbers,  _update_real_size, _is_updating, _using_flatpak);
 
             if (is_updating) {
                 halign = Gtk.Align.CENTER;
@@ -124,8 +126,9 @@ namespace AppCenter.Widgets {
             add (label);
         }
 
-        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
+        public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating, bool _using_flatpak) {
 
         }
     }
 }
+

--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -41,25 +41,21 @@ namespace AppCenter.Widgets {
 
     /** Header to show at top of list if there are updates available **/
     public class UpdatesGrid : AbstractHeaderGrid {
-        private Gtk.Label update_size_label;
+        private SizeLabel size_label;
         private Gtk.Label updates_label;
 
         construct {
             margin_top = 18;
+
             updates_label = new Gtk.Label (null);
             ((Gtk.Misc) updates_label).xalign = 0;
             updates_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
             updates_label.hexpand = true;
 
-            update_size_label = new Gtk.Label (null);
-
-            var update_size_grid = new Gtk.Grid ();
-            update_size_grid.tooltip_text = _("Actual download size likely to be much smaller. AppCenter downloads the parts of apps that have changed.");
-            update_size_grid.add (update_size_label);
-            update_size_grid.add (new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
+            size_label = new SizeLabel ();
 
             add (updates_label);
-            add (update_size_grid);
+            add (size_label);
         }
 
         public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
@@ -67,7 +63,8 @@ namespace AppCenter.Widgets {
 
             if (!is_updating) {
                 updates_label.label = ngettext ("%u Update Available", "%u Updates Available", update_numbers).printf (update_numbers);
-                update_size_label.label = _("Up to %s").printf (GLib.format_size (update_real_size));
+                size_label.update (update_real_size);
+
                 if (update_numbers > 0) {
                     show_all ();
                 } else {

--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -53,8 +53,13 @@ namespace AppCenter.Widgets {
 
             update_size_label = new Gtk.Label (null);
 
+            var update_size_grid = new Gtk.Grid ();
+            update_size_grid.tooltip_text = _("Actual download size likely to be much smaller. AppCenter downloads the parts of apps that have changed.");
+            update_size_grid.add (update_size_label);
+            update_size_grid.add (new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.LARGE_TOOLBAR));
+
             add (updates_label);
-            add (update_size_label);
+            add (update_size_grid);
         }
 
         public override void update (uint _update_numbers, uint64 _update_real_size, bool _is_updating) {
@@ -62,7 +67,7 @@ namespace AppCenter.Widgets {
 
             if (!is_updating) {
                 updates_label.label = ngettext ("%u Update Available", "%u Updates Available", update_numbers).printf (update_numbers);
-                update_size_label.label = _("Size: %s").printf (GLib.format_size (update_real_size));
+                update_size_label.label = _("Up to %s").printf (GLib.format_size (update_real_size));
                 if (update_numbers > 0) {
                     show_all ();
                 } else {
@@ -126,4 +131,3 @@ namespace AppCenter.Widgets {
         }
     }
 }
-

--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -63,6 +63,7 @@ namespace AppCenter.Widgets {
 
             if (!is_updating) {
                 updates_label.label = ngettext ("%u Update Available", "%u Updates Available", update_numbers).printf (update_numbers);
+                // TODO: pass in bool whether or not using Flatpak as second param
                 size_label.update (update_real_size);
 
                 if (update_numbers > 0) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -44,6 +44,7 @@ appcenter_files = files(
     'Widgets/ReleaseListBox.vala',
     'Widgets/ReleaseRow.vala',
     'Widgets/SharePopover.vala',
+    'Widgets/SizeLabel.vala',
     'Widgets/Switcher.vala',
     'Widgets/UpdateHeaderRow.vala',
     'Widgets/AppContainers/AbstractAppContainer.vala',


### PR DESCRIPTION
Fixes #1030 

- [x] Change from "Size: X" to "Up to X" on Updates page
- [x] Add info icon with tooltip
- [x] Only show when Flatpaks are involved
- [x] Also show on app listings
- [x] Fix expansion of SizeLabel causing weird tooltip placement