### PR TITLE
Sort search view using search term

### DIFF
--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -136,8 +136,8 @@ namespace AppCenter.Views {
             }
 #endif
 
-            int sp1 = search_priority(row1.get_name_label ());
-            int sp2 = search_priority(row2.get_name_label ());
+            int sp1 = search_priority (row1.get_name_label ());
+            int sp2 = search_priority (row2.get_name_label ());
             if (sp1 != sp2) {
                 return sp2 - sp1;
             }

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -62,8 +62,9 @@ namespace AppCenter.Views {
             // Don't show plugins or fonts in search and category views
             if (!package.is_plugin && !package.is_font) {
                 GLib.CompareDataFunc<AppCenterCore.Package> sort_fn = (a, b) => {
-                    return compare_packages(a, b);
+                    return compare_packages (a, b);
                 };
+
                 list_store.insert_sorted (package, sort_fn);
             }
         }

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -68,6 +68,7 @@ public class AppCenter.Views.SearchView : View {
         current_category = category;
 
         app_list_view.clear ();
+        app_list_view.current_search_term = current_search_term;
         unowned Client client = Client.get_default ();
 
         Gee.Collection<Package> found_apps;


### PR DESCRIPTION
Search order is defined by the search_priority function. This takes the lowercase application name and lowercase search term, and sorts with the following order:

- Name starts with term
- Name contains term
- Name does not contain term

Fixes https://github.com/pop-os/shop/issues/171 and is a good start on https://github.com/elementary/appcenter/issues/1279