### PR TITLE
Cache Houston API results to GSettings

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -11,6 +11,14 @@
     <p>An app store for indie and open source developers. Browse by categories or search and discover new apps. AppCenter is also used for updating your system to the latest and greatest version for new features and fixes.</p>
   </description>
   <releases>
+    <release version="3.3.1" date="2020-04-29" urgency="medium">
+      <description>
+        <p>Minor updates</p>
+        <ul>
+          <li>Ensure apps on the homepage are more reliably displayed</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.3.0" date="2020-04-29" urgency="medium">
       <description>
         <p>Performance improvements</p>

--- a/data/io.elementary.appcenter.gschema.xml
+++ b/data/io.elementary.appcenter.gschema.xml
@@ -47,4 +47,11 @@
       <description>Used to determine when AppCenter last refreshed its caches and checked for package updates</description>
     </key>
   </schema>
+  <schema path="/io/elementary/appcenter/caches/" id="io.elementary.appcenter.caches">
+    <key type="a{sas}" name="api-caches">
+      <default>{'/newest/project':[],'/newest/release':[],'/newest/downloads':[]}</default>
+      <summary>A dictionary of arrays of app IDs cached per API endpoint</summary>
+      <description>Updated automatically by AppCenter with the most recent successful API calls. Used as a backup when Houston is experiencing issues.</description>
+    </key>
+  </schema>
 </schemalist>

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ conf_data.set('BLACKLIST', get_option('blacklist_file'))
 conf_data.set('VERSION', meson.project_version())
 conf_data.set('CONFIGDIR', config_dir)
 conf_data.set('EXEC_PATH', join_paths (get_option('prefix'), get_option('bindir'), meson.project_name()))
