### PR TITLE
CategoryFlowBox: use correct icon for office category

### DIFF
--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -105,7 +105,7 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
             "Recorder",
             "Sequencer"
         }, "media-production"));
-        add (get_category (_("Office"), "x-office-document-symbolic", {
+        add (get_category (_("Office"), "applications-office-symbolic", {
             "Office",
             "Presentation",
             "Publishing",


### PR DESCRIPTION
This is the right icon name for this context since this is the icon name for the office category.

If we want to change the metaphor of this icon that should be done in the icon theme, not by using an icon name from the mimes context