### PR TITLE
build: add packagekit_backend meson option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,13 @@ jobs:
         meson configure -Dcurated=false -Dpayments=false -Dsharing=false -Dname=Pop\!_Shop build
         ninja -C build install
 
+    - name: Build (NixOS)
+      env:
+        DESTDIR: out
+      run: |
+        meson configure -Dcurated=false -Dpayments=false -Dpackagekit_backend=false build
+        ninja -C build install
+
   lint:
 
     runs-on: ubuntu-latest

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('name', type : 'string', value : 'AppCenter', description : 'The name of 
 option('payments', type : 'boolean', value : true, description : 'Enable payment features and display paid apps')
 option('sharing', type : 'boolean', value : true, description : 'Display sharing features, i.e. copyable URLs to appcenter.elementary.io')
 option('hide_upstream_distro_apps', type : 'boolean', value : true, description : 'Used for hiding Ubuntu repo apps on elementary OS')
+option('packagekit_backend', type : 'boolean', value : true, description : 'Enable PackageKit backend')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -167,9 +167,11 @@ public class AppCenter.App : Gtk.Application {
 
         var client = AppCenterCore.Client.get_default ();
 
+#if PACKAGEKIT_BACKEND
         if (fake_update_packages != null) {
             AppCenterCore.PackageKitBackend.get_default ().fake_packages = fake_update_packages;
         }
+#endif
 
         if (silent) {
             NetworkMonitor.get_default ().network_changed.connect ((available) => {
@@ -183,6 +185,7 @@ public class AppCenter.App : Gtk.Application {
             return;
         }
 
+#if PACKAGEKIT_BACKEND
         if (local_path != null) {
             var file = File.new_for_commandline_arg (local_path);
 
@@ -192,6 +195,7 @@ public class AppCenter.App : Gtk.Application {
                 warning ("Failed to load local AppStream XML file: %s", e.message);
             }
         }
+#endif
 
         if (main_window == null) {
             main_window = new MainWindow (this);

--- a/src/Core/BackendAggregator.vala
+++ b/src/Core/BackendAggregator.vala
@@ -26,8 +26,10 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
 
     construct {
         backends = new Gee.ArrayList<unowned Backend> ();
+#if PACKAGEKIT_BACKEND
         backends.add (PackageKitBackend.get_default ());
         backends.add (UbuntuDriversBackend.get_default ());
+#endif
         backends.add (FlatpakBackend.get_default ());
 
         unowned Gtk.Application app = (Gtk.Application) GLib.Application.get_default ();

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -328,7 +328,14 @@ public class AppCenterCore.Package : Object {
     public string origin_description {
         owned get {
             unowned string origin = component.get_origin ();
-            if (backend is PackageKitBackend) {
+            if (backend is FlatpakBackend) {
+                var fp_package = this as FlatpakPackage;
+                if (fp_package != null && fp_package.installation == FlatpakBackend.system_installation) {
+                    return _("%s (system-wide)").printf (origin);
+                }
+                return origin;
+#if PACKAGEKIT_BACKEND
+            } else if (backend is PackageKitBackend) {
                 if (origin == APPCENTER_PACKAGE_ORIGIN) {
                     return _("AppCenter");
                 } else if (origin == ELEMENTARY_STABLE_PACKAGE_ORIGIN) {
@@ -336,15 +343,9 @@ public class AppCenterCore.Package : Object {
                 } else if (origin.has_prefix ("ubuntu-")) {
                     return _("Ubuntu (non-curated)");
                 }
-            } else if (backend is FlatpakBackend) {
-                var fp_package = this as FlatpakPackage;
-                if (fp_package != null && fp_package.installation == FlatpakBackend.system_installation) {
-                    return _("%s (system-wide)").printf (origin);
-                }
-
-                return origin;
             } else if (backend is UbuntuDriversBackend) {
                 return _("Ubuntu Drivers");
+#endif
             }
 
             return _("Unknown Origin (non-curated)");
@@ -434,11 +435,15 @@ public class AppCenterCore.Package : Object {
         _author_title = null;
         backend_details = null;
 
+#if PACKAGEKIT_BACKEND
         // The version on a PackageKit package comes from the package not AppStream, so only reset the version
         // on other backends
         if (!(backend is PackageKitBackend)) {
             _latest_version = null;
         }
+#else
+        _latest_version = null;
+#endif
 
         this.component = component;
     }

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -52,6 +52,7 @@ public class AppCenterCore.UpdateManager : Object {
             installed_package.update_state ();
         }
 
+#if PACKAGEKIT_BACKEND
         Pk.Results pk_updates;
         unowned PackageKitBackend client = PackageKitBackend.get_default ();
         try {
@@ -60,10 +61,12 @@ public class AppCenterCore.UpdateManager : Object {
             warning ("Unable to get updates from PackageKit backend: %s", e.message);
             return 0;
         }
+#endif
 
         uint os_count = 0;
         string os_desc = "";
 
+#if PACKAGEKIT_BACKEND
         var package_array = pk_updates.get_package_array ();
         debug ("PackageKit backend reports %d updates", package_array.length);
 
@@ -87,6 +90,7 @@ public class AppCenterCore.UpdateManager : Object {
                 );
             }
         });
+#endif
 
         os_updates.component.set_pkgnames ({});
         os_updates.change_information.clear_update_info ();
@@ -159,6 +163,7 @@ public class AppCenterCore.UpdateManager : Object {
             count += 1;
         }
 
+#if PACKAGEKIT_BACKEND
         pk_updates.get_details_array ().foreach ((pk_detail) => {
             var pk_package = new Pk.Package ();
             try {
@@ -181,6 +186,7 @@ public class AppCenterCore.UpdateManager : Object {
                 critical (e.message);
             }
         });
+#endif
 
         os_updates.update_state ();
         return count;

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -107,13 +107,9 @@ public class AppCenter.Homepage : AbstractView {
             column_spacing = 24,
             orientation = Gtk.Orientation.VERTICAL
         };
-#if PACKAGEKIT_BACKEND
         grid.add (banner_revealer);
         grid.add (recently_updated_revealer);
         grid.add (categories_label);
-#else
-        category_flow.margin_top = 12;
-#endif
         grid.add (category_flow);
 
         scrolled_window = new Gtk.ScrolledWindow (null, null) {

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -107,9 +107,13 @@ public class AppCenter.Homepage : AbstractView {
             column_spacing = 24,
             orientation = Gtk.Orientation.VERTICAL
         };
+#if PACKAGEKIT_BACKEND
         grid.add (banner_revealer);
         grid.add (recently_updated_revealer);
         grid.add (categories_label);
+#else
+        category_flow.margin_top = 12;
+#endif
         grid.add (category_flow);
 
         scrolled_window = new Gtk.ScrolledWindow (null, null) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,10 +12,8 @@ appcenter_files = files(
     'Core/FlatpakBackend.vala',
     'Core/Job.vala',
     'Core/Package.vala',
-    'Core/PackageKitBackend.vala',
     'Core/ScreenshotCache.vala',
     'Core/Task.vala',
-    'Core/UbuntuDriversBackend.vala',
     'Core/UpdateManager.vala',
     'Dialogs/InstallFailDialog.vala',
     'Dialogs/NonCuratedWarningDialog.vala',
@@ -74,6 +72,14 @@ endif
 
 if get_option('hide_upstream_distro_apps')
     args += '--define=HIDE_UPSTREAM_DISTRO_APPS'
+endif
+
+if get_option('packagekit_backend')
+    args += '--define=PACKAGEKIT_BACKEND'
+    appcenter_files += files(
+        'Core/PackageKitBackend.vala',
+        'Core/UbuntuDriversBackend.vala',
+    )
 endif
 
 executable(


### PR DESCRIPTION
Sorry for this weird merge request, but sadly appcenter doesn't work on NixOS currently because of the current status of the packagekit on NixOS is not that matured. Excluding PackageKitBackend and UbuntuDriversBackend resolves most issues and at least we can search / install / update / remove some flatpak applications now after adding some flatpak remotes.

| <img src="https://user-images.githubusercontent.com/20080233/139618242-81bf103f-25f0-4d0f-a78f-f8ce5056dc4b.png"> | <img src="https://user-images.githubusercontent.com/20080233/139664671-8801f56d-0e2e-4b2d-b977-5428f8ea4396.png"> | <img src="https://user-images.githubusercontent.com/20080233/139618252-4c3c2690-6b71-42a5-8953-f7b03e7a3c1e.png"> | <img src="https://user-images.githubusercontent.com/20080233/139664768-22345a07-19be-4832-bac7-4a24a2c4bbc1.png"> |
|:----:|:----:|:----:|:----:|

This is probably not a solution for https://github.com/elementary/appcenter/issues/1076, however it will be great if appcenter can work on NixOS.

And very sorry I am adding 8d75bb9a6edcc7fb6fe9791df00310fce103adc6 as some (but not all) app icons failed to load on both banner and recently updated section and I have no idea for this yet (and seems the issue does not happen elsewhere, see above screenshots, and I noticed that when I keep the cache in `~/.cache/io.elementary.appcenter` then launch the original appcenter with all backends, all icons load). If the issue can be reproduced, will be appreciated if anyone can hack on it, otherwise I am also happy to drop that.

Not sure if this is related:

```
Gtk-WARNING **: 19:13:31.983: Could not load a pixbuf from icon theme.
This may indicate that pixbuf loaders or the mime database could not be found.
```

| <img src="https://user-images.githubusercontent.com/20080233/139663590-8b87725e-b516-49e9-a31b-56ce4093aa5d.png" width=30%> |
|:---:|
