### PR TITLE
Use `client.resolve_sync` in `get_package_internal`

### DIFF
--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -874,7 +874,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         Pk.Package? pk_package = null;
         var filter = Pk.Bitfield.from_enums (Pk.Filter.NEWEST);
         try {
-            var results = client.search_names_sync (filter, { name, null }, null, () => {});
+            var results = client.resolve_sync (filter, { name, null }, null, () => {});
             var array = results.get_package_array ();
             if (array.length > 0) {
                 pk_package = array.get (0);


### PR DESCRIPTION
`client.search_names_sync` may get a package that isn't an exact match. In testing on Pop!_OS, we noticed the `peek` package was incorrectly marked as uninstalled with the latest AppCenter.

It seems instead of `peek`, `client.search_names_sync` was getting `cardpeek` as the first result (just as `apt search peek` does).

This seems to be the correct function for this purpose.