+conf_data.set('HOUSTON_API_URL', get_option('api_url'))
 
 subdir('data')
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,4 +5,4 @@ option('icon', type : 'string', value : 'system-software-install', description :
 option('name', type : 'string', value : 'AppCenter', description : 'The name of the application')
 option('payments', type : 'boolean', value : true, description : 'Enable payment features and display paid apps')
 option('sharing', type : 'boolean', value : true, description : 'Display sharing features, i.e. copyable URLs to apps')
-
+option('api_url', type : 'string', value : 'https://developer.elementary.io/api', description : 'The base URL of the API to get app lists for the homepage banners')

--- a/src/Core/Houston.vala
+++ b/src/Core/Houston.vala
@@ -86,7 +86,7 @@ public class AppCenterCore.Houston : Object {
                         // Get the dict key of this existing item
                         existing_item.@get ("{sas}", out key, null);
 
-                        // Don't add this item to the new dict if its the one we're replacing
+                        // Copy existing items to new dict, unless this is the item we're updating
                         if (key != endpoint) {
                             dict_builder.add_value (existing_item);
                         }

--- a/src/Core/Houston.vala
+++ b/src/Core/Houston.vala
@@ -66,9 +66,13 @@ public class AppCenterCore.Houston : Object {
                 if (res.has_member ("data")) {
                     var data = res.get_array_member ("data");
 
-                    var arr_builder = new VariantBuilder (new VariantType ("as"));
-                    foreach (var id in data.get_elements ()) {
-                        var val = (string)id.get_value ();
+                    var arr_builder = new VariantBuilder (GLib.VariantType.STRING_ARRAY);
+                    foreach (unowned Json.Node id in data.get_elements ()) {
+                        unowned string? val = id.get_string ();
+                        if (val == null) {
+                            continue;
+                        }
+
                         arr_builder.add ("s", val);
                         app_ids += val;
                     }
@@ -104,7 +108,7 @@ public class AppCenterCore.Houston : Object {
 
                 var caches = caches_store.get_value ("api-caches");
                 // Get the array of app IDs corresponding to this API endpoint from the dictionary
-                var cached_ids = caches.lookup_value (endpoint, new VariantType ("as"));
+                var cached_ids = caches.lookup_value (endpoint, GLib.VariantType.STRING_ARRAY);
 
                 if (cached_ids != null) {
                     app_ids = cached_ids.get_strv ();

--- a/src/Core/Houston.vala
+++ b/src/Core/Houston.vala
@@ -17,9 +17,13 @@
 */
 
 public class AppCenterCore.Houston : Object {
-    private const string HOUSTON_API_URL = "https://developer.elementary.io/api";
-
     private Soup.Session session;
+
+    private static GLib.Settings caches_store;
+
+    static construct {
+        caches_store = new GLib.Settings ("io.elementary.appcenter.caches");
+    }
 
     construct {
         session = new Soup.Session ();
@@ -50,7 +54,7 @@ public class AppCenterCore.Houston : Object {
     }
 
     public async string[] get_app_ids (string endpoint) {
-        var uri = HOUSTON_API_URL + endpoint;
+        var uri = Build.HOUSTON_API_URL + endpoint;
         string[] app_ids = {};
 
         debug ("Requesting newest applications from %s", uri);
@@ -62,12 +66,49 @@ public class AppCenterCore.Houston : Object {
                 if (res.has_member ("data")) {
                     var data = res.get_array_member ("data");
 
+                    var arr_builder = new VariantBuilder (new VariantType ("as"));
                     foreach (var id in data.get_elements ()) {
-                        app_ids += ((string) id.get_value ());
+                        var val = (string)id.get_value ();
+                        arr_builder.add ("s", val);
+                        app_ids += val;
                     }
+
+                    var caches = caches_store.get_value ("api-caches");
+
+                    var dict_builder = new VariantBuilder (new VariantType ("a{sas}"));
+
+                    // Iterate over the caches already in the GSetting
+                    var iter = caches.iterator ();
+                    Variant? existing_item = iter.next_value ();
+                    while (existing_item != null) {
+                        string? key = null;
+
+                        // Get the dict key of this existing item
+                        existing_item.@get ("{sas}", out key, null);
+
+                        // Don't add this item to the new dict if its the one we're replacing
+                        if (key != endpoint) {
+                            dict_builder.add_value (existing_item);
+                        }
+
+                        existing_item = iter.next_value ();
+                    }
+
+                    // Add the new list of apps to the cache dict
+                    dict_builder.add ("{sas}", endpoint, arr_builder);
+
+                    caches_store.set_value ("api-caches", dict_builder.end ());
                 }
             } catch (Error e) {
                 warning ("Houston: %s", e.message);
+
+                var caches = caches_store.get_value ("api-caches");
+                // Get the array of app IDs corresponding to this API endpoint from the dictionary
+                var cached_ids = caches.lookup_value (endpoint, new VariantType ("as"));
+
+                if (cached_ids != null) {
+                    app_ids = cached_ids.get_strv ();
+                }
             }
 
             Idle.add (get_app_ids.callback);

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -5,4 +5,5 @@ namespace Build {
     public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
     public const string PROJECT_NAME = "@PROJECT_NAME@";
     public const string VERSION = "@VERSION@";
+    public const string HOUSTON_API_URL = "@HOUSTON_API_URL@";
 }


### PR DESCRIPTION
Fixes #476
Fixes #210 

Make the API base URL configurable via meson so this can be changed in packaging by downstreams (like System76) if desired.

On a successful fetch of app lists from the API, store the result in GSettings so if we have any subsequent failures, we can use the cached list instead.

I've opted to use a GSettings dictionary rather than specific settings for e.g. most downloaded, most recent. The key used in the dictionary is the API endpoint path, so again if these are changed downstream, the caching will still work.

I've put some blank dictionary entries in the default field of the schema file so there's an example of the syntax that will help downstreams write a list of apps in here manually if they wish.

Edit: As another note, it would have been simpler in terms of code to use a `VariantDict` here, but it only supports the `a{sv}` Variant type, rather than `a{sas}`. The former is a lot harder to write a `<default>` key for by hand as you need to use `<` `>` characters in the XML.