### PR TITLE
Various update badge fixes

### DIFF
--- a/po/extra/tr.po
+++ b/po/extra/tr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-04-30 22:00+0000\n"
-"PO-Revision-Date: 2020-04-30 21:59+0000\n"
+"PO-Revision-Date: 2020-05-03 21:10+0000\n"
 "Last-Translator: Ozgur Baskin <bebeto_baskin@yahoo.com>\n"
 "Language-Team: Turkish <https://l10n.elementary.io/projects/appcenter/extra/"
 "tr/>\n"
@@ -419,7 +419,9 @@ msgstr "@DESKTOP_ICON@"
 
 #: data/io.elementary.appcenter.desktop.in.in:7
 msgid "install;uninstall;remove;catalogue;store;apps;software;"
-msgstr "yükle;kaldır;sil;katalog;mağaza;uygulamalar;yazılım;"
+msgstr ""
+"yükle;kaldır;sil;katalog;mağaza;uygulamalar;yazılım;install;uninstall;remove;"
+"catalogue;store;apps;software;"
 
 #: data/io.elementary.appcenter.desktop.in.in:18
 msgid "Check for Updates"

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -78,7 +78,6 @@ public class AppCenter.App : Gtk.Application {
         var client = AppCenterCore.Client.get_default ();
         client.operation_finished.connect (on_operation_finished);
         client.cache_update_failed.connect (on_cache_update_failed);
-        client.installed_apps_changed.connect (on_updates_available);
 
         if (AppInfo.get_default_for_uri_scheme ("appstream") == null) {
             var appinfo = new DesktopAppInfo (application_id + ".desktop");
@@ -292,17 +291,6 @@ public class AppCenter.App : Gtk.Application {
             default:
                 break;
         }
-    }
-
-    public void on_updates_available () {
-        var client = AppCenterCore.Client.get_default ();
-        Idle.add (() => {
-            if (main_window != null) {
-                main_window.show_update_badge (client.updates_number);
-            }
-
-            return GLib.Source.REMOVE;
-        });
     }
 
     private void on_cache_update_failed (Error error) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -78,6 +78,7 @@ public class AppCenter.App : Gtk.Application {
         var client = AppCenterCore.Client.get_default ();
         client.operation_finished.connect (on_operation_finished);
         client.cache_update_failed.connect (on_cache_update_failed);
+        client.installed_apps_changed.connect (on_updates_available);
 
         if (AppInfo.get_default_for_uri_scheme ("appstream") == null) {
             var appinfo = new DesktopAppInfo (application_id + ".desktop");
@@ -291,6 +292,17 @@ public class AppCenter.App : Gtk.Application {
             default:
                 break;
         }
+    }
+
+    public void on_updates_available () {
+        var client = AppCenterCore.Client.get_default ();
+        Idle.add (() => {
+            if (main_window != null) {
+                main_window.show_update_badge (client.updates_number);
+            }
+
+            return GLib.Source.REMOVE;
+        });
     }
 
     private void on_cache_update_failed (Error error) {


### PR DESCRIPTION
Use `yield` syntax on the calls to Granite so we wait for one to finish before we start another and wrap the method in an `AsyncMutex` to make sure that there aren't any race conditions on `updates_number` where it gets updated in between Granite method calls.

I think this should probably fix issues where people are seeing incorrect/zero counts on the badge, but since I've never been able to reproduce that issue, I can't confirm for sure.