### PR TITLE
Use new orign name from appstream data

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -324,16 +324,17 @@ public class AppCenterCore.Package : Object {
 
     public string origin_description {
         owned get {
+            unowned string origin = component.get_origin ();
             if (backend is PackageKitBackend) {
-                if (component.get_origin () == APPCENTER_PACKAGE_ORIGIN) {
+                if (origin == APPCENTER_PACKAGE_ORIGIN) {
                     return _("AppCenter");
-                } else if (component.get_origin () == DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN || component.get_origin () == ELEMENTARY_STABLE_PACKAGE_ORIGIN) {
+                } else if (origin == DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN || origin == ELEMENTARY_STABLE_PACKAGE_ORIGIN) {
                     return _("elementary Updates");
-                } else if (component.get_origin ().has_prefix ("ubuntu-")) {
+                } else if (origin.has_prefix ("ubuntu-")) {
                     return _("Ubuntu (non-curated)");
                 }
             } else if (backend is FlatpakBackend) {
-                return _("%s (non-curated)").printf (component.get_origin ());
+                return _("%s (non-curated)").printf (origin);
             } else if (backend is UbuntuDriversBackend) {
                 return _("Ubuntu Drivers");
             }

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -36,8 +36,10 @@ public class AppCenterCore.PackageDetails : Object {
 
 public class AppCenterCore.Package : Object {
     public const string APPCENTER_PACKAGE_ORIGIN = "appcenter-bionic-main";
-    private const string ELEMENTARY_STABLE_PACKAGE_ORIGIN = "stable-bionic-main";
-    private const string ELEMENTARY_DAILY_PACKAGE_ORIGIN = "daily-bionic-main";
+    // We stopped using this origin in elementary OS 5.1, references to this can be removed
+    // after everyone has had chance to update their appstream-data-pantheon package
+    private const string DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN = "stable-bionic-main";
+    private const string ELEMENTARY_STABLE_PACKAGE_ORIGIN = "elementary-stable-bionic-main";
 
     /* Note: These are just a stopgap, and are not a replacement for a more
      * fleshed out parental control system. We assume any of these "moderate"
@@ -206,8 +208,8 @@ public class AppCenterCore.Package : Object {
         get {
             switch (component.get_origin ()) {
                 case APPCENTER_PACKAGE_ORIGIN:
+                case DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN:
                 case ELEMENTARY_STABLE_PACKAGE_ORIGIN:
-                case ELEMENTARY_DAILY_PACKAGE_ORIGIN:
                     return true;
                 default:
                     return false;
@@ -325,7 +327,7 @@ public class AppCenterCore.Package : Object {
             if (backend is PackageKitBackend) {
                 if (component.get_origin () == APPCENTER_PACKAGE_ORIGIN) {
                     return _("AppCenter");
-                } else if (component.get_origin () == ELEMENTARY_STABLE_PACKAGE_ORIGIN || component.get_origin () == ELEMENTARY_DAILY_PACKAGE_ORIGIN) {
+                } else if (component.get_origin () == DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN || component.get_origin () == ELEMENTARY_STABLE_PACKAGE_ORIGIN) {
                     return _("elementary Updates");
                 } else if (component.get_origin ().has_prefix ("ubuntu-")) {
                     return _("Ubuntu (non-curated)");


### PR DESCRIPTION
The new unreleased `appstream-data-pantheon` package now has a metadata bundle with an origin of `elementary-stable-{series}-main` instead of just `stable-{series}-main` which seemed a bit too generic and had the potential for conflicts. We need to update AppCenter to be aware of this new origin before releasing the new appdata package or elementary applications will appear as non-curated.

I've also removed the daily origin here because as far as I can tell, we never had a package origin called `daily-bionic-main`. The origin refers to the AppStream origin and we never had any daily AppStream data being generated or installed. I suspect that packages from the daily repos will just fall under the stable metadata. Though this is worth testing by someone running with the daily PPA.

