### PR TITLE
Move single-use reboot method out of utils

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -29,16 +29,6 @@ namespace Utils {
         *y = tmp;
     }
 
-
-    public void reboot () {
-        try {
-            SuspendControl.get_default ().reboot ();
-        } catch (GLib.Error e) {
-            var dialog = new AppCenter.Widgets.RestartDialog ();
-            dialog.show_all ();
-        }
-    }
-
     public static uint get_file_age (GLib.File file) {
         FileInfo info;
         try {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -73,7 +73,12 @@ namespace AppCenter.Views {
 
             infobar.response.connect ((response) => {
                 if (response == 0) {
-                    Utils.reboot ();
+                    try {
+                        SuspendControl.get_default ().reboot ();
+                    } catch (GLib.Error e) {
+                        var dialog = new AppCenter.Widgets.RestartDialog ();
+                        dialog.show_all ();
+                    }
                 }
             });
 


### PR DESCRIPTION
I'd prefer to keep code that depends on GUI classes out of `Utils.vala`