### PR TITLE
AppInfoView: only show non-curated badge when using `curated` flag

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -106,6 +106,7 @@ namespace AppCenter.Views {
                 margin_bottom = 24
             };
 
+#if CURATED
             if (!package.is_native) {
                 var uncurated = new ContentType (
                     _("Non-Curated"),
@@ -115,6 +116,7 @@ namespace AppCenter.Views {
 
                 oars_flowbox.add (uncurated);
             }
+#endif
 
             var ratings = package_component.get_content_ratings ();
             for (int i = 0; i < ratings.length; i++) {


### PR DESCRIPTION
Follow-up to #1683. If AppCenter is compiled with `-Dcurated=false` it doesn't make sense to show this badge.