### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,7 @@ conf_data.set('VERSION', meson.project_version())
 conf_data.set('CONFIGDIR', config_dir)
 conf_data.set('EXEC_PATH', join_paths (get_option('prefix'), get_option('bindir'), meson.project_name()))
 conf_data.set('HOUSTON_API_URL', get_option('api_url'))
+conf_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 
 subdir('data')
 subdir('src')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -58,6 +58,8 @@ public class AppCenter.App : Gtk.Application {
         flags |= ApplicationFlags.HANDLES_OPEN;
         Intl.setlocale (LocaleCategory.ALL, "");
         Intl.textdomain (Build.GETTEXT_PACKAGE);
+        Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
+        Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");
 
         add_main_option_entries (APPCENTER_OPTIONS);
 

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -2,6 +2,7 @@ namespace Build {
     public const string APP_NAME = "@APP_NAME@";
     public const string HIDDEN_APP_LIST = "@HIDDEN_APP_LIST@";
     public const string CONFIGDIR = "@CONFIGDIR@";
+    public const string LOCALEDIR = "@LOCALEDIR@";
     public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
     public const string PROJECT_NAME = "@PROJECT_NAME@";
     public const string VERSION = "@VERSION@";


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)