### PR TITLE
Remap AppStream 'metadata' tag to 'custom'

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -827,8 +827,22 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
 
         root->set_prop ("origin", origin_name);
 
+        // Remap the <metadata> tag that contains the custom x-appcenter-xxx values to
+        // <custom> as expected by the AppStream parser
+        Xml.XPath.Context cntx = new Xml.XPath.Context (doc);
+        Xml.XPath.Object* res = cntx.eval_expression ("/components/component/metadata");
+
+        if (res != null && res->type == Xml.XPath.ObjectType.NODESET && res->nodesetval != null) {
+            for (int i = 0; i < res->nodesetval->length (); i++) {
+                Xml.Node* node = res->nodesetval->item (i);
+                node->set_name ("custom");
+            }
+        }
+
         doc->set_compress_mode (7);
         doc->save_file (dest_file.get_path ());
+
+        delete res;
         delete doc;
     }
 

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -827,6 +827,7 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
 
         root->set_prop ("origin", origin_name);
 
+        // FIXME: This is a workaround for https://github.com/ximion/appstream/issues/339
         // Remap the <metadata> tag that contains the custom x-appcenter-xxx values to
         // <custom> as expected by the AppStream parser
         Xml.XPath.Context cntx = new Xml.XPath.Context (doc);


### PR DESCRIPTION
Fixes #1555

It's a bit of a hacky workaround since it's not really AppCenter's problem that whatever is generating the collection metadata isn't being standards compliant, but it's a workaround that gets us out of a hole quickly if we want it.