### PR TITLE
Move arrow CSS to its own file and adjust

### DIFF
--- a/data/io.elementary.appcenter.gresource.xml
+++ b/data/io.elementary.appcenter.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/io/elementary/appcenter">
     <file alias="application.css" compressed="true">styles/application.css</file>
+    <file alias="arrow.css" compressed="true">styles/arrow.css</file>
     <file alias="categories.css" compressed="true">styles/categories.css</file>
   </gresource>
 </gresources>

--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -130,20 +130,3 @@
 .switcher:checked {
     opacity: 1;
 }
-
-.arrow {
-    background: linear-gradient(@SILVER_100, mix(@SILVER_100, @SILVER_300, 0.25));
-    border: 1px solid @SILVER_300;
-    box-shadow:
-        0 1px 1px rgba(0, 0, 0, 0.25),
-        0 1px 4px rgba(0, 0, 0, 0.125);
-    margin: 8px;
-    padding: 8px;
-    color: #333;
-}
-
-.arrow:active {
-    background: linear-gradient(@SILVER_100, @SILVER_100);
-    box-shadow: 0 0px 0px rgba(0, 0, 0, 0.125);
-}
-

--- a/data/styles/arrow.css
+++ b/data/styles/arrow.css
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.arrow {
+    background: @base_color;
+    box-shadow:
+        inset 0 0 0 1px alpha (@bg_highlight_color, 0.05),
+        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.45),
+        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.15),
+        0 0 0 1px alpha (#000, 0.05),
+        0 1px 3px rgba(0,0,0,0.12),
+        0 1px 2px rgba(0,0,0,0.24);
+    margin: 6px;
+    padding: 6px;
+    color: #333;
+}
+
+.arrow:active,
+.arrow:disabled {
+    background-color: @bg_color;
+    box-shadow:
+        0 0 0 1px alpha (#000, 0.05),
+        0 1px 2px alpha (#000, 0.22);
+    box-shadow:
+        inset 0 0 0 1px alpha (@bg_highlight_color, 0.05),
+        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.45),
+        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.15),
+        0 0 0 1px alpha (#000, 0.05),
+        0 1px 2px alpha (#000, 0.22);
+}

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -26,7 +26,8 @@ namespace AppCenter.Views {
             Gtk.StackTransitionType transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT
         );
 
-        static Gtk.CssProvider? previous_css_provider = null;
+        private static Gtk.CssProvider arrow_provider;
+        private static Gtk.CssProvider? previous_css_provider = null;
 
         GenericArray<AppStream.Screenshot> screenshots;
 
@@ -51,6 +52,11 @@ namespace AppCenter.Views {
 
         public AppInfoView (AppCenterCore.Package package) {
             Object (package: package);
+        }
+
+        static construct {
+            arrow_provider = new Gtk.CssProvider ();
+            arrow_provider.load_from_resource ("io/elementary/appcenter/arrow.css");
         }
 
         construct {
@@ -83,6 +89,7 @@ namespace AppCenter.Views {
                 previous_context.add_class (Gtk.STYLE_CLASS_FLAT);
                 previous_context.add_class ("circular");
                 previous_context.add_class ("arrow");
+                previous_context.add_provider (arrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
                 screenshot_previous.clicked.connect (() => {
                     GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();
@@ -101,6 +108,7 @@ namespace AppCenter.Views {
                 next_context.add_class (Gtk.STYLE_CLASS_FLAT);
                 next_context.add_class ("circular");
                 next_context.add_class ("arrow");
+                next_context.add_provider (arrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
                 screenshot_next.clicked.connect (() => {
                     GLib.List<unowned Gtk.Widget> screenshot_children = app_screenshots.get_children ();


### PR DESCRIPTION
* For things that overlay, a semi-transparent box shadow usually looks cleaner than a border
* Inner highlights to match other widgets
* Also apply the clicked style to :disabled buttons
* move arrow CSS to its own file and add the provider directly to the button context so we make sure we don't leak this .arrow class anywhere else on accident