### PR TITLE
AbstractAppContainer: check build flag for noncurated dialog

### DIFF
--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -316,7 +316,7 @@ namespace AppCenter {
 
         private bool install_approved () {
             bool approved = true;
-
+#if CURATED
             var curated_dialog_allowed = App.settings.get_boolean ("non-curated-warning");
             var app_installed = package.state != AppCenterCore.Package.State.NOT_INSTALLED;
             var app_curated = package.is_native || package.is_os_updates;
@@ -354,7 +354,7 @@ namespace AppCenter {
                     return false;
                 }
             }
-
+#endif
             return approved;
         }
     }


### PR DESCRIPTION
Fixes #1702. Only attempt checking and throwing the non-curated dialog if `-Dcurated=true`.