### PR TITLE
FlatpakBackend: Fix stuck updates issue

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -1094,7 +1094,7 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
         }
 
         if (user_updates.length > 0) {
-            run_user = false;
+            run_user = true;
             transactions++;
         }
 
@@ -1128,6 +1128,14 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
         } catch (Error e) {
             critical ("Error creating transaction for flatpak updates: %s", e.message);
             return false;
+        }
+
+        try {
+            foreach (var bundle_id in ids) {
+                transaction.add_update (bundle_id, null, null);
+            }
+        } catch (Error e) {
+            critical ("Error adding update to flatpak transaction: %s", e.message);
         }
 
         transaction.choose_remote_for_ref.connect ((@ref, runtime_ref, remotes) => {


### PR DESCRIPTION
Fixes part of #1403 (The names are still not displayed correctly, but they are updated now)

It turns out if you invert your booleans and don't actually tell flatpak to update any packages, things go a bit awry when you try to update flatpak packages.

I have no idea who wrote this code originally. Hint: *it definitely wasn't me* :grimacing: 