### PR TITLE
Have backend classes construct their own Settings objects

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -37,6 +37,12 @@ public class AppCenterCore.Client : Object {
 
     private AsyncMutex update_notification_mutex = new AsyncMutex ();
 
+    public static GLib.Settings settings;
+
+    static construct {
+        settings = new GLib.Settings ("io.elementary.appcenter.settings");
+    }
+
     private Client () {
         Object (screenshot_cache: AppCenterCore.ScreenshotCache.new_cache ());
     }
@@ -44,7 +50,7 @@ public class AppCenterCore.Client : Object {
     construct {
         cancellable = new GLib.Cancellable ();
 
-        last_cache_update = new DateTime.from_unix_utc (AppCenter.App.settings.get_int64 ("last-refresh-time"));
+        last_cache_update = new DateTime.from_unix_utc (settings.get_int64 ("last-refresh-time"));
     }
 
     public async Gee.Collection<AppCenterCore.Package> get_installed_applications (Cancellable? cancellable = null) {
@@ -141,7 +147,7 @@ public class AppCenterCore.Client : Object {
                     success = yield BackendAggregator.get_default ().refresh_cache (cancellable);
                     if (success) {
                         last_cache_update = new DateTime.now_utc ();
-                        AppCenter.App.settings.set_int64 ("last-refresh-time", last_cache_update.to_unix ());
+                        settings.set_int64 ("last-refresh-time", last_cache_update.to_unix ());
                     }
 
                     seconds_since_last_refresh = 0;

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -150,7 +150,7 @@ public class AppCenterCore.Package : Object {
                 return false;
             }
 
-            if (component.get_id () in AppCenter.App.settings.get_strv ("paid-apps")) {
+            if (component.get_id () in settings.get_strv ("paid-apps")) {
                 return false;
             }
 
@@ -366,6 +366,12 @@ public class AppCenterCore.Package : Object {
     private PackageDetails? backend_details = null;
     private AppInfo? app_info;
     private bool app_info_retrieved = false;
+
+    public static GLib.Settings settings;
+
+    static construct {
+        settings = new GLib.Settings ("io.elementary.appcenter.settings");
+    }
 
     construct {
         change_information = new ChangeInformation ();

--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -23,6 +23,12 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
 
     private Gee.TreeSet<Package>? cached_packages = null;
 
+    public static GLib.Settings settings;
+
+    static construct {
+        settings = new GLib.Settings ("io.elementary.appcenter.settings");
+    }
+
     private async bool get_drivers_output (Cancellable? cancellable = null, out string? output = null) {
         output = null;
         string? drivers_exec_path = Environment.find_program_in_path ("ubuntu-drivers");
@@ -49,7 +55,7 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
         working = true;
 
         cached_packages = new Gee.TreeSet<Package> ();
-        var tokens = AppCenter.App.settings.get_strv ("cached-drivers");
+        var tokens = settings.get_strv ("cached-drivers");
 
         for (int i = 0; i < tokens.length; i++) {
             if (cancellable.is_cancelled ()) {
@@ -147,7 +153,7 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
             }
         }
 
-        AppCenter.App.settings.set_strv ("cached-drivers", pkgnames);
+        settings.set_strv ("cached-drivers", pkgnames);
 
         working = false;
         return true;


### PR DESCRIPTION
Instead of having all of these core/backend classes use the `settings` instance belonging to `AppCenter.App` and hence depending on all of the GUI classes, have them construct their own.

This allows these classes to stand more freely and should in theory allow them to be compiled and tested independently from the rest of AppCenter. 