### PR TITLE
Replace network stack child with info bar

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -38,8 +38,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     private Gtk.Button return_button;
     private ulong task_finished_connection = 0U;
     private Gee.LinkedList<string> return_button_history;
-    private Granite.Widgets.AlertView network_alert_view;
-    private Gtk.Grid network_view;
     private Gtk.Label updates_badge;
 
     private GLib.Settings settings;
@@ -82,8 +80,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
         search_entry.search_changed.connect (() => trigger_search ());
 
-        view_mode.notify["selected"].connect (on_view_mode_changed);
-
         search_entry.key_press_event.connect ((event) => {
             if (event.keyval == Gdk.Key.Escape) {
                 search_entry.text = "";
@@ -101,16 +97,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         installed_view.subview_entered.connect (view_opened);
         search_view.subview_entered.connect (view_opened);
 
-        NetworkMonitor.get_default ().network_changed.connect (on_view_mode_changed);
-
-        network_alert_view.action_activated.connect (() => {
-            try {
-                AppInfo.launch_default_for_uri ("settings://network", null);
-            } catch (Error e) {
-                warning (e.message);
-            }
-        });
-
         unowned AppCenterCore.BackendAggregator client = AppCenterCore.BackendAggregator.get_default ();
         client.notify["working"].connect (() => {
             Idle.add (() => {
@@ -118,8 +104,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
                 return GLib.Source.REMOVE;
             });
         });
-
-        show.connect (on_view_mode_changed);
     }
 
     construct {
@@ -200,24 +184,20 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         installed_view = new Views.InstalledView ();
         search_view = new Views.SearchView ();
 
-        network_alert_view = new Granite.Widgets.AlertView (_("Network Is Not Available"),
-                                                            _("Connect to the Internet to install or update apps."),
-                                                            "network-error");
-        network_alert_view.get_style_context ().remove_class (Gtk.STYLE_CLASS_VIEW);
-        network_alert_view.show_action (_("Network Settings…"));
-
-        network_view = new Gtk.Grid ();
-        network_view.margin = 24;
-        network_view.attach (network_alert_view, 0, 0, 1, 1);
-
         stack = new Gtk.Stack ();
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
         stack.add (homepage);
         stack.add (installed_view);
         stack.add (search_view);
-        stack.add (network_view);
 
-        add (stack);
+        var network_info_bar = new AppCenter.Widgets.NetworkInfoBar ();
+
+        var grid = new Gtk.Grid ();
+        grid.orientation = Gtk.Orientation.VERTICAL;
+        grid.add (network_info_bar);
+        grid.add (stack);
+
+        add (grid);
 
         homepage.page_loaded.connect (() => homepage_loaded ());
     }
@@ -373,29 +353,5 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
         View view = (View) stack.visible_child;
         view.return_clicked ();
-    }
-
-    private void on_view_mode_changed () {
-        var connection_available = NetworkMonitor.get_default ().get_network_available ();
-        if (connection_available) {
-            if (search_entry.text.length >= VALID_QUERY_LENGTH) {
-                stack.visible_child = search_view;
-                search_entry.sensitive = !search_view.viewing_package;
-            } else {
-                if (view_mode.selected == homepage_view_id) {
-                    stack.visible_child = homepage;
-                    search_entry.sensitive = !homepage.viewing_package;
-                } else if (view_mode.selected == installed_view_id) {
-                    stack.visible_child = installed_view;
-                    search_entry.sensitive = false;
-                }
-            }
-        } else {
-            stack.visible_child = network_view;
-            search_entry.sensitive = false;
-        }
-
-        custom_title_stack.sensitive = connection_available;
-        return_button.sensitive = connection_available;
     }
 }

--- a/src/Widgets/NetworkInfoBar.vala
+++ b/src/Widgets/NetworkInfoBar.vala
@@ -1,0 +1,70 @@
+/*
+* Copyright © 2019 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+public class AppCenter.Widgets.NetworkInfoBar : Gtk.InfoBar {
+    private GLib.Settings settings;
+
+    public NetworkInfoBar () {
+        Object (
+            message_type: Gtk.MessageType.WARNING
+        );
+    }
+
+    construct {
+        settings = new GLib.Settings ("io.elementary.appcenter.settings");
+
+        string title = _("Network Not Available.");
+        string details = _("Connect to the Internet to browse and install apps.");
+
+        var default_label = new Gtk.Label ("<b>%s</b> %s".printf (title, details));
+        default_label.use_markup = true;
+        default_label.wrap = true;
+
+        get_content_area ().add (default_label);
+        // TRANSLATORS: Includes an ellipsis (…) in English to signify the action will be performed in a new window
+        add_button (_("Network Settings…"), Gtk.ResponseType.ACCEPT);
+
+        try_set_revealed ();
+
+        response.connect ((response_id) => {
+            switch (response_id) {
+                case Gtk.ResponseType.ACCEPT:
+                    try {
+                        AppInfo.launch_default_for_uri ("settings://network", null);
+                    } catch (GLib.Error e) {
+                        critical (e.message);
+                    }
+                    break;
+                default:
+                    assert_not_reached ();
+            }
+        });
+
+        var network_monitor = NetworkMonitor.get_default ();
+        network_monitor.network_changed.connect (() => {
+            try_set_revealed ();
+        });
+    }
+
+    private void try_set_revealed (bool? reveal = true) {
+        var network_available = NetworkMonitor.get_default ().get_network_available ();
+        revealed = reveal && !network_available;
+    }
+}
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,6 +40,7 @@ appcenter_files = files(
     'Widgets/CategoryItem.vala',
     'Widgets/HumbleButton.vala',
     'Widgets/HumblePopover.vala',
+    'Widgets/NetworkInfoBar.vala',
     'Widgets/PackageRow.vala',
     'Widgets/ReleaseListBox.vala',
     'Widgets/ReleaseRow.vala',


### PR DESCRIPTION
Fixes #970 

- Replaces the blocking network grid with a non-blocking infobar
- Enables browsing local information when offline
- Enables uninstalling apps when offline
- Works with custom network setups (still warns, but allows the app to work)

AppCenter already gives a proper error if attempting to install an app without a working network. Open to feedback.