### PR TITLE
GResource: Fix substance icon

### DIFF
--- a/data/icons/categories.gresource.xml
+++ b/data/icons/categories.gresource.xml
@@ -23,7 +23,7 @@
     <file alias="oars-offensive-language-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/language.svg</file>
     <file alias="oars-sex-nudity-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/nudity.svg</file>
     <file alias="oars-socal-info-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/social-info.svg</file>
-    <file alias="oars-illicit-substance-symbolic" compressed="true" preprocess="xml-stripblanks">oars/substance.svg</file>
+    <file alias="oars-illicit-substance-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/substance.svg</file>
     <file alias="oars-violence-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/violence.svg</file>
   </gresource>
   <gresource prefix="/io/elementary/appcenter/backgrounds">


### PR DESCRIPTION
Looks like we missed a `.svg`. Fixes #1709.

![Screenshot from 2021-10-06 21 46 35](https://user-images.githubusercontent.com/611168/136317078-d9da285c-cd84-42fe-b7bd-49036ee1d9b9.png)
