### PR TITLE
Desktop: Add icon to updates and remove keyword

### DIFF
--- a/data/io.elementary.appcenter.desktop.in.in
+++ b/data/io.elementary.appcenter.desktop.in.in
@@ -3,7 +3,7 @@ Name=@APP_NAME@
 Comment=Browse and manage apps
 Exec=@EXEC_NAME@ %U
 Icon=@DESKTOP_ICON@
-Keywords=install;uninstall;remove;catalogue;store;apps;updates;software;
+Keywords=install;uninstall;remove;catalogue;store;apps;software;
 Actions=ShowUpdates;
 Terminal=false
 Type=Application
@@ -15,3 +15,4 @@ X-GNOME-UsesNotifications=true
 [Desktop Action ShowUpdates]
 Exec=@EXEC_NAME@ --show-updates
 Name=Check for Updates
+Icon=system-software-update


### PR DESCRIPTION
Currently when you search for "Updates" in the applications menu you get:
![Screenshot from 2019-09-12 17 17 07@2x](https://user-images.githubusercontent.com/7277719/64829468-4c5a6200-d581-11e9-9123-af84b3eeed3d.png)

This gives you less one fewer option and would ideally be better if we sorted app actions higher:
![Screenshot from 2019-09-12 17 16 19@2x](https://user-images.githubusercontent.com/7277719/64829466-4bc1cb80-d581-11e9-8fde-019d2d2d0e41.png)

Also sets an icon so that will show up when we fix that in the applications menu