### PR TITLE
Oars socialinfo

### DIFF
--- a/data/icons/categories.gresource.xml
+++ b/data/icons/categories.gresource.xml
@@ -20,6 +20,7 @@
     <file alias="application-content-gambling-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/gambling.svg</file>
     <file alias="application-content-offensive-language-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/language.svg</file>
     <file alias="application-content-sex-nudity-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/nudity.svg</file>
+    <file alias="application-content-socal-info-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/social-info.svg</file>
     <file alias="application-content-illicit-substance-symbolic" compressed="true" preprocess="xml-stripblanks">oars/substance.svg</file>
     <file alias="application-content-violence-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/violence.svg</file>
   </gresource>

--- a/data/icons/oars/social-info.svg
+++ b/data/icons/oars/social-info.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="32"
+   height="32"
+   sodipodi:docname="social-info.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="38.03125"
+     inkscape:cx="15.986853"
+     inkscape:cy="12.21364"
+     inkscape:window-width="2560"
+     inkscape:window-height="1379"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="rect1280"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M 5,1 C 2.784,1 1,2.8084335 1,5 V 9 H 3 V 5 C 3,3.892 3.892,3 5,3 H 9 V 1 Z m 18,0 v 2 h 4 c 1.108,0 1.731271,0.9250821 2,2 v 4 h 2 V 5 C 31,2.784 29.216,1 27,1 Z m -7,4 c -3.313708,0 -6,2.6862915 -6,6 0,3.313708 2.686292,6 6,6 3.313708,0 6,-2.686292 6,-6 C 22,7.6862915 19.313708,5 16,5 Z M 15.53125,18 C 11.795857,18.112913 8,19.973012 8,22.791016 8,24.568679 9.4264188,26 11.199219,26 h 9.601562 C 22.573581,26 24,24.568679 24,22.791016 23.91899,20.100989 20.282321,18.148265 16.441406,18.005859 Z M 1,23 v 4 c 0,2.216 1.784,4 4,4 H 9 V 29 H 5 C 3.892,29 3,28.108 3,27 v -4 z m 28,0 v 4 c 0,1.108 -0.892,2 -2,2 h -4 v 2 h 4 c 2.216,0 4,-1.759599 4,-4 v -4 z"
+     sodipodi:nodetypes="scccssccsccscccsscssssscsssccccssccsscccssccsccc" />
+  <g
+     id="g4"
+     transform="translate(-872,-552)"
+     color="#000000" />
+</svg>

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -1068,25 +1068,31 @@ namespace AppCenter.Views {
 
     class ContentType : Gtk.Grid {
         public ContentType (string title, string description, string icon_name) {
+            orientation = Gtk.Orientation.VERTICAL;
             row_spacing = 3;
 
             var icon = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.DND) {
+                halign = Gtk.Align.START,
                 margin_bottom = 6
             };
 
-            var label = new Gtk.Label (title);
+            var label = new Gtk.Label (title) {
+                xalign = 0
+            };
 
             var description_label = new Gtk.Label (description) {
-                wrap = true,
                 max_width_chars = 25,
-                justify = Gtk.Justification.CENTER
+                wrap = true,
+                xalign = 0
             };
-            description_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
-            description_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-            attach (icon, 0, 0);
-            attach (label, 0, 1);
-            attach (description_label, 0, 2);
+            unowned var description_label_context = description_label.get_style_context ();
+            description_label_context.add_class (Granite.STYLE_CLASS_SMALL_LABEL);
+            description_label_context.add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
+            add (icon);
+            add (label);
+            add (description_label);
         }
     }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -165,12 +165,32 @@ namespace AppCenter.Views {
 
                 if (
                     rating.get_value ("social-chat") > AppStream.ContentRatingValue.NONE ||
-                    rating.get_value ("social-info") > AppStream.ContentRatingValue.NONE ||
                     rating.get_value ("social-audio") > AppStream.ContentRatingValue.NONE ||
                     rating.get_value ("social-location") > AppStream.ContentRatingValue.NONE ||
                     rating.get_value ("social-contacts") > AppStream.ContentRatingValue.NONE
                 ) {
                     oars_flowbox.add (social);
+                }
+
+                var social_info_value = rating.get_value ("social-info");
+                if (social_info_value > AppStream.ContentRatingValue.MILD) {
+                    string? description = null;
+                    switch (social_info_value) {
+                        case AppStream.ContentRatingValue.MODERATE:
+                            description = _("Collects anonymous usage data");
+                            break;
+                        case AppStream.ContentRatingValue.INTENSE:
+                            description = _("Collects usage data that could be used to identify you");
+                            break;
+                    }
+
+                    var social_info = new ContentType (
+                        _("Info Sharing"),
+                        description,
+                        "application-content-socal-info-symbolic"
+                    );
+
+                    oars_flowbox.add (social_info);
                 }
             }
 
@@ -1049,17 +1069,24 @@ namespace AppCenter.Views {
 
     class ContentType : Gtk.Grid {
         public ContentType (string title, string description, string icon_name) {
-            row_spacing = 6;
-            tooltip_text = description;
-
             var icon = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.DND) {
+                margin_bottom = 6,
                 hexpand = true
             };
 
             var label = new Gtk.Label (title);
 
+            var description_label = new Gtk.Label (description) {
+                wrap = true,
+                max_width_chars = 25,
+                justify = Gtk.Justification.CENTER
+            };
+            description_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
+            description_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
             attach (icon, 0, 0);
             attach (label, 0, 1);
+            attach (description_label, 0, 2);
         }
     }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -1068,7 +1068,7 @@ namespace AppCenter.Views {
 
     class ContentType : Gtk.Grid {
         public ContentType (string title, string description, string icon_name) {
-            row_spacing = 6;
+            row_spacing = 3;
 
             var icon = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.DND) {
                 margin_bottom = 6


### PR DESCRIPTION
* Show descriptions for OARS ratings in a label rather than a tooltip
* Break out `social-info` into its own item with specific descriptions for each level

![Screenshot from 2021-09-15 10 40 17](https://user-images.githubusercontent.com/7277719/133482632-275d82d4-be7e-4b9a-a83b-dbce5c3e4c9c.png)
