### PR TITLE
Choose a more appropriate screenshot size to download

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -23,6 +23,7 @@
           <li>Fix for notification not appearing when a restart is required</li>
           <li>Prevent unescaped XML entities from appearing in application names</li>
           <li>Load the "Installed" view faster</li>
+          <li>Save some bandwidth by downloading smaller screenshots where appropriate</li>
         </ul>
       </description>
     </release>

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -656,7 +656,7 @@ namespace AppCenter.Views {
 
                     if (screenshot.get_kind () == AppStream.ScreenshotKind.DEFAULT && best_image != null) {
                         urls.prepend (best_image.get_url ());
-                    } else {
+                    } else if (best_image != null) {
                         urls.append (best_image.get_url ());
                     }
                 });


### PR DESCRIPTION
Instead of always downloading the largest (original) size image, save a bit of bandwidth (especially on LoDPI) by choosing the image that is closest to the width it will be displayed at.

This is related to #1104 but doesn't necessarily completely solve it.