### PR TITLE
Fix #1086 by ignoring non-fatal Flatpak errors

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -610,14 +610,14 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
         bool success = false;
 
         transaction.operation_error.connect ((operation, e, detail) => {
-            warning ("Flatpak installation failed: %s", e.message);
+            warning ("Flatpak installation failed: %s (detail: %d)", e.message, detail);
             if (e is GLib.IOError.CANCELLED) {
                 cb (false, _("Cancelling"), 1.0f, ChangeInformation.Status.CANCELLED);
                 success = true;
             }
 
-            // Any error during the installation of a single package and its deps is probably fatal, don't continue
-            return false;
+            // Only stop if this is a fatal error
+            return detail == Flatpak.TransactionErrorDetails.NON_FATAL;
         });
 
         transaction.operation_done.connect ((operation, commit, details) => {

--- a/vapi/flatpak.vapi
+++ b/vapi/flatpak.vapi
@@ -295,10 +295,10 @@ namespace Flatpak {
 		MMC,
 		NETWORK
 	}
-	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_TRANSACTION_ERROR_DETAILS_NON_", type_id = "flatpak_transaction_error_details_get_type ()")]
+	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_TRANSACTION_ERROR_DETAILS_", type_id = "flatpak_transaction_error_details_get_type ()")]
 	[Flags]
 	public enum TransactionErrorDetails {
-		FATAL
+		NON_FATAL
 	}
 	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_TRANSACTION_OPERATION_", type_id = "flatpak_transaction_operation_type_get_type ()")]
 	public enum TransactionOperationType {


### PR DESCRIPTION
I ran into #1086 while installing Steam, which also failed due to openh264:

> FlatpakBackend.vala:613: Flatpak installation failed: runtime/org.freedesktop.Platform.openh264/x86_64/19.08 needs a later flatpak version (1.4.2;1.2.5;1.0.9;)

It turns out the error callback lets us know if an error is fatal, and we can ignore non-fatal errors. This change allowed me to install Celluloid.