### PR TITLE
PackageKitBackend: Tell PackageKit about any system proxy config

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -19,7 +19,7 @@
       <description>
         <p>Fixes</p>
         <ul>
-          <li>AppCenter now uses configured network proxy settings</li>
+          <li>AppCenter now uses configured network proxy settings for apt operations</li>
         </ul>
       </description>
     </release>

--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -15,6 +15,14 @@
     </p>
   </description>
   <releases>
+    <release version="3.2.5" date="2020-04-28" urgency="medium">
+      <description>
+        <p>Fixes</p>
+        <ul>
+          <li>AppCenter now uses configured network proxy settings</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.2.4" date="2020-04-08" urgency="medium">
       <description>
         <p>Fixes</p>


### PR DESCRIPTION
Fixes #508 

Even if you manage to set your proxy settings in dconf using the switchboard plug, set up `http_proxy` and `ftp_proxy` environment variables, remember to modify apt's config files to include the proxy, AppCenter still can't do any PackageKit operations behind a proxy.

This is because PackageKit does its own proxy handling and you can manually configure it in yet another config file, but we can get AppCenter to use GLib's proxy resolver which reads from the dconf keys setup by the switchboard plug and pass any relevant proxy config to PackageKit.