### PR TITLE
Release 3.2.4

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -15,11 +15,12 @@
     </p>
   </description>
   <releases>
-    <release version="3.2.4" date="2020-04-25" urgency="medium">
+    <release version="3.2.4" date="2020-04-08" urgency="medium">
       <description>
         <p>Fixes</p>
         <ul>
           <li>Prevent crashes when updating Flatpaks and system packages simultaneously</li>
+          <li>Updated translations</li>
         </ul>
       </description>
     </release>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'io.elementary.appcenter',
     'vala', 'c',
-    version: '3.2.3'
+    version: '3.2.4'
 )
 
 gettext_name = meson.project_name()


### PR DESCRIPTION
https://github.com/elementary/appcenter/compare/3.2.3...release-3.2.4

I know this was recently released, but this fixes a super annoying crash when installing updates.

User-facing:
- Prevent crashes when updating Flatpaks and system packages simultaneously (#1246)
- Prevent suspending when installing, updating, or removing packages (#1255)
- Updated translations

Also adds debugging to further clean up the Updates tab (#1252)