### PR TITLE
Installed state optimisations

### DIFF
--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -197,6 +197,15 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
             var time_since_last_action = (new DateTime.now_local ()).difference (last_action) / GLib.TimeSpan.MILLISECOND;
             if (time_since_last_action >= PACKAGEKIT_ACTIVITY_TIMEOUT_MS) {
                 info ("packages possibly changed by external program, refreshing cache");
+
+                // Clear the installed state of all packages as something may have changed we weren't
+                // aware of
+                foreach (var package in package_list.values) {
+                    if (package.state != Package.State.NOT_INSTALLED || package.installed) {
+                        package.clear_installed ();
+                    }
+                }
+
                 trigger_update_check.begin ();
             }
         }

--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -78,9 +78,13 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
             driver_component.add_icon (icon);
 
             var package = new Package (this, driver_component);
-            if (package.installed) {
-                package.mark_installed ();
-                package.update_state ();
+            try {
+                if (yield is_package_installed (package)) {
+                    package.mark_installed ();
+                    package.update_state ();
+                }
+            } catch (Error e) {
+                warning ("Unable to check if driver is installed: %s", e.message);
             }
 
             cached_packages.add (package);

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -280,7 +280,7 @@ namespace AppCenter.Views {
             if (apps_to_update.size > 0) {
                 first_package = apps_to_update[0];
                 first_package.info_changed.connect_after (after_first_package_info_changed);
-                first_package.update.begin (() => {
+                first_package.update.begin (false, () => {
                     on_app_update_end ();
                 });
             } else {
@@ -303,7 +303,7 @@ namespace AppCenter.Views {
                 if (status != AppCenterCore.ChangeInformation.Status.CANCELLED) { /* must  be running */
                     apps_remaining_started = true;
                     for (int i = 1; i < apps_to_update.size; i++) {
-                        apps_to_update[i].update.begin (() => {
+                        apps_to_update[i].update.begin (false, () => {
                             on_app_update_end ();
                         });
                     }
@@ -338,19 +338,16 @@ namespace AppCenter.Views {
                 foreach (var row in list_box.get_children ()) {
                     if (row is Widgets.PackageRow) {
                         var pkg_row = ((Widgets.PackageRow)(row));
-                        var pkg = pkg_row.get_package ();
-
-                        /* clear update information if the package was successfully updated */
-                        /* This information is refreshed by Client on start up (log in) or at daily intervals */
-                        /* TODO: Implement refresh on demand (or on list display?) */
-                        if (pkg.state == AppCenterCore.Package.State.INSTALLED) {
-                            pkg.change_information.clear_update_info ();
-                        }
 
                         pkg_row.set_action_sensitive (true);
-                        pkg_row.changed ();
                     }
                 }
+
+                list_box.invalidate_sort ();
+
+                unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
+                client.refresh_updates ();
+
                 return GLib.Source.REMOVE;
             });
         }

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -384,7 +384,7 @@ namespace AppCenter {
                 if (package.installed && !package.update_available) {
                     result = ActionResult.HIDE_BUTTON;
                 } else if (package.update_available) {
-                    package.update.begin ((obj, res) => {
+                    package.update.begin (true, (obj, res) => {
                         package.update.end (res);
                         loop.quit ();
                     });


### PR DESCRIPTION
This takes some of the work from #1319 and breaks it into its own PR.

This is quite an important first step in some refactoring/optimizations that start to unblock some of the work of prioritizing different package sources and enabling systemwide flatpak support.

This should bring about no functionality changes to make testing easier.

In summary, the changes are:
* Only update the flatpak cache if changes weren't triggered by AppCenter. We were previously picking up on the `changed` signal for stuff that was being changed in AppCenter which is unnecessary.
* Refresh the installed/updatable state of applications when external changes happen (i.e. CLI tools)
* Never query the backend synchronously for the installed state of an application. Check once at startup and then try to keep it up to date.
* Only emit state changed signals on packages when the state actually changes
* Only refresh the available updates once at the end of updating a bunch of packages instead of in between each one

This will need some pretty in-depth testing to check that everything stays in sync, but I'd appreciate it if people could run this branch and test it out for a few days as it's blocking quite a bit of my other work.