### PR TITLE
Release 3.5.1

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -11,7 +11,7 @@
     <p>An app store for indie and open source developers. Browse by categories or search and discover new apps. AppCenter is also used for updating your system to the latest and greatest version for new features and fixes.</p>
   </description>
   <releases>
-    <release version="3.5.1" date="2020-09-08" urgency="medium">
+    <release version="3.5.1" date="2020-10-08" urgency="medium">
       <description>
         <p>Fixes</p>
         <ul>

--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -11,7 +11,7 @@
     <p>An app store for indie and open source developers. Browse by categories or search and discover new apps. AppCenter is also used for updating your system to the latest and greatest version for new features and fixes.</p>
   </description>
   <releases>
-    <release version="3.5.1" date="2020-09-05" urgency="medium">
+    <release version="3.5.1" date="2020-09-08" urgency="medium">
       <description>
         <p>Fixes</p>
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'io.elementary.appcenter',
     'vala', 'c',
-    version: '3.5.0'
+    version: '3.5.1'
 )
 
 gettext_name = meson.project_name()


### PR DESCRIPTION
Fixes the Flatpak runtime name issue.

https://github.com/elementary/appcenter/compare/3.5.0...release-3.5.1