### PR TITLE
Only call update on backends which have updates available

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -15,6 +15,14 @@
     </p>
   </description>
   <releases>
+    <release version="3.2.1" date="2019-11-06" urgency="medium">
+      <description>
+        <p>Minor fixes</p>
+        <ul>
+          <li>Prevent ghost update notification when there are no updates available</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.2.0" date="2019-10-31" urgency="medium">
       <description>
         <ul>

--- a/src/Core/BackendAggregator.vala
+++ b/src/Core/BackendAggregator.vala
@@ -175,7 +175,10 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
 
     public async bool update_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable cancellable) throws GLib.Error {
         var success = true;
-        foreach (var backend in backends) {
+        // updatable_packages is a HashMultiMap of packages to be updated, where the key is
+        // a pointer to the backend that is capable of updating them. Call update on each of these
+        // backends to update the packages belonging to them
+        foreach (var backend in package.change_information.updatable_packages.get_keys ()) {
             if (!yield backend.update_package (package, (owned)cb, cancellable)) {
                 success = false;
             }


### PR DESCRIPTION
Instead of iterating through all backends when they don't necessarily have updates. Only call the update method on the ones that have updates listed in `change_information`.

This may improve issues like #1119 but I'm struggling to reproduce it consistently. Either way, this should at least be a minor efficiency improvement.