### PR TITLE
AbstractAppContainer: remove threading and locking

### DIFF
--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -44,16 +44,8 @@ namespace AppCenter {
         private Gtk.Revealer open_button_revealer;
         private Gtk.Revealer uninstall_button_revealer;
         private Gtk.Revealer action_button_revealer;
-        private Mutex action_mutex = Mutex ();
-        private Cancellable action_cancellable = new Cancellable ();
 
         private uint state_source = 0U;
-
-        private enum ActionResult {
-            NONE = 0,
-            HIDE_BUTTON = 1,
-            ADD_TO_INSTALLED_SCREEN = 2
-        }
 
         public bool is_os_updates {
             get {
@@ -356,7 +348,6 @@ namespace AppCenter {
         }
 
         private void action_cancelled () {
-            action_cancellable.cancel ();
             update_action ();
             package.action_cancellable.cancel ();
         }
@@ -370,66 +361,17 @@ namespace AppCenter {
         }
 
         private async void action_clicked () {
-            ActionResult result = 0;
-            SourceFunc callback = action_clicked.callback;
-
-            // Apply packagekit actions in the background, and ultimately yield a result
-            // to this once the action is complete
-            ThreadFunc<bool> run = () => {
-                // Ensure that only one action is performed at a time.
-                action_mutex.lock ();
-
-                var loop = new MainLoop ();
-
-                if (package.installed && !package.update_available) {
-                    result = ActionResult.HIDE_BUTTON;
-                } else if (package.update_available) {
-                    package.update.begin ((obj, res) => {
-                        package.update.end (res);
-                        loop.quit ();
-                    });
-                } else {
-                    package.install.begin ((obj, res) => {
-                        if (package.update.end (res)) {
-                            result = ActionResult.ADD_TO_INSTALLED_SCREEN;
-                        }
-
-                        loop.quit ();
-                    });
+            if (package.installed && !package.update_available) {
+                action_button_revealer.reveal_child = false;
+            } else if (package.update_available) {
+                yield package.update ();
+            } else {
+                if (yield package.install ()) {
+                    MainWindow.installed_view.add_app.begin (package);
                 }
-
-                if (action_cancellable.is_cancelled ()) {
-                    package.action_cancellable.cancel ();
-                    action_cancellable.reset ();
-                    action_mutex.unlock ();
-                    Idle.add ((owned)callback);
-                    return true;
-                }
-
-                loop.run (); // wait for async methods above
-
-                action_mutex.unlock ();
-                Idle.add ((owned)callback);
-                return true;
-            };
-
-            new Thread<bool> ("action_clicked", run);
+            }
 
             action_stack.set_visible_child_name ("progress");
-
-            yield;
-
-            switch (result) {
-                case ActionResult.HIDE_BUTTON:
-                    action_button_revealer.reveal_child = false;
-                    break;
-                case ActionResult.ADD_TO_INSTALLED_SCREEN:
-                    // Add this app to the Installed Apps View
-                    MainWindow.installed_view.add_app.begin (package);
-                    break;
-                default:
-                    break;
-            }
         }
 
         private async void uninstall_clicked () {


### PR DESCRIPTION
In theory, all of the threading and locking is now done in the backend, so none of this should be necessary anymore.

This affects the install/update action button and the cancellation of that action across all views, but my initial testing on this has gone well.