### PR TITLE
Monitor FlatpakInstallation for Changes

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -37,6 +37,8 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
 
     private static Flatpak.Installation? installation;
 
+    private static GLib.FileMonitor monitor;
+
     private uint total_operations;
     private int current_operation;
 
@@ -72,6 +74,11 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
         appstream_pool = new AppStream.Pool ();
         appstream_pool.set_cache_flags (AppStream.CacheFlags.NONE);
         package_list = new Gee.HashMap<string, Package> (null, null);
+        monitor = installation.create_monitor ();
+        monitor.changed.connect (() => {
+            debug ("Flatpak installation changed.");
+            // Flatpak cache update tasks go here?
+        });
 
         local_metadata_path = Path.build_filename (
             Environment.get_user_cache_dir (),

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -77,7 +77,6 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
         monitor = installation.create_monitor ();
         monitor.changed.connect (() => {
             debug ("Flatpak installation changed.");
-            GLib.Cancellable cancellable = new GLib.Cancellable ();
             // Flatpak cache update tasks go here?
             Client.get_default ().update_cache.begin (true);
         });

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -80,16 +80,15 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
             try {
                 installation_changed_monitor = installation.create_monitor ();
             } catch (Error e) {
-                critical ("Couldn't create Installation File Monitor : %s", e.message);
+                warning ("Couldn't create Installation File Monitor : %s", e.message);
             }
 
             installation_changed_monitor.changed.connect (() => {
                 debug ("Flatpak installation changed.");
-                var cache_cancellable = new GLib.Cancellable ();
-                refresh_cache (cache_cancellable);
+                refresh_cache (null);
             });
         } else {
-            error ("Couldn't create Installation File Monitor due to no installation");
+            warning ("Couldn't create Installation File Monitor due to no installation");
         }
 
         local_metadata_path = Path.build_filename (

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -74,7 +74,7 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
         appstream_pool = new AppStream.Pool ();
         appstream_pool.set_cache_flags (AppStream.CacheFlags.NONE);
         package_list = new Gee.HashMap<string, Package> (null, null);
-        
+
         // Monitor the FlatpakInstallation for changes (e.g. adding/removing remotes)
         if (installation != null) {
             try {
@@ -82,7 +82,7 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
             } catch (Error e) {
                 critical ("Couldn't create Installation File Monitor : %s", e.message);
             }
-            
+
             installation_changed_monitor.changed.connect (() => {
                 debug ("Flatpak installation changed.");
                 var cache_cancellable = new GLib.Cancellable ();


### PR DESCRIPTION
This should monitor the FlatpakInstallation for any changes, and if it finds some, trigger a cache refresh to update the UI accordingly. This will allow changes to propagate if a remote is modified/added/removed without needing to restart AppCenter.

fixes #1198 