### PR TITLE
deb-packaging: remove dbus service install

### DIFF
--- a/debian/appcenter.install
+++ b/debian/appcenter.install
@@ -1,6 +1,5 @@
 usr/bin/
 usr/share/applications/
-usr/share/dbus-1/services/io.elementary.appcenter.service
 usr/share/glib-2.0/
 usr/share/gnome-shell/search-providers/io.elementary.appcenter.search-provider.ini
 usr/share/locale/

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@
 	dh $@ 
 
 override_dh_missing:
-	dh_missing --fail-missing --exclude=appcenter.blacklist --exclude=io.elementary.appcenter.service
+	dh_missing --fail-missing --exclude=appcenter.blacklist
 
 override_dh_strip:
 	dh_strip --dbgsym-migration='appcenter-dbg (<< 0.2.9)'


### PR DESCRIPTION
Follow up to #1126 to remove the dbus service file from packaging.