### PR TITLE
AbstractAppContainer: Subclass bin

### DIFF
--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -28,7 +28,7 @@ namespace AppCenter {
         }
     }
 
-    public abstract class AbstractAppContainer : Gtk.Grid {
+    public abstract class AbstractAppContainer : Gtk.Bin {
         public AppCenterCore.Package package { get; construct set; }
         protected bool show_uninstall { get; set; default = true; }
         protected bool show_open { get; set; default = true; }

--- a/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/AbstractPackageRowGrid.vala
@@ -20,7 +20,9 @@
 
 public abstract class AppCenter.Widgets.AbstractPackageRowGrid : AbstractAppContainer {
     public signal void changed ();
+
     protected Gtk.Grid info_grid;
+    protected Gtk.Grid grid;
 
     protected AbstractPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
         Object (
@@ -41,11 +43,6 @@ public abstract class AppCenter.Widgets.AbstractPackageRowGrid : AbstractAppCont
     }
 
     construct {
-        column_spacing = 24;
-        margin = 6;
-        margin_start = 12;
-        margin_end = 12;
-
         inner_image.icon_size = Gtk.IconSize.DIALOG;
         /* Needed to enforce size on icons from Filesystem/Remote */
         inner_image.pixel_size = 48;
@@ -65,7 +62,14 @@ public abstract class AppCenter.Widgets.AbstractPackageRowGrid : AbstractAppCont
         action_stack.margin_top = 10;
         action_stack.valign = Gtk.Align.START;
 
-        attach (info_grid, 0, 0, 1, 1);
-        attach (action_stack, 3, 0, 1, 1);
+        grid = new Gtk.Grid ();
+        grid.attach (info_grid, 0, 0);
+        grid.attach (action_stack, 3, 0);
+        grid.column_spacing = 24;
+
+        add (grid);
+        margin = 6;
+        margin_start = 12;
+        margin_end = 12;
     }
 }

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -76,8 +76,9 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
         set_widget_visibility (release_stack, false);
 
-        info_grid.attach (app_version, 1, 1, 1, 1);
-        attach (release_stack, 2, 0, 1, 2);
+        info_grid.attach (app_version, 1, 1);
+
+        grid.attach (release_stack, 2, 0, 1, 2);
     }
 
     protected override void set_up_package (uint icon_size = 48) {


### PR DESCRIPTION
Trying to cut down on the UI code in AbstractAppContainer. Making it a `Bin` forces subclasses to lay out their own grids