### PR TITLE
AppInfoView: load_more_content on realize

### DIFF
--- a/src/Views/AbstractView.vala
+++ b/src/Views/AbstractView.vala
@@ -66,12 +66,6 @@ public abstract class AppCenter.AbstractView : Gtk.Stack {
         add (app_info_view);
         set_visible_child (app_info_view);
 
-        var cache = AppCenterCore.Client.get_default ().screenshot_cache;
-        Timeout.add (transition_duration, () => {
-            app_info_view.load_more_content (cache);
-            return Source.REMOVE;
-        });
-
         app_info_view.show_other_package.connect ((_package, remember_history, _transition_type) => {
             transition_type = _transition_type;
             show_package (_package, remember_history);

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -717,6 +717,8 @@ namespace AppCenter.Views {
                     });
                 });
             }
+
+            realize.connect (load_more_content);
         }
 
         protected override void update_state (bool first_update = false) {
@@ -794,7 +796,9 @@ namespace AppCenter.Views {
             }
         }
 
-        public void load_more_content (AppCenterCore.ScreenshotCache cache) {
+        private void load_more_content () {
+            var cache = AppCenterCore.Client.get_default ().screenshot_cache;
+
             Gtk.TreeIter iter;
             uint count = 0;
             foreach (var origin_package in package.origin_packages) {


### PR DESCRIPTION
Sometimes I've experienced an issue where the method is trying to pack widgets into the carousel before it's completely constructed so we get warnings about how the toplevel container can't hold more than one widget

I'm not sure why this is a timeout waiting for the end of the transition and why we're passing in the cache from `AbstractView`. Is there a significant difference between this and connected to `realize`?