### PR TITLE
AppListRow: Remove unused has_package

### DIFF
--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -56,9 +56,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
         package.changing.disconnect (on_package_changing);
         foreach (weak Gtk.Widget r in list_box.get_children ()) {
             weak Widgets.AppListRow row = r as Widgets.AppListRow;
-            if (!row.has_package ()) {
-                continue;
-            }
 
             if (row.get_package () == package) {
                 row.destroy ();
@@ -76,11 +73,9 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
                 continue;
             }
 
-            if (row.has_package ()) {
-                var package = row.get_package ();
-                package.changing.disconnect (on_package_changing);
-                row.destroy ();
-            }
+            var package = row.get_package ();
+            package.changing.disconnect (on_package_changing);
+            row.destroy ();
         };
 
         on_list_changed ();
@@ -100,9 +95,7 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
                 continue;
             }
 
-            if (row.has_package ()) {
-                tree_set.add (row.get_package ());
-            }
+            tree_set.add (row.get_package ());
         }
 
         return tree_set;

--- a/src/Widgets/AppListRow.vala
+++ b/src/Widgets/AppListRow.vala
@@ -27,7 +27,6 @@ namespace AppCenter.Widgets {
         public abstract bool get_is_driver ();
         public abstract bool get_is_updating ();
         public abstract string get_name_label ();
-        public abstract bool has_package ();
         public abstract AppCenterCore.Package? get_package ();
     }
 }

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -65,9 +65,5 @@ namespace AppCenter.Widgets {
         public void set_action_sensitive (bool is_sensitive) {
             grid.action_sensitive = is_sensitive;
         }
-
-        public bool has_package () {
-            return true;
-        }
     }
 }


### PR DESCRIPTION
Not sure why this existed historically, but since `PackageRow` is the only class that implements `AppListRow` and it hardcodes the result to `true`, this property is useless