### PR TITLE
FlatpakBackend: Improve XML parsing efficiency

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -948,7 +948,7 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
                     } else {
                         sorted_components.add (component);
                     }
-                    
+
                     break;
                 }
             }


### PR DESCRIPTION
Potential minor efficiency follow up to #1731

We can stop looking for the `<bundle>` tag once we've found it and decided what we're going to do with that component.