### PR TITLE
Animate screenshot background while loading

### DIFF
--- a/data/io.elementary.appcenter.gresource.xml
+++ b/data/io.elementary.appcenter.gresource.xml
@@ -4,5 +4,6 @@
     <file alias="application.css" compressed="true">styles/application.css</file>
     <file alias="arrow.css" compressed="true">styles/arrow.css</file>
     <file alias="categories.css" compressed="true">styles/categories.css</file>
+    <file alias="loading.css" compressed="true">styles/loading.css</file>
   </gresource>
 </gresources>

--- a/data/styles/loading.css
+++ b/data/styles/loading.css
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.loading {
+    animation: loading 1.5s ease-in infinite;
+    background-image: linear-gradient(
+        to right,
+        @bg_color 20%,
+        white,
+        @bg_color 80%
+    );
+}
+
+@keyframes loading {
+    from {
+        background-position: -600px center;
+    }
+
+    to {
+        background-position: 600px center;
+    }
+}
+

--- a/data/styles/loading.css
+++ b/data/styles/loading.css
@@ -20,7 +20,7 @@
     background-image: linear-gradient(
         to right,
         @bg_color 20%,
-        white,
+        @base_color,
         @bg_color 80%
     );
 }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -27,6 +27,7 @@ namespace AppCenter.Views {
         );
 
         private static Gtk.CssProvider arrow_provider;
+        private static Gtk.CssProvider loading_provider;
         private static Gtk.CssProvider? previous_css_provider = null;
 
         GenericArray<AppStream.Screenshot> screenshots;
@@ -44,6 +45,7 @@ namespace AppCenter.Views {
         private Gtk.Button screenshot_previous;
         private Gtk.Button screenshot_next;
         private Gtk.Stack screenshot_stack;
+        private Gtk.StyleContext stack_context;
         private Gtk.Overlay screenshot_overlay;
         private Gtk.TextView app_description;
         private Widgets.Switcher screenshot_switcher;
@@ -57,6 +59,9 @@ namespace AppCenter.Views {
         static construct {
             arrow_provider = new Gtk.CssProvider ();
             arrow_provider.load_from_resource ("io/elementary/appcenter/arrow.css");
+
+            loading_provider = new Gtk.CssProvider ();
+            loading_provider.load_from_resource ("io/elementary/appcenter/loading.css");
         }
 
         construct {
@@ -174,11 +179,15 @@ namespace AppCenter.Views {
                 app_screenshot_not_found.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
                 screenshot_stack = new Gtk.Stack ();
-                screenshot_stack.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
                 screenshot_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
                 screenshot_stack.add (app_screenshot_spinner);
                 screenshot_stack.add (screenshot_overlay);
                 screenshot_stack.add (app_screenshot_not_found);
+
+                stack_context = screenshot_stack.get_style_context ();
+                stack_context.add_class (Gtk.STYLE_CLASS_BACKGROUND);
+                stack_context.add_class ("loading");
+                stack_context.add_provider (loading_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             }
 
             package_name.selectable = true;
@@ -703,6 +712,7 @@ namespace AppCenter.Views {
 
                     if (number_of_screenshots > 0) {
                         screenshot_stack.visible_child = screenshot_overlay;
+                        stack_context.remove_class ("loading");
                         screenshot_switcher.update_selected ();
 
                         if (number_of_screenshots > 1) {
@@ -711,6 +721,7 @@ namespace AppCenter.Views {
                         }
                     } else {
                         screenshot_stack.visible_child = app_screenshot_not_found;
+                        stack_context.remove_class ("loading");
                     }
 
                     return GLib.Source.REMOVE;


### PR DESCRIPTION
Inspired by #1050, using the sort of shine placeholder animation that's become common on the web and in apps like Slack. If we think it's clear enough that it's loading, we could even remove the spinner altogether.