### PR TITLE
AppInfoView: Don't try to update size info in case of local packages

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -503,7 +503,10 @@ namespace AppCenter.Views {
         }
 
         protected override void update_state (bool first_update = false) {
-            size_label.update ();
+            if (!package.is_local) {
+                size_label.update ();
+            }
+
             if (package.state == AppCenterCore.Package.State.NOT_INSTALLED) {
                 get_app_download_size.begin ();
             }
@@ -526,7 +529,7 @@ namespace AppCenter.Views {
         }
 
         private async void get_app_download_size () {
-            if (package.state == AppCenterCore.Package.State.INSTALLED) {
+            if (package.state == AppCenterCore.Package.State.INSTALLED || package.is_local) {
                 return;
             }
 


### PR DESCRIPTION
`size_label` has an instance only when the package is loaded from local:

https://github.com/elementary/appcenter/blob/dfb5ecd641d1214a67cf7909423400a3894799bb/src/Views/AppInfoView.vala#L367-L376

So we need to make sure it's not null before calling `size_label.update ()`; you should get the following warning message when you load local package with the latest master branch:

```
** (io.elementary.appcenter:45910): CRITICAL **: 21:39:33.842: app_center_widgets_size_label_update: assertion 'self != NULL' failed
```
