### PR TITLE
BACKERS.md: Add AppCenter for Everyone backers

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,260 +1,766 @@
-# IndieGoGo Backers
-Thanks again to all of the backers of our [March 2017 IndieGoGo campaign](https://www.indiegogo.com/projects/appcenter-the-pay-what-you-want-app-store)!
+# Backers
 
-    Aaron Dickey
-    Adam Slavík
-    adammakarucha
-    Adarsh Barik
-    Aidan Stewart
-    Alan Salisbury
-    Alex Boutros
-    Alex Gleason
-    Alex Gorshkov
-    Alex Mamaev
-    Alexander Nekrasov
-    Alexander Schäfer
-    Alexandr Jeliuc
-    Allan Stromfeldt Christensen
-    Anastas Dancha
-    Anatoli Natschalow
-    Andre Mohr
-    Andrew Ego
-    Andy Byers
-    Ansel Taft
-    Aspen Digital
-    Aymeric Sorek
-    Ben Davey
-    Ben McClure
-    Benoît Labaere
-    Bill O'Dwyer
-    Boyan Iliev
-    brejoc
-    Brett Biery
-    Brian Douglass
-    Brian Fagioli
-    Brooke
-    Bruguier Nicolas
-    Bryce Call
-    Carlos Ceja Espinosa
-    Carlos Gonzalez Juarez
-    Carmelito Andrade
-    Cato Gaustad
-    Chironjit Das
-    Chris Cowan
-    Chris Harvey
-    Christian Ander
-    Christopher Horton
-    cimm
-    Ciprian Tepes
-    Cody Still
-    conrad sykes
-    contact.mirekm
-    cricel472
-    crisconru
-    daniel.colson99
-    Daniel Germán Cosenza
-    Darshak Parikh
-    David Berg
-    David Capello
-    David Cornejo
-    David Krawiec
-    David Medeiros
-    David Monarres
-    davidak (https://davidak.de/)
-    Dawid Ciulkiewicz
-    deesee04
-    Derek Ekins
-    Dez Blanchfield
-    Dimitar Sirakov
-    Don Duvall
-    Eddy Ahmed
-    el Moussaoui
-    Elias Gabrielsson
-    Eric Nicholls
-    Eric Pritchett
-    Ernestas Kvedaras
-    Eugene Chow
-    Ezra Sharp
-    Fab Trillaud
-    falface
-    Félix Brezo
-    Felix Schröter
-    Fery Wardiyanto
-    Finn M. Schroeder
-    Frank Gregor
-    Fred Lin
-    Fredrik Ekelund
-    Fulvi Igor
-    Gabriel Diosan
-    Gabriele Lippi
-    Gamunu Balagalla
-    Georgi Kasev
-    Giovanni Casisa
-    Goutham D
-    graeter
-    Grant Bourque
-    Grant Ford
-    Gregor Aisch
-    Grisel Yarinda Morales Ortiz
-    Guillaume Bouchard
-    GUILLOIS François-Xavier
-    Henry Pagan
-    Herbert Scheffknecht
-    Ian Cosgrove
-    Isak Holmström
-    ivan
-    Ivo Van Humbeeck
-    Ivo Karadzhov
-    Jakub Hlusička
-    James Feak
-    Jared Schwartz
-    Jeremy Garcia
-    Jeremy Vaartjes
-    Jesse Fisher
-    jf.allie
-    jhnkrklnd
-    Jindrich S.
-    Jod Mangel
-    Joe Petrus
-    Joel Wallis Jucá
-    John Kennedy
-    John Pangalos
-    joke7p
-    jonasmarx
-    Jonathan Reisdorf
-    Jose Martinez
-    Joesph Hager
-    Jörg Arnold
-    Joshua Garrett
-    Jovan Gerodetti
-    Jun Takeda
-    Jung-Kyu Park
-    Jussi Virtanen
-    Kevin Kleinman
-    Kevin Lawrence
-    Kevin Rodríguez
-    Kevin Smith
-    Kjetil Gauslaa
-    Konrad Kruk
-    kwikchek
-    Laurence A Lowe
-    Lee Pfeifer
-    Leo Herzog
-    Ludovic L.
-    Luis Carlos Osorio Jayk
-    Magnus Teekivi
-    mail
-    Manos Parzakonis
-    Manuel del Valle
-    Marc Demierre
-    Marcelo Dornelles Hosannah
-    Marcin L
-    Marco Carrizales
-    Marco Mueller
-    Mark Ridley
-    Martin Hammerschmied
-    Martin Hengst
-    Martin Svoboda
-    Matthew Morek
-    Matthew Perrone
-    Matthias Neid
-    Matthieu CHARTIER GALOU
-    Maurice Achtenhagen
-    Max Engel
-    Maxence Dubois
-    Maxim Taranov
-    Maxime Cornet
-    Mehmet Hanoğlu
-    Michael Devenish
-    Michael Holley
-    Michael Holt
-    Michael Juan Robayo
-    Michael Kanis
-    Michael Rampl
-    Michael Terry
-    Miguel Fontoura
-    Mike Wild
-    Muhammad Fikri
-    Nathan Caza
-    Neal Gompa
-    Nerbiz Dijkstra
-    Neylson de Oliveira Gularte
-    Nicholas La Roux
-    Nick Melnick
-    Niklas Liechti
-    niko lazaridis
-    Nils Grundmann
-    Nils Wikström
-    Nuno Ribeiro
-    Olav Ro
-    Orta Therox
-    Patrick Hyder
-    Pavel Dolinin
-    Pavlos Michalopoulos
-    Paweł Banach
-    Pawel Koper
-    Peter Uithoven
-    Piotrek Dabrowski
-    pobr1990
-    portugal402
-    qkiel q
-    Rafał Jędruszek
-    Ralph Plawetzki
-    Raphael Schweikert
-    Reinhard Pointner
-    Richard Burleigh
-    Rob White
-    Robert Gorbul
-    Robinson Collado
-    Rodolfo Baeza
-    Rolly Fordham
-    Romain De Filippi
-    Roman Stoffel
-    Ron Yoskovich
-    Ronny Dobra
-    Ross Leonel Miller
-    Sam Morrow
-    Sasan Cooper
-    schuerbel
-    Scott Christoffersen
-    Scott Rothman
-    Serge Specht
-    Sergey Nikulin
-    Seth Storm Rosenaa
-    Simon Buckley
-    Siniša Perović
-    splendor
-    stefan.binder17
-    Stefan Skotte
-    Steffen Riediger
-    Stephan Kochs
-    Swaroop C H
-    Thomas Constantine Moore
-    Thomas Fritz
-    Thomas Lundquist
-    Tobias Kuendig
-    Tobias Lahrmann Hansen
-    Tobias Paar
-    Tomáš Bubeníček
-    Tomislav Capan
-    Tonnis Oosterhoff
-    Travis Jeppson
-    Tuan Anh Nguyen
-    Tyler Brown
-    ukulucas
-    Valentin BONNEAUD
-    Victoria Laux
-    villanueva.giancarlo
-    Vyacheslav Dzyba
-    Wesley Hearn
-    Wesley Moore
-    Weston Smith
-    Will Liou
-    William Dierkes
-    William Fernando Merlotto
-    Yasen Tzvetkov
-    Zack Michener
-    Zhou Fang
-    Zlatko Đurić
-    Zoltan Kochan
-    曾政嘉
+## AppCenter for Everyone (March, 2020)
+
+Thanks again to all of the backers of our [March, 2020 Indiegogo campaign](https://www.indiegogo.com/projects/appcenter-for-everyone)! These individuals chose the $10 "Your Name In Our Source Code" perk (or higher):
+
+- Aaron Honeycutt
+- Aaron Newsome
+- Aaron Tan
+- Abir Mukherjee
+- Adam Balla
+- Adam Miller
+- Ahmed Hamed
+- Alan Diggs
+- Alejandro Morales Lepe
+- Alessandro Castellani
+- Alfonso Amores Villafuerte
+- Alonso Zamorano
+- amalczynski
+- andersonkw2
+- André Barata
+- Andre Mohr
+- Andrea Micheli
+- andreas
+- Andrew Allen
+- Andrew Westaway
+- Anian Ziegler
+- Ankit Sadana
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anonymous Backer
+- Anthony Weathers
+- Antti Impiö
+- Arnaud Durif
+- Ascii Wolf
+- Ashton Snapp
+- Audric Gueidan
+- Avi Romanoff
+- Baboon Outdoors
+- Badry Darkoush
+- Barbara Parry
+- Barnabas Lewis
+- Bartłomiej Piotrowski
+- Benedikt Willi
+- Benjamin Bellamy
+- Benjamin Collet
+- Bernardo Ferrari
+- binternagel
+- Bjarne Kristensen
+- Bobby Moss
+- Boris Mann
+- brejoc
+- Brendan Kirby
+- Brian Battell
+- Brian Bohall
+- Brian Douglass
+- Brian Reading
+- Bryan Paget
+- Bryce Adam Prescott
+- Caio Vitor Hungria
+- cairon
+- Callum
+- Cameron N. Coulter
+- camerontauxe
+- Carlos López
+- Carlos Soutullo
+- cdnbigj
+- Chase Longmore
+- Chau Ngoc Duy Khuong
+- Che Dean
+- Chris Darby
+- Chris Edwards
+- Chris Fisher
+- Christian Schumacher
+- Christoph Uber
+- Christophe Boissonnade
+- Christopher Kaster
+- clarkaddison
+- Clemens Lang
+- Conor Stayt
+- Corbin Davenport
+- Cory DeVore
+- Craig Lovell
+- Craig Luchtefeld
+- crisconru
+- Dan Livingston
+- Dan Mullen
+- Daniel Batsche
+- DANIEL J JAMES
+- Daniel Landau
+- Daniel Patton
+- Daniel Pontoriero
+- Daniel Tauschke
+- Danilo Weber Nunes
+- Danny Roth
+- darrel
+- Darryl Daniel
+- Dave Kretz
+- davemelanson
+- David Dew
+- David Fernengel
+- David Frossard
+- David Kudera
+- David Muller
+- David Thompson
+- David Warburton
+- David. Schroff
+- Dawid Stern
+- dazadlp
+- DebugDave
+- Devin Becker
+- Dileep Sivadas Padmini
+- Dimas Cyriaco
+- Dirk Bauer
+- dlocasci
+- Domenico Lamberti
+- Donald  Ricci
+- Dork Farm GmbH
+- dragonlich
+- Dustin Nguyen
+- Eddie Ehlin
+- Emanuel Francisco Garcia Bautista
+- Emanuel Vitorino
+- en15for
+- Eric Rogers
+- Érico Porto
+- Erik Volkmann
+- etherpulse
+- Fabio Sussarellu
+- Faisal almosbahi
+- Faiyaz Haider
+- Felix Faassen
+- Felix Görner
+- Felix Lehmann
+- Florian Ludwig
+- Florian Stahl
+- Francisco Freitas
+- Fredrik Ekelund
+- Friedrich Petras
+- Gabor Czene
+- Gabriel Sieben
+- Gary Moore
+- Gemeinde Wedemark
+- Gennaro Grieco
+- Georges-Emmanuel Pallud
+- gerardo
+- Geri Vahey
+- gffranco
+- graygoats
+- Greg Hedin
+- Guillaume Deflaux
+- Hans Husurianto
+- Haonan Fang
+- Hedzer Ferwerda
+- Henrik Hemrin
+- Henry Reyna
+- Hugo Lloreda
+- Ian Cleary
+- Ian Jones
+- Igor Rodriguez
+- Ilango Rajagopal
+- indiegogo
+- Irina Ene
+- isak1096
+- Ivo Karadzhov
+- Jack Micklethwaite
+- Jacob Duba
+- Jacques Alexandre Bossu
+- Jalen Heidelburg
+- James Bamkin
+- James Banks
+- James Gordon
+- Jamie Phillips
+- Jan Kočí
+- Jason Jacobs
+- Javier Olguin
+- Jayant Moosad
+- Jean-Luc Barras
+- Jeff Patriarche
+- Jens Walter
+- Jeppe Terndrup
+- Jeremy Pregent
+- Jerry Walraven
+- Jesse Persons
+- Jinke Song
+- Joan Miralles
+- Joel Baxter
+- Jœrg Arnold
+- johanbjare
+- Johannes Langlotz
+- John Been
+- John Beers
+- John Cooper
+- John Ferguson
+- John Joseph Radecki
+- johnnie
+- Jonas Emil Sommer
+- Jonas Zagatta
+- Jonathan Eilerman
+- Jordan Bouëllat
+- Jordan Williams
+- Jorge Benavides Escobillana
+- Jorge Garcia Oncins
+- Jorge Garcia Rodriguez
+- Jos Henson Gric
+- José Luis Rojas Gonzalez
+- Joseph Borg
+- Joshua E. Herron
+- Joshua Phelps
+- Josias D Busiquia
+- JP LeBreton
+- Juan Visbal
+- Juno Computers
+- Justin Lamp
+- Justin Moore
+- Juwan Wheatley
+- Kamran Ahmed Ansari
+- Kellyn Delgado
+- Kenny Stier
+- Keno Sparenborg
+- Kevin Doyle
+- kinphi
+- Konstantin Anoshkin
+- krisgesling
+- Kristoffer Lindstrøm
+- Krzysztof Ferenc
+- Kyle Riedemann
+- Larry Archer
+- Larry Franks
+- Laurent Pointecouteau
+- Lee Armbuster
+- Lee Pfeifer
+- Leo Herzog
+- Leonardo Bertechini Stabile
+- Leszek Szczepański
+- lhanssen
+- Lin Hung-Shin
+- Lior Lobel
+- Logan Fouchet
+- Long Do
+- Luis Barron
+- lukeco11
+- lxmcf20
+- Maksim Kuzmich
+- Maksym Semikin
+- Malte Buettner
+- Malte Schütz
+- Manaurys Suazo
+- Mangirish Wagle
+- Manuel Galli
+- Marc DIJOUX
+- Marcelo Dornelles Hosannah
+- Marco Betschart
+- Marco Bluethgen
+- Marco Marzillier
+- Mario Siqueira
+- Martin Giger
+- Martin Kerz
+- Martin Untersteiner
+- Martin Wimpress
+- Matheus Fantinel
+- Mathew Robinson
+- Matt Lee
+- Matthew
+- Matthew Cowie
+- Matthew Crews
+- Max-Jonathan Luckow
+- mcronen
+- Melf Christiansen
+- Micah Ilbery
+- Michael B Nielsen
+- Michael Hadley
+- Michael Terry
+- Michal Konečný
+- Mikael Carneholm
+- Mikko Majander
+- Mitko Mirevski
+- Mohammed Ismail Ansari
+- Moritz Fiedler
+- Nate Hunzaker
+- Nathan Bland
+- Neal Gompa
+- nealbrophy
+- Nick Melnick
+- Nick Richards
+- Nicola Fantacuzzi
+- Nicolas Stouff
+- Niko Lazaridis
+- Nils Offermann
+- Ole Andreas
+- oliver
+- Orta Therox
+- Patrick Griffis
+- Paul Demers
+- Paul Hibbitts
+- Paul Stephenson III
+- Pavel Dolgov
+- Pavel Dolinin
+- Pedro Rittner
+- Per Bering
+- pesasa
+- Peter Uithoven
+- Peter Vanderfeesten
+- Peter Volf
+- Petr Pech
+- Petr Silon
+- Phil Roggenbuck
+- Philip Roche
+- Phillip Stürzl
+- Pierre Adrien Carton
+- Pierre Fabarius
+- pkulak
+- Platon Bykadorov
+- Praneet Loke
+- Prasad Kumar Manigaradi
+- Quentin Ricci
+- Raj Sardhara
+- Randolph Murdock III
+- Reed Love
+- Rein Bentdal
+- Ricardo Rodrigues
+- Richard Kevin Bennett
+- Riley Trautman
+- Riley Weist
+- Rob Collins
+- Rob Weatherly
+- Robert Gorbul
+- Robin Candau
+- robinsoncollado
+- Rohith Madhavan
+- Roland Hemmer
+- Romain De Filippi
+- Romain Nienajadlo
+- Ross Leonel Miller
+- Ross McLean
+- Ruben J. Jongejan
+- Rubén Manuel Vera Cañal
+- Ryan Kornheisl
+- Ryan McNeely
+- Sam Muirhead
+- Sami Mannila
+- Sampath Rajapakse
+- Sandro Pansa
+- Sayak Biswas
+- Scott Griepentrog
+- Serge Specht
+- Seth Henderson
+- Shaun Kristopher Lamb
+- Shiraaz Lall
+- Shirah Rubin and Bret Ancowitz
+- Simon Buckley
+- sonny
+- Srikanth Pulikanti
+- Stefan Weber
+- Stefano Gorlezza
+- Stephan Müller
+- Stephen Hinton
+- Stuart Still
+- Sudip Chatterjee
+- Swaroop Chirayinkil
+- Tarek Raafat
+- Taufiq Widi Nugroho
+- Taylor Baldwin
+- teledan
+- Thomas Erdt
+- Thomas Haller
+- Thomas Kent
+- Thomas Schuering
+- Tim Bischoff
+- Timothy Byers
+- timz
+- TNG Entertainment
+- Tom Wor
+- Tommy Andrew Creuzer
+- Uncle Steve Fishing AB4EL
+- Vaclav Schneider
+- Vettrivel Viswanathan
+- Vicrant Narayan
+- Victor Kilikaev
+- Vinodh Moodley
+- Volker Thiel
+- Volodimir Biloshicky
+- Vuk Boskovic
+- Wesley McCormick
+- Wesley Payne
+- Will Barnard
+- Willi Mutschler
+- wtleung
+- Xavier Scheuer
+- Xiaoxuan He
+- Yasen Tzvetkov
+- Yash Karmchandani
+- YoonHyung Jo
+- Yunier Nieves
+- 嘉良 郑
+
+## AppCenter: The Pay What You Want App Store (March, 2017)
+
+Thanks again to all of the backers of our [March, 2017 Indiegogo campaign](https://www.indiegogo.com/projects/appcenter-the-pay-what-you-want-app-store)! These individuals chose the $10 "Name in Backers.md" perk (or higher):
+
+- Aaron Dickey
+- Adam Slavík
+- adammakarucha
+- Adarsh Barik
+- Aidan Stewart
+- Alan Salisbury
+- Alex Boutros
+- Alex Gleason
+- Alex Gorshkov
+- Alex Mamaev
+- Alexander Nekrasov
+- Alexander Schäfer
+- Alexandr Jeliuc
+- Allan Stromfeldt Christensen
+- Anastas Dancha
+- Anatoli Natschalow
+- Andre Mohr
+- Andrew Ego
+- Andy Byers
+- Ansel Taft
+- Aspen Digital
+- Aymeric Sorek
+- Ben Davey
+- Ben McClure
+- Benoît Labaere
+- Bill O'Dwyer
+- Boyan Iliev
+- brejoc
+- Brett Biery
+- Brian Douglass
+- Brian Fagioli
+- Brooke
+- Bruguier Nicolas
+- Bryce Call
+- Carlos Ceja Espinosa
+- Carlos Gonzalez Juarez
+- Carmelito Andrade
+- Cato Gaustad
+- Chironjit Das
+- Chris Cowan
+- Chris Harvey
+- Christian Ander
+- Christopher Horton
+- cimm
+- Ciprian Tepes
+- Cody Still
+- conrad sykes
+- contact.mirekm
+- cricel472
+- crisconru
+- daniel.colson99
+- Daniel Germán Cosenza
+- Darshak Parikh
+- David Berg
+- David Capello
+- David Cornejo
+- David Krawiec
+- David Medeiros
+- David Monarres
+- davidak (https://davidak.de/)
+- Dawid Ciulkiewicz
+- deesee04
+- Derek Ekins
+- Dez Blanchfield
+- Dimitar Sirakov
+- Don Duvall
+- Eddy Ahmed
+- el Moussaoui
+- Elias Gabrielsson
+- Eric Nicholls
+- Eric Pritchett
+- Ernestas Kvedaras
+- Eugene Chow
+- Ezra Sharp
+- Fab Trillaud
+- falface
+- Félix Brezo
+- Felix Schröter
+- Fery Wardiyanto
+- Finn M. Schroeder
+- Frank Gregor
+- Fred Lin
+- Fredrik Ekelund
+- Fulvi Igor
+- Gabriel Diosan
+- Gabriele Lippi
+- Gamunu Balagalla
+- Georgi Kasev
+- Giovanni Casisa
+- Goutham D
+- graeter
+- Grant Bourque
+- Grant Ford
+- Gregor Aisch
+- Grisel Yarinda Morales Ortiz
+- Guillaume Bouchard
+- GUILLOIS François-Xavier
+- Henry Pagan
+- Herbert Scheffknecht
+- Ian Cosgrove
+- Isak Holmström
+- ivan
+- Ivo Van Humbeeck
+- Ivo Karadzhov
+- Jakub Hlusička
+- James Feak
+- Jared Schwartz
+- Jeremy Garcia
+- Jeremy Vaartjes
+- Jesse Fisher
+- jf.allie
+- jhnkrklnd
+- Jindrich S.
+- Jod Mangel
+- Joe Petrus
+- Joel Wallis Jucá
+- John Kennedy
+- John Pangalos
+- joke7p
+- jonasmarx
+- Jonathan Reisdorf
+- Jose Martinez
+- Joesph Hager
+- Jörg Arnold
+- Joshua Garrett
+- Jovan Gerodetti
+- Jun Takeda
+- Jung-Kyu Park
+- Jussi Virtanen
+- Kevin Kleinman
+- Kevin Lawrence
+- Kevin Rodríguez
+- Kevin Smith
+- Kjetil Gauslaa
+- Konrad Kruk
+- kwikchek
+- Laurence A Lowe
+- Lee Pfeifer
+- Leo Herzog
+- Ludovic L.
+- Luis Carlos Osorio Jayk
+- Magnus Teekivi
+- mail
+- Manos Parzakonis
+- Manuel del Valle
+- Marc Demierre
+- Marcelo Dornelles Hosannah
+- Marcin L
+- Marco Carrizales
+- Marco Mueller
+- Mark Ridley
+- Martin Hammerschmied
+- Martin Hengst
+- Martin Svoboda
+- Matthew Morek
+- Matthew Perrone
+- Matthias Neid
+- Matthieu CHARTIER GALOU
+- Maurice Achtenhagen
+- Max Engel
+- Maxence Dubois
+- Maxim Taranov
+- Maxime Cornet
+- Mehmet Hanoğlu
+- Michael Devenish
+- Michael Holley
+- Michael Holt
+- Michael Juan Robayo
+- Michael Kanis
+- Michael Rampl
+- Michael Terry
+- Miguel Fontoura
+- Mike Wild
+- Muhammad Fikri
+- Nathan Caza
+- Neal Gompa
+- Nerbiz Dijkstra
+- Neylson de Oliveira Gularte
+- Nicholas La Roux
+- Nick Melnick
+- Niklas Liechti
+- niko lazaridis
+- Nils Grundmann
+- Nils Wikström
+- Nuno Ribeiro
+- Olav Ro
+- Orta Therox
+- Patrick Hyder
+- Pavel Dolinin
+- Pavlos Michalopoulos
+- Paweł Banach
+- Pawel Koper
+- Peter Uithoven
+- Piotrek Dabrowski
+- pobr1990
+- portugal402
+- qkiel q
+- Rafał Jędruszek
+- Ralph Plawetzki
+- Raphael Schweikert
+- Reinhard Pointner
+- Richard Burleigh
+- Rob White
+- Robert Gorbul
+- Robinson Collado
+- Rodolfo Baeza
+- Rolly Fordham
+- Romain De Filippi
+- Roman Stoffel
+- Ron Yoskovich
+- Ronny Dobra
+- Ross Leonel Miller
+- Sam Morrow
+- Sasan Cooper
+- schuerbel
+- Scott Christoffersen
+- Scott Rothman
+- Serge Specht
+- Sergey Nikulin
+- Seth Storm Rosenaa
+- Simon Buckley
+- Siniša Perović
+- splendor
+- stefan.binder17
+- Stefan Skotte
+- Steffen Riediger
+- Stephan Kochs
+- Swaroop C H
+- Thomas Constantine Moore
+- Thomas Fritz
+- Thomas Lundquist
+- Tobias Kuendig
+- Tobias Lahrmann Hansen
+- Tobias Paar
+- Tomáš Bubeníček
+- Tomislav Capan
+- Tonnis Oosterhoff
+- Travis Jeppson
+- Tuan Anh Nguyen
+- Tyler Brown
+- ukulucas
+- Valentin BONNEAUD
+- Victoria Laux
+- villanueva.giancarlo
+- Vyacheslav Dzyba
+- Wesley Hearn
+- Wesley Moore
+- Weston Smith
+- Will Liou
+- William Dierkes
+- William Fernando Merlotto
+- Yasen Tzvetkov
+- Zack Michener
+- Zhou Fang
+- Zlatko Đurić
+- Zoltan Kochan
+- 曾政嘉


### PR DESCRIPTION
Also made it a bulleted list instead of code style. "Anonymous Backer" is someone who chose to back at a "Name in Source Code" level, but chose to keep their contribution anonymous. We'll want to get their permission before exposing their names.