### PR TITLE
PackageKitBackend: only refresh PK cache on changes

### DIFF
--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -195,7 +195,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
             var time_since_last_action = (new DateTime.now_local ()).difference (last_action) / GLib.TimeSpan.MILLISECOND;
             if (time_since_last_action >= PACKAGEKIT_ACTIVITY_TIMEOUT_MS) {
                 info ("packages possibly changed by external program, refreshing cache");
-                Client.get_default ().update_cache.begin (true);
+                refresh_cache.begin (null);
             }
         }
     }


### PR DESCRIPTION
The `Client` class talks to all backends, including Flatpak. When things change in PackageKit, we only want to refresh our PackageKit cache, not our flatpak cache too.