### PR TITLE
Lookup PackageKit packages for the installed view in parallel

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -20,7 +20,7 @@
         <p>Minor fixes</p>
         <ul>
           <li>Prevent ghost update notification when there are no updates available</li>
-          <li>Speedup loading of installed applications view</li>
+          <li>Speed up loading apps in the Installed view</li>
         </ul>
       </description>
     </release>

--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -20,6 +20,7 @@
         <p>Minor fixes</p>
         <ul>
           <li>Prevent ghost update notification when there are no updates available</li>
+          <li>Speedup loading of installed applications view</li>
         </ul>
       </description>
     </release>

--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -20,6 +20,7 @@
         <p>Minor fixes</p>
         <ul>
           <li>Prevent unescaped XML entities from appearing in application names</li>
+          <li>Load the "Installed" view faster</li>
         </ul>
       </description>
     </release>

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -847,9 +847,15 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         try {
             var results = yield client.search_names_async (filter, query, null, () => {});
             var array = results.get_package_array ();
-            array.foreach ((package) => {
-                if (package.info == Pk.Info.INSTALLED) {
-                    package_list[package.get_name ()].mark_installed ();
+            array.foreach ((pk_package) => {
+                var package = package_list[pk_package.get_name ()];
+                if (package == null) {
+                    return;
+                }
+
+                package.latest_version = pk_package.get_version ();
+                if (pk_package.info == Pk.Info.INSTALLED) {
+                    package.mark_installed ();
                 }
             });
         } catch (Error e) {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -70,6 +70,19 @@ public class AppCenter.Views.InstalledView : View {
         unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
 
         var installed_apps = yield client.get_installed_applications (refresh_cancellable);
+
+        // To gain some speedup of the installed applications list, update the state of the packages ahead
+        // of adding them to the list. Otherwise, AppCenter will query each one in turn to get the latest
+        // verison string from PackageKit. The update_multiple_package state method ignores packages that
+        // aren't PackageKit packages, so this is safe to run on the whole list, even if it includes Flatpaks
+        if (AppCenterCore.PackageKitBackend.supports_parallel_package_queries && installed_apps != null) {
+            try {
+                yield AppCenterCore.PackageKitBackend.get_default ().update_multiple_package_state (installed_apps);
+            } catch (Error e) {
+                warning ("Error while updating state of installed packages, loading of installed list may fail or be slow: %s", e.message);
+            }
+        }
+
         if (!refresh_cancellable.is_cancelled ()) {
             app_list_view.clear ();
 


### PR DESCRIPTION
I've noticed that since merging the speedups for the homepage, the installed view seems to be loading one package at a time quite slowly. I've applied the same parallel learnings to that page so that everything loads in much quicker.