### PR TITLE
Fix sorting of native apps in list views

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -21,6 +21,7 @@
         <ul>
           <li>Update application details when changes happen outside of AppCenter</li>
           <li>Fix for notification not appearing when a restart is required</li>
+          <li>Apps in list views now load in the correct order when scrolling</li>
           <li>Prevent unescaped XML entities from appearing in application names</li>
           <li>Load the "Installed" view faster</li>
         </ul>

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -84,7 +84,7 @@ namespace AppCenter.Views {
 #if CURATED
             bool p1_is_elementary_native = p1.is_native;
 
-            if (p1_is_elementary_native || p2.is_native) {
+            if (p1_is_elementary_native != p2.is_native) {
                 return p1_is_elementary_native ? -1 : 1;
             }
 #endif


### PR DESCRIPTION
If the compare function was comparing two elementary native applications, it would be kind of random as to which one would come out on top.

Ensure we use lower sorting criteria (alphabetical) if both apps are native.