### PR TITLE
Inhibit suspend during all package operations

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -20,6 +20,7 @@
         <p>Fixes</p>
         <ul>
           <li>Prevent crashes when updating Flatpaks and system packages simultaneously</li>
+          <li>Prevent suspending when installing, updating, or removing packages</li>
         </ul>
       </description>
     </release>

--- a/src/Core/BackendAggregator.vala
+++ b/src/Core/BackendAggregator.vala
@@ -39,11 +39,16 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
 
                     SuspendControl.get_default ().inhibit ();
                 } else {
-                    remove_inhibit_timeout = Timeout.add_seconds (5, () => {
-                        SuspendControl.get_default ().uninhibit ();
+                    // Wait for 5 seconds of inactivity before uninhibiting as we may be
+                    // rapidly switching between working states on different backends etc...
+                    if (remove_inhibit_timeout == 0) {
+                        remove_inhibit_timeout = Timeout.add_seconds (5, () => {
+                            SuspendControl.get_default ().uninhibit ();
+                            remove_inhibit_timeout = 0;
 
-                        return false;
-                    });
+                            return false;
+                        });
+                    }
                 }
 
                 notify_property ("working");

--- a/src/Core/BackendAggregator.vala
+++ b/src/Core/BackendAggregator.vala
@@ -21,6 +21,7 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
     public signal void cache_flush_needed ();
 
     private Gee.ArrayList<unowned Backend> backends;
+    private uint remove_inhibit_timeout = 0;
 
     construct {
         backends = new Gee.ArrayList<unowned Backend> ();
@@ -30,6 +31,21 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
 
         foreach (var backend in backends) {
             backend.notify["working"].connect (() => {
+                if (working) {
+                    if (remove_inhibit_timeout != 0) {
+                        Source.remove (remove_inhibit_timeout);
+                        remove_inhibit_timeout = 0;
+                    }
+
+                    SuspendControl.get_default ().inhibit ();
+                } else {
+                    remove_inhibit_timeout = Timeout.add_seconds (5, () => {
+                        SuspendControl.get_default ().uninhibit ();
+
+                        return false;
+                    });
+                }
+
                 notify_property ("working");
             });
         }

--- a/src/SuspendControl.vala
+++ b/src/SuspendControl.vala
@@ -55,7 +55,7 @@ public class SuspendControl {
     public bool inhibit () {
         if (inhibited == false && supported) {
             try {
-                inhibit_cookie = sm.inhibit ("org.richardfairthorne.SuspendControl", 0, "Inhibit suspend during update", 4);
+                inhibit_cookie = sm.inhibit ("io.elementary.appcenter", 0, "Inhibit suspend during package operations", 4);
                 inhibited = true;
             } catch (GLib.Error e) {
                 critical (e.message);

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -243,9 +243,6 @@ namespace AppCenter.Views {
 
             // Update all updateable apps
             if (apps_to_update.size > 0) {
-                // Prevent computer from sleeping while updating apps
-                SuspendControl.get_default ().inhibit ();
-
                 first_package = apps_to_update[0];
                 first_package.info_changed.connect_after (after_first_package_info_changed);
                 first_package.update.begin (() => {
@@ -299,7 +296,6 @@ namespace AppCenter.Views {
             assert (updating_all_apps && packages_changing == 0);
 
             updating_all_apps = false;
-            SuspendControl.get_default ().uninhibit ();
 
             /* Set the action button sensitive and emit "changed" on each row in order to update
              * the sort order and headers (any change would have been ignored while updating) */


### PR DESCRIPTION
Fixes #1253 

The backends can transition rapidly from working to not working between operations, so we wait for 5 seconds of no activity before removing the inhibitor.

Also fix the app ID while we're here.