### PR TITLE
Allow build with appstream 0.14.x

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -286,7 +286,7 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
 
     public Gee.Collection<Package> search_applications (string query, AppStream.Category? category) {
         var apps = new Gee.TreeSet<AppCenterCore.Package> ();
-        GLib.GenericArray<weak AppStream.Component> comps = user_appstream_pool.search (query);
+        var comps = user_appstream_pool.search (query);
         if (category == null) {
             comps.foreach ((comp) => {
                 var packages = get_packages_for_component_id (comp.get_id ());

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -393,7 +393,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
 
     public Gee.Collection<AppCenterCore.Package> search_applications (string query, AppStream.Category? category) {
         var apps = new Gee.TreeSet<AppCenterCore.Package> ();
-        GLib.GenericArray<weak AppStream.Component> comps = appstream_pool.search (query);
+        var comps = appstream_pool.search (query);
         if (category == null) {
             comps.foreach ((comp) => {
                 var package = get_package_for_component_id (comp.get_id ());


### PR DESCRIPTION
```shell
../src/Core/FlatpakBackend.vala:289.53-289.57: error: Assignment: Cannot convert from `GLib.GenericArray<AppStream.Component>' to `GLib.GenericArray<weak AppStream.Component>?'
        GLib.GenericArray<weak AppStream.Component> comps = user_appstream_pool.search (query);
                                                    ^^^^^
../src/Core/PackageKitBackend.vala:396.53-396.57: error: Assignment: Cannot convert from `GLib.GenericArray<AppStream.Component>' to `GLib.GenericArray<weak AppStream.Component>?'
        GLib.GenericArray<weak AppStream.Component> comps = appstream_pool.search (query);
```