### PR TITLE
FlatpakBackend: Update installed applications on external change

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -27,6 +27,7 @@
           <li>Ensure flatpak applications show in the category views</li>
           <li>Save some bandwidth by downloading smaller screenshots where appropriate</li>
           <li>System components no longer have an "Open" button</li>
+          <li>Applications menu can now remove flatpaks that weren't installed by AppCenter</li>
         </ul>
       </description>
     </release>

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -85,7 +85,8 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
 
             installation_changed_monitor.changed.connect (() => {
                 debug ("Flatpak installation changed.");
-                refresh_cache (null);
+                refresh_cache.begin (null);
+                get_installed_applications.begin (null);
             });
         } else {
             warning ("Couldn't create Installation File Monitor due to no installation");


### PR DESCRIPTION
Fixes #1072 

Allows us to track the installed state of flatpaks that are being changed outside of AppCenter, which makes the "Uninstall" action in the applications menu context menu work properly.