### PR TITLE
ScreenshotCache: support older GLib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ add_project_arguments(
 vapi_dir = join_paths(meson.current_source_dir(), 'vapi')
 add_project_arguments(['--vapidir', vapi_dir], language: 'vala')
 
+glib = dependency ('glib-2.0')
 gee = dependency ('gee-0.8')
 gtk = dependency ('gtk+-3.0', version: '>=3.10')
 granite = dependency ('granite', version: '>=5.2.5')
@@ -34,6 +35,7 @@ posix = meson.get_compiler('vala').find_library('posix')
 dbus = dependency ('dbus-1')
 
 dependencies = [
+    glib,
     gee,
     gtk,
     granite,

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -187,7 +187,19 @@ public class AppCenterCore.ScreenshotCache : GLib.Object {
                 GLib.Source.remove (cancel_source);
             }
 
+#if GLIB_2_62
             remote_mtime = file_info.get_modification_date_time ();
+#else
+            var mtime = file_info.get_attribute_uint64 (GLib.FileAttribute.TIME_MODIFIED);
+            if (mtime != 0) {
+                remote_mtime = new DateTime.from_unix_utc ((int64)mtime);
+
+                var usec = file_info.get_attribute_uint32 (GLib.FileAttribute.TIME_MODIFIED_USEC);
+                if (usec != 0) {
+                    remote_mtime = remote_mtime.add (usec);
+                }
+            }
+#endif
         } catch (Error e) {
             warning ("Error getting modification time of remote screenshot file: %s", e.message);
         }


### PR DESCRIPTION
`file_info_get_modification_date_time` was added in GLib 2.62. We need to put a conditional compile in to allow this to continue compiling on bionic which we still want to support for now.