### PR TITLE
Fixup package origins for focal

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -36,10 +36,7 @@ public class AppCenterCore.PackageDetails : Object {
 
 public class AppCenterCore.Package : Object {
     public const string APPCENTER_PACKAGE_ORIGIN = "appcenter";
-    // We stopped using this origin in elementary OS 5.1, references to this can be removed
-    // after everyone has had chance to update their appstream-data-pantheon package
-    private const string DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN = "stable-bionic-main";
-    private const string ELEMENTARY_STABLE_PACKAGE_ORIGIN = "elementary-stable-bionic-main";
+    private const string ELEMENTARY_STABLE_PACKAGE_ORIGIN = "elementary-stable-focal-main";
 
     /* Note: These are just a stopgap, and are not a replacement for a more
      * fleshed out parental control system. We assume any of these "moderate"
@@ -216,7 +213,6 @@ public class AppCenterCore.Package : Object {
         get {
             switch (component.get_origin ()) {
                 case APPCENTER_PACKAGE_ORIGIN:
-                case DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN:
                 case ELEMENTARY_STABLE_PACKAGE_ORIGIN:
                     return true;
                 default:
@@ -336,7 +332,7 @@ public class AppCenterCore.Package : Object {
             if (backend is PackageKitBackend) {
                 if (origin == APPCENTER_PACKAGE_ORIGIN) {
                     return _("AppCenter");
-                } else if (origin == DEPRECATED_ELEMENTARY_STABLE_PACKAGE_ORIGIN || origin == ELEMENTARY_STABLE_PACKAGE_ORIGIN) {
+                } else if (origin == ELEMENTARY_STABLE_PACKAGE_ORIGIN) {
                     return _("elementary Updates");
                 } else if (origin.has_prefix ("ubuntu-")) {
                     return _("Ubuntu (non-curated)");


### PR DESCRIPTION
Now that we have appstream data for focal building in the stable PPA, we can change `bionic` -> `focal`

I've also removed the deprecated origin while I was here.