### PR TITLE
Remove dbus service file

### DIFF
--- a/data/io.elementary.appcenter.service.in
+++ b/data/io.elementary.appcenter.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=io.elementary.appcenter
-Exec=@EXEC_PATH@ -s

--- a/data/meson.build
+++ b/data/meson.build
@@ -6,14 +6,6 @@ configure_file(
     install_dir: join_paths(get_option('datadir'), 'applications')
 )
 
-# D-Bus Service
-configure_file(
-    input: meson.project_name() + '.service.in',
-    output: meson.project_name() + '.service',
-    configuration: conf_data,
-    install_dir: dbus.get_pkgconfig_variable('session_bus_services_dir', define_variable: ['datadir', get_option('datadir')])
-)
-
 # GNOME Shell Search Provider
 configure_file(
     input: meson.project_name() + '.search-provider.ini.in',


### PR DESCRIPTION
Fixes #1063

This prevents AppCenter from being able to be launched by DBus.

Rationale:

- The AppCenter daemon autostarts anyway with its autostart file, and the applications menu watches the bus and connects/reconnects as necessary when it starts/restarts. We might opt to reduce the autostart delay down from 60 seconds, so it's ready for the applications menu sooner.
- Having this service file makes it even more difficult to stop AppCenter autostarting. Even if you remove the autostart file, it will still start every time you open the applications menu. There are people that like to disable the autostart for various reasons (bandwidth, CPU load, etc...)
- This is the cause of the AppCenter window opening on startup that's being reported a lot at the moment. If you've opened the applications menu before the 60 second delay on the autostart, gnome session manager will start it again. Of course it's a different issue that launching it twice with the silent flag still opens a window, but I haven't yet been able to fix that.


If we choose to merge this, we'll require a follow up in the `deb-packaging` branch to remove the service from the install file.