### PR TITLE
Optimise search rank algorithm

### DIFF
--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -108,12 +108,19 @@ namespace AppCenter.Views {
             if (name != null && current_search_term != null) {
                 var name_lower = name.down ();
                 var term_lower = current_search_term.down ();
-                if (name_lower.has_prefix (term_lower)) {
+
+                var term_position = name_lower.index_of (term_lower);
+
+                // App name starts with our search term, highest priority
+                if (term_position == 0) {
                     return 2;
-                } else if (name_lower.contains (term_lower)) {
+                // App name contains our search term, high priority
+                } else if (term_position != -1) {
                     return 1;
                 }
             }
+
+            // Otherwise, normal appstream search ranking order
             return 0;
         }
 


### PR DESCRIPTION
Instead of doing `string.has_prefix` and `string.contains`, we can do `string.index_of` and use the result to figure out the answer to both. 

If the needle is at the start, it's as fast as `has_prefix`, if it's not in the string, it's as slow as `contains` but this means we're doing slightly less expensive string operations in some cases. It probably doesn't save much, but for some reason I had this idea rattling around in my head as I was falling asleep, so I had to open a quick PR and clear my conscience... :sleeping: 