### PR TITLE
AppInfoView: allow opening plugins

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -20,6 +20,7 @@
         <p>Fixes</p>
         <ul>
           <li>AppCenter no longer prompts for approval to update non-curated apps</li>
+          <li>Clicking an extension on an app's info page now shows details for the extension</li>
         </ul>
       </description>
     </release>

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -259,7 +259,13 @@ namespace AppCenter.Views {
 
             if (package_component.get_addons ().length > 0) {
                 extension_box = new Gtk.ListBox ();
-                extension_box.selection_mode = Gtk.SelectionMode.NONE;
+                extension_box.selection_mode = Gtk.SelectionMode.SINGLE;
+                extension_box.row_activated.connect ((row) => {
+                    var extension_row = row as Widgets.PackageRow;
+                    if (extension_row != null) {
+                        show_other_package (extension_row.get_package (), true, Gtk.StackTransitionType.SLIDE_LEFT_RIGHT);
+                    }
+                });
 
                 var extension_label = new Gtk.Label (_("Extensions:"));
                 extension_label.margin_top = 12;


### PR DESCRIPTION
Currently clicking on a plugin on an app info view does nothing. Now we browse to the app info view for that plugin.

This is quite slow for switchboard plugs due to them not having a description field in the appdata and us falling back to fetching that information from packagekit when it's not available from appstream.