### PR TITLE
Prevent the daemon refreshing on every startup

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -19,6 +19,7 @@
       <description>
         <p>Fixes</p>
         <ul>
+          <li>Only check for updates at computer startup if it's more than 24 hours since we last checked</li>
           <li>AppCenter now uses configured network proxy settings for apt operations</li>
           <li>AppCenter no longer prompts for approval to update non-curated apps</li>
           <li>Clicking an extension on an app's info page now shows details for the extension</li>

--- a/data/io.elementary.appcenter.gschema.xml
+++ b/data/io.elementary.appcenter.gschema.xml
@@ -36,5 +36,10 @@
       <summary>Display warning for non-curated apps</summary>
       <description>Whether to display a warning dialog when attempting to install apps are not from a curated source</description>
     </key>
+    <key type="x" name="last-refresh-time">
+      <default>0</default>
+      <summary>Unix UTC time of last cache refresh</summary>
+      <description>Used to determine when AppCenter last refreshed its caches and checked for package updates</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -153,7 +153,8 @@ public class AppCenter.App : Gtk.Application {
                 schedule_cache_update (!available);
             });
 
-            client.update_cache.begin (true);
+            // Don't force a cache refresh for the silent daemon, it'll run if it was >24 hours since the last one
+            client.update_cache.begin (false);
             silent = false;
             hold ();
             return;
@@ -172,12 +173,14 @@ public class AppCenter.App : Gtk.Application {
         if (main_window == null) {
             main_window = new MainWindow (this);
 
+
+            // Force a cache refresh when the window opens, so we get new apps
 #if HOMEPAGE
             main_window.homepage_loaded.connect (() => {
-                client.update_cache.begin ();
+                client.update_cache.begin (true);
             });
 #else
-            client.update_cache.begin ();
+            client.update_cache.begin (true);
 #endif
 
             main_window.destroy.connect (() => {

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -23,8 +23,6 @@ public class AppCenterCore.Client : Object {
      */
     public signal void installed_apps_changed ();
 
-    public bool updating_cache { public get; private set; default = false; }
-
     public AppCenterCore.ScreenshotCache? screenshot_cache { get; construct; }
 
     private GLib.Cancellable cancellable;
@@ -43,6 +41,8 @@ public class AppCenterCore.Client : Object {
 
     construct {
         cancellable = new GLib.Cancellable ();
+
+        last_cache_update = new DateTime.from_unix_utc (AppCenter.App.settings.get_int64 ("last-refresh-time"));
     }
 
     public async Gee.Collection<AppCenterCore.Package> get_installed_applications (Cancellable? cancellable = null) {
@@ -105,14 +105,12 @@ public class AppCenterCore.Client : Object {
         if (update_cache_timeout_id > 0 && cancel_timeout) {
             Source.remove (update_cache_timeout_id);
             update_cache_timeout_id = 0;
-            last_cache_update = null;
         }
-
-        cancellable = new GLib.Cancellable ();
-        refresh_in_progress = false;
     }
 
     public async void update_cache (bool force = false) {
+        cancellable.reset ();
+
         debug ("update cache called %s", force.to_string ());
         bool success = false;
 
@@ -129,52 +127,48 @@ public class AppCenterCore.Client : Object {
                 update_cache_timeout_id = 0;
             } else {
                 debug ("Refresh timeout running and not forced - returning");
-                refresh_in_progress = false;
                 return;
             }
         }
 
+        var nm = NetworkMonitor.get_default ();
+
         /* One cache update a day, keeps the doctor away! */
-        if (force || last_cache_update == null ||
-            (new DateTime.now_local ()).difference (last_cache_update) / GLib.TimeSpan.SECOND >= SECONDS_BETWEEN_REFRESHES) {
-            var nm = NetworkMonitor.get_default ();
+        var seconds_since_last_refresh = new DateTime.now_utc ().difference (last_cache_update) / GLib.TimeSpan.SECOND;
+        if (force || seconds_since_last_refresh >= SECONDS_BETWEEN_REFRESHES) {
             if (nm.get_network_available ()) {
                 debug ("New refresh task");
 
                 refresh_in_progress = true;
-                updating_cache = true;
                 try {
                     success = yield PackageKitBackend.get_default ().refresh_cache (cancellable);
                     yield FlatpakBackend.get_default ().refresh_cache (cancellable);
-                    last_cache_update = new DateTime.now_local ();
+                    last_cache_update = new DateTime.now_utc ();
+                    seconds_since_last_refresh = 0;
+                    AppCenter.App.settings.set_int64 ("last-refresh-time", last_cache_update.to_unix ());
                 } catch (Error e) {
-                    refresh_in_progress = false;
-                    updating_cache = false;
-
                     critical ("Update_cache: Refesh cache async failed - %s", e.message);
                     cache_update_failed (e);
-                }
-
-                if (success) {
-                    refresh_updates.begin ();
+                } finally {
+                    refresh_in_progress = false;
                 }
             }
-
-            refresh_in_progress = false; //Stops new timeout while no network.
-            updating_cache = false;
         } else {
             debug ("Too soon to refresh and not forced");
         }
 
-        if (refresh_in_progress) {
-            update_cache_timeout_id = GLib.Timeout.add_seconds (SECONDS_BETWEEN_REFRESHES, () => {
-                update_cache_timeout_id = 0;
-                update_cache.begin (true);
-                return GLib.Source.REMOVE;
-            });
+        if (nm.get_network_available ()) {
+            refresh_updates.begin ();
+        }
 
-            refresh_in_progress = success;
-        } // Otherwise updates and timeout were cancelled during refresh, or no network present.
+        var next_refresh = SECONDS_BETWEEN_REFRESHES - (uint)seconds_since_last_refresh;
+        debug ("Setting a timeout for a refresh in %f minutes", next_refresh / 60.0f);
+        update_cache_timeout_id = GLib.Timeout.add_seconds (next_refresh, () => {
+            update_cache_timeout_id = 0;
+            update_cache.begin (true);
+
+            return GLib.Source.REMOVE;
+        });
     }
 
     public Package? get_package_for_component_id (string id) {


### PR DESCRIPTION
Store the last refresh time in GSettings and only refresh the cache if it's been >24 hours since the last refresh. Opening the window still forces a refresh of the cache, but now at least if you start your computer multiple times in a 24 hour window, AppCenter isn't doing a cache refresh every time.

We still notify that updates are available on startup without refreshing the cache if there are some leftover from the last cache update.

I removed an unused `updating_cache` property while I was here and cleaned up some of the overly complicated setting of `refresh_in_progress`

Finally, I've ensured the next refresh gets scheduled from 24 hours after the last refresh, rather than 24 hours from when AppCenter started. Meaning if your computer starts 23 hours after the last cache refresh, AppCenter will run the next cache update in an hour and notify of any new updates.