### PR TITLE
Don't replace .desktop in component ID

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -817,7 +817,7 @@ namespace AppCenter.Views {
                 selection.payment_requested.connect ((amount) => {
                     var stripe = new Widgets.StripeDialog (amount,
                                                            package.get_name (),
-                                                           package.component.id.replace (".desktop", ""),
+                                                           package.normalized_component_id,
                                                            package.get_payments_key ()
                                                           );
 

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -199,7 +199,7 @@ namespace AppCenter {
             var stripe = new Widgets.StripeDialog (
                 amount,
                 package_name.label,
-                package.component.id.replace (".desktop", ""),
+                package.normalized_component_id,
                 package.get_payments_key ()
             );
 


### PR DESCRIPTION
We shouldn't be using `replace` to remove `".desktop"` from the component ID, which could remove `".desktop"` from the middle of a string:

(`com.github.spheras.desktopfolder -> com.github.spherasfolder` :scream: )

We should be only removing it from the end of the string. Luckily we already have a pre-built property for this in the `Package` class :wink: 