### PR TITLE
Fix lint error and delegate warnings

### DIFF
--- a/src/AsyncMutex.vala
+++ b/src/AsyncMutex.vala
@@ -53,4 +53,3 @@ public class AsyncMutex {
         }
     }
 }
-

--- a/src/Core/BackendAggregator.vala
+++ b/src/Core/BackendAggregator.vala
@@ -176,7 +176,7 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
     public async bool update_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable cancellable) throws GLib.Error {
         var success = true;
         foreach (var backend in backends) {
-            if (!yield backend.update_package (package, cb, cancellable)) {
+            if (!yield backend.update_package (package, (owned)cb, cancellable)) {
                 success = false;
             }
         }

--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -134,15 +134,15 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
     }
 
     public async bool install_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable cancellable) throws GLib.Error {
-        return yield PackageKitBackend.get_default ().install_package (package, cb, cancellable);
+        return yield PackageKitBackend.get_default ().install_package (package, (owned)cb, cancellable);
     }
 
     public async bool remove_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable cancellable) throws GLib.Error {
-        return yield PackageKitBackend.get_default ().remove_package (package, cb, cancellable);
+        return yield PackageKitBackend.get_default ().remove_package (package, (owned)cb, cancellable);
     }
 
     public async bool update_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable cancellable) throws GLib.Error {
-        return yield PackageKitBackend.get_default ().update_package (package, cb, cancellable);
+        return yield PackageKitBackend.get_default ().update_package (package, (owned)cb, cancellable);
     }
 
     private static GLib.Once<UbuntuDriversBackend> instance;


### PR DESCRIPTION
Fixes a lint error about a blank line at the end of a file and fixes a few warnings about not being able to copy delegates (so transfer them as owned).