### PR TITLE
AbstractPackageRowGrid: Reduce args where possible

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -534,7 +534,7 @@ namespace AppCenter.Views {
                     return;
                 }
 
-                var row = new Widgets.PackageRow.list (extension_package, null, null, false);
+                var row = new Widgets.PackageRow.list (extension_package, null, null);
                 if (extension_box != null) {
                     extension_box.add (row);
                 }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -534,7 +534,7 @@ namespace AppCenter.Views {
                     return;
                 }
 
-                var row = new Widgets.PackageRow.list (extension_package, null, null);
+                var row = new Widgets.PackageRow.list (extension_package, null);
                 if (extension_box != null) {
                     extension_box.add (row);
                 }

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -104,7 +104,7 @@ namespace AppCenter.Views {
         }
 
         protected override Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.installed (package, info_grid_group, action_button_group, false);
+            return new Widgets.PackageRow.installed (package, info_grid_group, action_button_group);
         }
 
         protected override void on_package_changing (AppCenterCore.Package package, bool is_changing) {

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -71,7 +71,7 @@ namespace AppCenter.Views {
         }
 
         protected override Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.list (package, null, action_button_group, false);
+            return new Widgets.PackageRow.list (package, null, action_button_group);
         }
 
         // Show 20 more apps on the listbox

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -71,7 +71,7 @@ namespace AppCenter.Views {
         }
 
         protected override Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.list (package, null, action_button_group);
+            return new Widgets.PackageRow.list (package, action_button_group);
         }
 
         // Show 20 more apps on the listbox

--- a/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
@@ -22,17 +22,16 @@ public abstract class AppCenter.Widgets.AbstractPackageRowGrid : AbstractAppCont
     public signal void changed ();
     protected Gtk.Grid info_grid;
 
-    protected AbstractPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
+    protected AbstractPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
         Object (
             package: package,
-            show_uninstall: show_uninstall,
+            show_uninstall: false,
             show_open: false
         );
 
         if (action_size_group != null) {
             action_size_group.add_widget (action_button);
             action_size_group.add_widget (cancel_button);
-            action_size_group.add_widget (uninstall_button);
         }
 
         if (info_size_group != null) {

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -27,8 +27,8 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
     Gtk.Label release_single_label;
     AppStream.Release? newest = null;
 
-    public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
-        base (package, info_size_group, action_size_group, show_uninstall);
+    public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
+        base (package, info_size_group, action_size_group);
         set_up_package ();
     }
 

--- a/src/Widgets/AppContainers/ListPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/ListPackageRowGrid.vala
@@ -19,8 +19,8 @@
  */
 
 public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
-    public ListPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
-        base (package, info_size_group, action_size_group, show_uninstall);
+    public ListPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
+        base (package, info_size_group, action_size_group);
         set_up_package ();
     }
 

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -22,16 +22,16 @@ namespace AppCenter.Widgets {
     public class PackageRow : Gtk.ListBoxRow, AppListRow {
         AbstractPackageRowGrid grid;
 
-        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
-            grid = new InstalledPackageRowGrid (package, info_size_group, action_size_group, show_uninstall);
+        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
+            grid = new InstalledPackageRowGrid (package, info_size_group, action_size_group);
             add (grid);
             grid.changed.connect (() => {
                 changed ();
             });
         }
 
-        public PackageRow.list (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
-            grid = new ListPackageRowGrid (package, info_size_group, action_size_group, show_uninstall);
+        public PackageRow.list (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
+            grid = new ListPackageRowGrid (package, info_size_group, action_size_group);
             add (grid);
             grid.changed.connect (() => {
                 changed ();

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -30,8 +30,8 @@ namespace AppCenter.Widgets {
             });
         }
 
-        public PackageRow.list (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
-            grid = new ListPackageRowGrid (package, info_size_group, action_size_group);
+        public PackageRow.list (AppCenterCore.Package package, Gtk.SizeGroup? action_size_group) {
+            grid = new ListPackageRowGrid (package, null, action_size_group);
             add (grid);
             grid.changed.connect (() => {
                 changed ();


### PR DESCRIPTION
* Every place we use this row, we set `show_uninstall` to false
* `info_size_group` is never used for `PackageRow.list`
* Don't add uninstall to the group because we never use it