### PR TITLE
Refresh state after marking package installed

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -111,6 +111,7 @@ public class AppCenterCore.Package : Object {
 
     public void mark_installed () {
         installed_cached = true;
+        update_state ();
     }
 
     public bool update_available {


### PR DESCRIPTION
Fixes a minor regression noticed since the recent performance improvements. While AppCenter is initially starting up, if you're looking at the installed tab, you briefly see that some of these apps have a "Free"/"Install" button until loaded fully.

Since we know these apps are installed, we need to make sure that state is consistent while loading.