### PR TITLE
MainWindow: Restore window size and position last

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -11,6 +11,18 @@
     <p>An app store for indie and open source developers. Browse by categories or search and discover new apps. AppCenter is also used for updating your system to the latest and greatest version for new features and fixes.</p>
   </description>
   <releases>
+    <release version="3.4.2" date="2020-07-30" urgency="medium">
+      <description>
+        <p>Fixes</p>
+        <ul>
+          <li>Ensure AppCenter is reopened at the correct position</li>
+        </ul>
+        <p>Minor updates</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.4.1" date="2020-06-30" urgency="medium">
       <description>
         <p>Fixes</p>

--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -16,6 +16,7 @@
         <p>Fixes</p>
         <ul>
           <li>Ensure AppCenter is reopened at the correct position</li>
+          <li>Clicking the updates badge in the header navigates to the updates view</li>
         </ul>
         <p>Minor updates</p>
         <ul>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -122,21 +122,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         icon_name = "system-software-install";
         set_size_request (910, 640);
 
-        int window_x, window_y;
-        int window_width, window_height;
-        App.settings.get ("window-position", "(ii)", out window_x, out window_y);
-        App.settings.get ("window-size", "(ii)", out window_width, out window_height);
-
-        if (window_x != -1 || window_y != -1) {
-            move (window_x, window_y);
-        }
-
-        resize (window_width, window_height);
-
-        if (App.settings.get_boolean ("window-maximized")) {
-            maximize ();
-        }
-
         title = _(Build.APP_NAME);
 
         return_button = new Gtk.Button ();
@@ -211,6 +196,21 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         grid.add (stack);
 
         add (grid);
+
+        int window_x, window_y;
+        int window_width, window_height;
+        App.settings.get ("window-position", "(ii)", out window_x, out window_y);
+        App.settings.get ("window-size", "(ii)", out window_width, out window_height);
+
+        if (window_x != -1 || window_y != -1) {
+            move (window_x, window_y);
+        }
+
+        resize (window_width, window_height);
+
+        if (App.settings.get_boolean ("window-maximized")) {
+            maximize ();
+        }
 
         homepage.page_loaded.connect (() => homepage_loaded ());
     }


### PR DESCRIPTION
Fixes an issue where AppCenter would reopen at a different position than the last saved.

We need to make sure we construct the UI before trying to restore size and position, otherwise the window can resize after the restore and we get faulty coordinates. This makes the window move slightly every time we restore until eventually it's opening off in some corner of the display