### PR TITLE
Improve installation failure dialog

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -18,6 +18,7 @@ src/Core/Task.vala
 src/Core/UbuntuDriversBackend.vala
 src/Core/UpdateManager.vala
 src/Dialogs/ContentWarningDialog.vala
+src/Dialogs/InstallFailDialog.vala
 src/Dialogs/NonCuratedWarningDialog.vala
 src/Dialogs/RestartDialog.vala
 src/Dialogs/StripeDialog.vala

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -281,12 +281,8 @@ public class AppCenter.App : Gtk.Application {
                         break;
                     }
 
-                    var dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                        _("There Was An Error Installing %s.").printf (package.get_name ()),
-                        format_error_message (error.message),
-                        "dialog-error",
-                        Gtk.ButtonsType.CLOSE
-                    );
+                    var dialog = new InstallFailDialog (package, error);
+
                     dialog.show_all ();
                     dialog.run ();
                     dialog.destroy ();

--- a/src/Dialogs/InstallFailDialog.vala
+++ b/src/Dialogs/InstallFailDialog.vala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class InstallFailDialog : Granite.MessageDialog {
+    public AppCenterCore.Package? package { get; construct; }
+    public Error error { get; construct; }
+    private const string FALLBACK_ICON = "application-default-icon";
+
+    public InstallFailDialog (AppCenterCore.Package? package, Error error) {
+        Object (
+            title: "",
+            secondary_text: _("This may be a temporary issue or could have been caused by external or manually compiled software."),
+            buttons: Gtk.ButtonsType.CLOSE,
+            badge_icon: new ThemedIcon ("dialog-error"),
+            window_position: Gtk.WindowPosition.CENTER,
+            error: error,
+            package: package
+        );
+    }
+
+    construct {
+        if (package == null) {
+            primary_text = _("Failed to install app");
+            image_icon = new ThemedIcon (FALLBACK_ICON);
+        } else {
+            primary_text = _("Failed to install “%s”").printf (package.get_name ());
+            image_icon = package.get_icon (48, get_scale_factor ());
+        }
+
+        response.connect (() => destroy ());
+
+        show_error_details (error.message);
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ appcenter_files = files(
     'Core/UbuntuDriversBackend.vala',
     'Core/UpdateManager.vala',
     'Dialogs/ContentWarningDialog.vala',
+    'Dialogs/InstallFailDialog.vala',
     'Dialogs/NonCuratedWarningDialog.vala',
     'Dialogs/RestartDialog.vala',
     'Dialogs/StripeDialog.vala',


### PR DESCRIPTION
Replace the dialog that appears when an app fails to install that looks like this:

![](https://user-images.githubusercontent.com/63694847/80049147-73fbaa80-8512-11ea-9b22-4d4f98ac65d3.png)

With one that looks like this:

![image](https://user-images.githubusercontent.com/3372394/80143018-ac939680-859b-11ea-8251-f5863a852b15.png)

