### PR TITLE
AppData: Organize 3.2.5 release notes

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -19,7 +19,7 @@
       <description>
         <p>Performance improvements</p>
         <ul>
-          <li>Only check for updates at computer startup if it's more than 24 hours since we last checked</li>
+          <li>Only check for updates at device startup if it's more than 24 hours since we last checked</li>
           <li>Reduce slowdowns when opening certain apps</li>
         </ul>
         <p>Extension improvements</p>

--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -17,22 +17,32 @@
   <releases>
     <release version="3.2.5" date="2020-04-16" urgency="medium">
       <description>
-        <p>Fixes</p>
-        <ul>
-          <li>AppCenter now uses configured network proxy settings for apt operations</li>
-          <li>AppCenter no longer prompts for approval to update non-curated apps</li>
-          <li>Reduce slowdowns when opening certain apps</li>
-          <li>Ensure the OS updates subheading copy is correct after finishing updates</li>
-          <li>Show a more informative loading screen when checking for updates</li>
-        </ul>
-        <p>Other updates</p>
+        <p>Performance improvements</p>
         <ul>
           <li>Only check for updates at computer startup if it's more than 24 hours since we last checked</li>
-          <li>Pressing down in the search field moves the keyboard focus to the search results list</li>
+          <li>Reduce slowdowns when opening certain apps</li>
+        </ul>
+        <p>Extension improvements</p>
+        <ul>
+          <li>To de-clutter the updates view, extensions are now only shown if they require updates</li>
           <li>Clicking an extension on an app's info page now shows details for the extension</li>
+          <li>Swap the main and overlay icons for extensions to more clearly associate extensions with their app</li>
+        </ul>
+        <p>Keyboard improvements</p>
+        <ul>
+          <li>Pressing down in the search field moves the keyboard focus to the search results list</li>
           <li>Ctrl+F now moves the cursor to the search field</li>
-          <li>To de-clutter the updates view, plugins are now only shown if they require updates</li>
-          <li>Swapped the main and overlay icons for plugins to more clearly associate plugins with their app</li>
+        </ul>
+        <p>Fixes</p>
+        <ul>
+          <li>Use configured network proxy settings for apt operations</li>
+          <li>No longer prompt for approval to update non-curated apps</li>
+          <li>Ensure the OS updates subheading copy is correct after finishing updates</li>
+        </ul>
+        <p>And more</p>
+        <ul>
+          <li>Show a more informative loading screen when checking for updates</li>
+          <li>Updated translations</li>
         </ul>
       </description>
     </release>


### PR DESCRIPTION
It was getting a bit unwieldy. 

- Categorize them under performance, extensions, keyboard, fixes, and more
- Consistently use "extension" instead of plugin (since that's what it says in the UI)
- "computer" → "device"

How it looks in AppCenter:

![Screenshot from 2020-04-20 11 20 09](https://user-images.githubusercontent.com/611168/79780313-f14bd300-82f8-11ea-8a65-05707151ef90.png)

