### PR TITLE
Drivers: Ensure headers are installed for dkms drivers

### DIFF
--- a/src/Core/Job.vala
+++ b/src/Core/Job.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2019 elementary, Inc. (https://elementary.io)
+ * Copyright 2019-2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,7 +36,8 @@ public class AppCenterCore.Job : Object {
         UPDATE_PACKAGE,
         REMOVE_PACKAGE,
         IS_PACKAGE_INSTALLED,
-        GET_PACKAGE_DETAILS
+        GET_PACKAGE_DETAILS,
+        GET_PACKAGE_DEPENDENCIES
     }
 
     public Job (Type type) {
@@ -87,4 +88,9 @@ public class AppCenterCore.IsPackageInstalledArgs : JobArgs {
 
 public class AppCenterCore.GetPackageDetailsArgs : JobArgs {
     public Package package;
+}
+
+public class AppCenterCore.GetPackageDependenciesArgs : JobArgs {
+    public Package package;
+    public Cancellable cancellable;
 }

--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2019 elementary, Inc. (https://elementary.io)
+ * Copyright 2019-2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -111,6 +111,21 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
                 }
             } catch (Error e) {
                 warning ("Unable to check if driver is installed: %s", e.message);
+            }
+
+            var depends = yield PackageKitBackend.get_default ().get_package_dependencies (package, cancellable);
+            // If the driver depends on dkms, it means we need to build some kernel modules for it, so we need kernel headers
+            if ("dkms" in depends) {
+                // Ensure we have matching kernel headers installed for our installed `linux-image-generic` metapackages.
+                // Sometimes Ubuntu drivers depend on non-HWE headers and the module doesn't get built for the running kernel
+                var installed = yield PackageKitBackend.get_default ().get_installed_packages (cancellable);
+                foreach (var pkg in installed) {
+                    unowned string pkgname = pkg.get_name ();
+                    if (pkgname.has_prefix ("linux-image-generic")) {
+                        pkgnames += pkgname.replace ("linux-image", "linux-headers");
+                        package.component.set_pkgnames (pkgnames);
+                    }
+                }
             }
 
             cached_packages.add (package);


### PR DESCRIPTION
Fixes #1603 

As described in the linked issue report, the `bcmwl-kernel-source` module and probably other Ubuntu driver packages, only depend on the non-HWE kernel headers.

As they are dkms drivers, they have to compile the driver from source against a set of kernel headers that match the running kernel. On elementary and HWE Ubuntu, installing one of these drivers via any means (AppCenter/`apt`/`ubuntu-drivers`) pulls in the headers for the non-HWE kernel and if you don't already have the HWE headers installed by some other means, the module doesn't get compiled for your running kernel and you're left confused because you installed the driver but it doesn't work.

This checks if a driver to be installed depends on `dkms`. If so, we know it needs headers, so we add the correct header metapackages to the list of packages to be installed with the driver. If those headers are already installed, then no big deal, they just get skipped. If they were missing, at least you have a working driver at the end of it.

I've tested that this correctly installs a working `bcmwl-kernel-source` driver on my laptop with a Broadcom WiFi chipset.