### PR TITLE
Document the libpolkit-gobject-1-dev build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You'll need the following dependencies:
 * libhandy-0.0-dev
 * libjson-glib-dev
 * libpackagekit-glib2-dev
+* libpolkit-gobject-1-dev
 * libsoup2.4-dev
 * libxml2-dev
 * libxml2-utils


### PR DESCRIPTION
Fixes #1339.

This just documents a required build dependency. 🤗