### PR TITLE
arrow.css: Don't hardcode arrow color

### DIFF
--- a/data/styles/arrow.css
+++ b/data/styles/arrow.css
@@ -26,7 +26,7 @@
         0 1px 2px rgba(0,0,0,0.24);
     margin: 6px;
     padding: 6px;
-    color: @textColorPrimary;
+    color: @text_color;
 }
 
 .arrow:active,

--- a/data/styles/arrow.css
+++ b/data/styles/arrow.css
@@ -26,7 +26,7 @@
         0 1px 2px rgba(0,0,0,0.24);
     margin: 6px;
     padding: 6px;
-    color: #333;
+    color: @textColorPrimary;
 }
 
 .arrow:active,


### PR DESCRIPTION
Instead, use `@textColorPrimary` so it remains contrasty with the `@base_color`. Fixes unreadable arrows when using a dark style.