### PR TITLE
Use Meson project name for icons

### DIFF
--- a/data/io.elementary.appcenter-daemon.desktop.in
+++ b/data/io.elementary.appcenter-daemon.desktop.in
@@ -2,7 +2,7 @@
 Name=@APP_NAME@ Daemon
 Comment=Browse and manage apps
 Exec=@EXEC_NAME@ -s
-Icon=@DESKTOP_ICON@
+Icon=@PROJECT_NAME@
 Terminal=false
 Type=Application
 NoDisplay=true

--- a/data/io.elementary.appcenter.desktop.in.in
+++ b/data/io.elementary.appcenter.desktop.in.in
@@ -2,7 +2,7 @@
 Name=@APP_NAME@
 Comment=Browse and manage apps
 Exec=@EXEC_NAME@ %U
-Icon=@DESKTOP_ICON@
+Icon=@PROJECT_NAME@
 Keywords=install;uninstall;remove;catalogue;store;apps;software;
 Actions=ShowUpdates;
 Terminal=false

--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,6 @@ dependencies = [
 config_dir = join_paths(get_option('sysconfdir'), meson.project_name())
 conf_data = configuration_data()
 conf_data.set('PROJECT_NAME', meson.project_name())
-conf_data.set('DESKTOP_ICON', get_option('icon'))
 conf_data.set('EXEC_NAME', meson.project_name())
 conf_data.set('GETTEXT_PACKAGE', meson.project_name())
 conf_data.set('APP_NAME', get_option('name'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,6 @@
 option('hidden_app_list_file', type : 'string', value : 'appcenter.hiddenapps', description : 'The name of the file listing applications to not be shown in AppCenter')
 option('curated', type : 'boolean', value : true, description : 'Differentiate between apps created for elementary and not')
 option('homepage', type : 'boolean', value : true, description: 'Dynamic homepage using remote server data')
-option('icon', type : 'string', value : 'io.elementary.appcenter', description : 'The name of the icon')
 option('name', type : 'string', value : 'AppCenter', description : 'The name of the application')
 option('payments', type : 'boolean', value : true, description : 'Enable payment features and display paid apps')
 option('sharing', type : 'boolean', value : true, description : 'Display sharing features, i.e. copyable URLs to apps')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -294,7 +294,7 @@ public class AppCenter.App : Gtk.Application {
 
                     var notification = new Notification (_("The app has been installed"));
                     notification.set_body (_("“%s” has been installed").printf (package.get_name ()));
-                    notification.set_icon (new ThemedIcon ("io.elementary.appcenter"));
+                    notification.set_icon (new ThemedIcon (Build.PROJECT_NAME));
                     notification.set_default_action ("app.open-application");
 
                     send_notification ("installed", notification);

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -74,7 +74,7 @@ public class AppCenterCore.Client : Object {
 
             var notification = new Notification (title);
             notification.set_body (body);
-            notification.set_icon (new ThemedIcon ("io.elementary.appcenter"));
+            notification.set_icon (new ThemedIcon (Build.PROJECT_NAME));
             notification.set_default_action ("app.show-updates");
 
             application.send_notification ("io.elementary.appcenter.updates", notification);

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -194,7 +194,7 @@ public class AppCenterCore.UpdateManager : Object {
                 string body = _("Please restart your system to finalize updates");
                 var notification = new Notification (title);
                 notification.set_body (body);
-                notification.set_icon (new ThemedIcon ("io.elementary.appcenter"));
+                notification.set_icon (new ThemedIcon (Build.PROJECT_NAME));
                 notification.set_priority (NotificationPriority.URGENT);
                 notification.set_default_action ("app.open-application");
                 Application.get_default ().send_notification ("restart", notification);

--- a/src/Dialogs/StripeDialog.vala
+++ b/src/Dialogs/StripeDialog.vala
@@ -81,7 +81,7 @@ public class AppCenter.Widgets.StripeDialog : Granite.Dialog {
         var image = new Gtk.Image.from_icon_name ("payment-card", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
 
-        var overlay_image = new Gtk.Image.from_icon_name ("io.elementary.appcenter", Gtk.IconSize.LARGE_TOOLBAR);
+        var overlay_image = new Gtk.Image.from_icon_name (Build.PROJECT_NAME, Gtk.IconSize.LARGE_TOOLBAR);
         overlay_image.halign = overlay_image.valign = Gtk.Align.END;
 
         var overlay = new Gtk.Overlay ();
@@ -274,7 +274,7 @@ public class AppCenter.Widgets.StripeDialog : Granite.Dialog {
             secondary_error_label.wrap = true;
             secondary_error_label.xalign = 0;
 
-            var icon = new Gtk.Image.from_icon_name ("io.elementary.appcenter", Gtk.IconSize.DIALOG);
+            var icon = new Gtk.Image.from_icon_name (Build.PROJECT_NAME, Gtk.IconSize.DIALOG);
 
             var overlay_icon = new Gtk.Image.from_icon_name ("dialog-warning", Gtk.IconSize.LARGE_TOOLBAR);
             overlay_icon.halign = Gtk.Align.END;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -128,7 +128,7 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
 
     construct {
         Hdy.init ();
-        icon_name = "io.elementary.appcenter";
+        icon_name = Build.PROJECT_NAME;
         set_size_request (910, 640);
 
         title = _(Build.APP_NAME);

--- a/src/Widgets/Banner.vala
+++ b/src/Widgets/Banner.vala
@@ -91,7 +91,7 @@ namespace AppCenter.Widgets {
                 if (has_package) {
                     icon.gicon = package.get_icon (128, icon.get_scale_factor ());
                 } else {
-                    icon.icon_name = "io.elementary.appcenter";
+                    icon.icon_name = Build.PROJECT_NAME;
                 }
 
                 attach (icon, 0, 0, 1, 3);


### PR DESCRIPTION
This just seems less error-prone since we're using the same string over and over again. We name the icons from the Meson project name to begin with, so let's ensure we're requesting the exact icons by using the same Meson variable.