### PR TITLE
Add polkit action to allow updates without admin prompt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y gettext libappstream-dev libflatpak-dev libgee-0.8-dev libgranite-dev libgtk-3-dev libhandy-0.0-dev libjson-glib-dev libpackagekit-glib2-dev libsoup2.4-dev libxml2-dev libxml2-utils meson valac
+        apt install -y gettext libappstream-dev libflatpak-dev libgee-0.8-dev libgranite-dev libgtk-3-dev libhandy-0.0-dev libjson-glib-dev libpackagekit-glib2-dev libsoup2.4-dev libxml2-dev libxml2-utils libpolkit-gobject-1-dev meson valac
     - name: Build
       env:
         DESTDIR: out

--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -11,8 +11,12 @@
     <p>An app store for indie and open source developers. Browse by categories or search and discover new apps. AppCenter is also used for updating your system to the latest and greatest version for new features and fixes.</p>
   </description>
   <releases>
-    <release version="3.3.1" date="2020-04-29" urgency="medium">
+    <release version="3.4.0" date="2020-04-29" urgency="medium">
       <description>
+        <p>New features</p>
+        <ul>
+          <li>Perform updates without administrator permissions</li>
+        </ul>
         <p>Minor updates</p>
         <ul>
           <li>Ensure apps on the homepage are more reliably displayed</li>

--- a/data/io.elementary.appcenter.policy.in
+++ b/data/io.elementary.appcenter.policy.in
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>elementary</vendor>
+  <vendor_url>https://elementary.io/</vendor_url>
+
+  <action id="io.elementary.appcenter.update">
+    <description>Update software</description>
+    <message>Authentication is required to update software</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.packagekit.system-update</annotate>
+  </action>
+
+</policyconfig>

--- a/data/meson.build
+++ b/data/meson.build
@@ -40,6 +40,14 @@ i18n.merge_file(
     install: true
 )
 
+i18n.merge_file(
+    input: 'io.elementary.appcenter.policy.in',
+    output: 'io.elementary.appcenter.policy',
+    po_dir: join_paths(meson.source_root (), 'po', 'extra'),
+    install_dir: join_paths(get_option('datadir'), 'polkit-1', 'actions'),
+    install: true
+)
+
 # Blacklist file
 install_data(
     'appcenter.blacklist',

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,8 @@ libsoup = dependency ('libsoup-2.4')
 json = dependency ('json-glib-1.0')
 flatpak = dependency ('flatpak')
 xml = dependency ('libxml-2.0')
+polkit = dependency ('polkit-gobject-1')
+posix = meson.get_compiler('vala').find_library('posix')
 
 dbus = dependency ('dbus-1')
 
@@ -41,7 +43,9 @@ dependencies = [
     libsoup,
     json,
     flatpak,
-    xml
+    xml,
+    polkit,
+    posix
 ]
 
 config_dir = join_paths(get_option('sysconfdir'), meson.project_name())

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,2 +1,3 @@
 data/io.elementary.appcenter.appdata.xml.in
 data/io.elementary.appcenter.desktop.in.in
+data/io.elementary.appcenter.policy.in


### PR DESCRIPTION
This is part of our recent decisions in #465 and it allows PackageKit/apt packages to be updated without throwing a password dialog.

@cassidyjames I'm still debating in my own head whether it's a good idea to allow systemwide Flatpaks to be installed without auth for the following reasons:

1. It's then inconsistent with PackageKit packages. We need a password to install a package from an apt repo systemwide. Why are Flatpaks special? I understand an admin has to have jumped through the hoops of adding the remote intially.
2. But, Flatpaks _could_ be just as dangerous as debian packages in theory and we're going to allow any other non-admins (children?) on the machine to just install them systemwide?
3. I think initially we thought Flatpak might not have granular enough permissions to differentiate between installs/updates, but it does, and systemwide updates are already allowed without throwing a password prompt it seems.