### PR TITLE
AppInfoView: load description async

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -20,6 +20,7 @@
         <p>Fixes</p>
         <ul>
           <li>AppCenter no longer prompts for approval to update non-curated apps</li>
+          <li>Reduce slowdowns when opening certain apps</li>
         </ul>
       </description>
     </release>

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -744,7 +744,14 @@ namespace AppCenter.Views {
                     for (int i = 1; i < lines.length; i++) {
                         stripped_description += " " + lines[i].strip ();
                     }
-                    app_description.buffer.text = AppStream.markup_convert_simple (stripped_description);
+
+                    // This method may be called in a thread, pass back to GTK thread
+                    Idle.add (() => {
+                        app_description.buffer.text = AppStream.markup_convert_simple (stripped_description);
+
+                        return false;
+                    });
+
                 } catch (Error e) {
                     critical (e.message);
                 }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -497,7 +497,6 @@ namespace AppCenter.Views {
 #endif
             view_entered ();
             set_up_package (128);
-            parse_description (package.get_description ());
 
             if (package.is_os_updates) {
                 package.notify["state"].connect (() => {
@@ -611,6 +610,8 @@ namespace AppCenter.Views {
                 if (package.is_os_updates) {
                     package_author.label = package.get_version ();
                 }
+
+                parse_description (package.get_description ());
 
                 get_app_download_size.begin ();
 


### PR DESCRIPTION
I've noticed that if a given package doesn't have a description set in appdata (Switchboard plugs seem to be a good example) we fall back to loading this from the backend. For packages that come from PackageKit, this is pretty slow (especially if we're refreshing updates too). 

This was causing a hang when clicking on these apps. But if we move this into the `load_more_content` method, we get to the page instantly and then that data pops in afterwards.