### PR TITLE
AbstractAppList: move placeholders to subclasses

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2014-2016 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2014-2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,7 +47,15 @@ namespace AppCenter.Views {
         }
 
         construct {
+            var loading_view = new Granite.Widgets.AlertView (
+                _("Checking for Updates"),
+                _("Downloading a list of available updates to the OS and installed apps"),
+                "sync-synchronizing"
+            );
+            loading_view.show_all ();
+
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
+            list_box.set_placeholder (loading_view);
 
             update_mutex = GLib.Mutex ();
             apps_to_update = new Gee.LinkedList<AppCenterCore.Package> ();

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2014-2016 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2014-2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,9 +25,18 @@ namespace AppCenter.Views {
         private GLib.ListStore list_store;
 
         construct {
+            var alert_view = new Granite.Widgets.AlertView (
+                _("No Results"),
+                _("No apps could be found. Try changing search terms."),
+                "edit-find-symbolic"
+            );
+            alert_view.show_all ();
+
 #if CURATED
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
 #endif
+            list_box.set_placeholder (alert_view);
+
             list_store = new GLib.ListStore (typeof (AppCenterCore.Package));
             scrolled.edge_reached.connect ((position) => {
                 if (position == Gtk.PositionType.BOTTOM) {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2014-2016 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2014-2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,12 +37,10 @@ public class AppCenter.Views.InstalledView : View {
 
         unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
 
-        app_list_view.set_placeholder_loading ();
         get_apps.begin ();
 
         client.installed_apps_changed.connect (() => {
             Idle.add (() => {
-                app_list_view.set_placeholder_loading ();
                 get_apps.begin ();
                 return GLib.Source.REMOVE;
             });
@@ -81,10 +78,6 @@ public class AppCenter.Views.InstalledView : View {
             var os_updates = AppCenterCore.UpdateManager.get_default ().os_updates;
             app_list_view.add_package (os_updates);
             app_list_view.add_packages (installed_apps);
-
-            if (os_updates == null && installed_apps.size == 0) { // Can this ever happen?
-                app_list_view.set_placeholder_no_results ();
-            }
         }
 
         refresh_mutex.unlock ();

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2014-2015 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2014-2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -79,8 +78,6 @@ public class AppCenter.Views.SearchView : View {
             found_apps = client.search_applications (current_search_term, current_category);
             app_list_view.add_packages (found_apps);
         }
-
-        app_list_view.set_placeholder_no_results (); //will only be visible if no packages found
 
         if (current_category != null) {
             subview_entered (_("Search Apps"), true, current_category.name);

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2014-2016 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2014-2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,33 +19,16 @@
 
 public abstract class AppCenter.AbstractAppList : Gtk.Box {
     public signal void show_app (AppCenterCore.Package package);
+
     protected Gtk.ScrolledWindow scrolled;
     protected Gtk.ListBox list_box;
     protected Gtk.SizeGroup action_button_group;
     protected Gtk.SizeGroup info_grid_group;
     protected uint packages_changing = 0;
-    protected Granite.Widgets.AlertView alert_view;
-    protected Granite.Widgets.AlertView loading_view;
 
     construct {
         orientation = Gtk.Orientation.VERTICAL;
 
-        scrolled = new Gtk.ScrolledWindow (null, null);
-        scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-
-        alert_view = new Granite.Widgets.AlertView (
-            _("No Results"),
-            _("No apps could be found. Try changing search terms."),
-            "edit-find-symbolic"
-        );
-
-        loading_view = new Granite.Widgets.AlertView (
-            _("Checking for Updates"),
-            _("Downloading a list of available updates to the OS and installed apps"),
-            "sync-synchronizing"
-        );
-        alert_view.show_all ();
-        loading_view.show_all ();
         list_box = new Gtk.ListBox ();
         list_box.expand = true;
         list_box.activate_on_single_click = true;
@@ -57,18 +39,12 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
             show_app (row.get_package ());
         });
 
+        scrolled = new Gtk.ScrolledWindow (null, null);
+        scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scrolled.add (list_box);
 
         action_button_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
         info_grid_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
-    }
-
-    public void set_placeholder_loading () {
-        list_box.set_placeholder (loading_view);
-    }
-
-    public void set_placeholder_no_results () {
-        list_box.set_placeholder (alert_view);
     }
 
     protected abstract Widgets.AppListRow construct_row_for_package (AppCenterCore.Package package);


### PR DESCRIPTION
* `loading_view` is only ever used in `AppListUpdateView` so it should go there
* The copy for `alert_view` is specific to search, so it should go to `AppListView` (for now, because category and search views use the same app list)
* I removed the placeholder switching from the installed view because it shouldn't theoretically be possible to have absolutely zero packages installed. You're always going to at least have AppCenter. And if it were possible, the copy is wrong anyways