### PR TITLE
Hide fonts unless they need an update

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -192,6 +192,12 @@ public class AppCenterCore.Package : Object {
        }
     }
 
+    public bool is_font {
+        get {
+            return component.get_kind () == AppStream.ComponentKind.FONT;
+        }
+    }
+
     public bool is_local {
         get {
             return component.get_id ().has_suffix (LOCAL_ID_SUFFIX);

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -90,8 +90,10 @@ namespace AppCenter.Views {
         }
 
         private void add_row_for_package (AppCenterCore.Package package) {
-            // Only add row if this isn't a plugin, or it's a plugin needing an update
-            if (!package.is_plugin || (package.is_plugin && package.state == AppCenterCore.Package.State.UPDATE_AVAILABLE)) {
+            var needs_update = package.state == AppCenterCore.Package.State.UPDATE_AVAILABLE;
+
+            // Only add row if this package needs an update or it's not a font or plugin
+            if (needs_update || (!package.is_plugin && !package.is_font)) {
                 var row = construct_row_for_package (package);
                 add_row (row);
             }

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -58,8 +58,8 @@ namespace AppCenter.Views {
         }
 
         private void add_row_for_package (AppCenterCore.Package package) {
-            // Don't show plugins in search and category views
-            if (!package.is_plugin) {
+            // Don't show plugins or fonts in search and category views
+            if (!package.is_plugin && !package.is_font) {
                 list_store.insert_sorted (package, (GLib.CompareDataFunc<AppCenterCore.Package>) compare_packages);
             }
         }


### PR DESCRIPTION
Fixes #1275 

Hide them from category and search views and only show them in the installed/updates view if they need an update.