### PR TITLE
Application: "successfully" is redundant

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -291,7 +291,7 @@ public class AppCenter.App : Gtk.Application {
                     }
 
                     var notification = new Notification (_("Application installed"));
-                    notification.set_body (_("%s has been successfully installed").printf (package.get_name ()));
+                    notification.set_body (_("%s has been installed").printf (package.get_name ()));
                     notification.set_icon (new ThemedIcon ("system-software-install"));
                     notification.set_default_action ("app.open-application");
 


### PR DESCRIPTION
Related to #1456, see https://github.com/elementary/sideload/pull/101 and https://github.com/elementary/sideload/pull/102