### PR TITLE
Client: Use RDNN for notification ID

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -79,9 +79,9 @@ public class AppCenterCore.Client : Object {
             notification.set_icon (new ThemedIcon ("system-software-install"));
             notification.set_default_action ("app.show-updates");
 
-            application.send_notification ("updates", notification);
+            application.send_notification ("io.elementary.appcenter.updates", notification);
         } else {
-            application.withdraw_notification ("updates");
+            application.withdraw_notification ("io.elementary.appcenter.updates");
         }
 
         try {


### PR DESCRIPTION
Make sure we're RDNNing our notification ID so we don't conflict with anybody else