### PR TITLE
Homepage: Allow AppCenter Homepage to shrink to narrow sizes

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -11,6 +11,18 @@
     <p>The open source, pay-what-you-want app store from elementary. Reviewed and curated by elementary to ensure a native, privacy-respecting, and secure experience. Browse by categories or search and discover new apps. AppCenter is also used for updating your system to the latest and greatest version for new features and fixes.</p>
   </description>
   <releases>
+    <release version="3.9.0" date="2021-10-28" urgency="medium">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Improve wrapping at narrow window sizes</li>
+        </ul>
+        <p>Improvements:</p>
+        <ul>
+          <li>Allow Window to shrink to much narrower sizes</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.8.2" date="2021-10-29" urgency="medium">
       <description>
         <p>Fixes:</p>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -129,7 +129,8 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
     construct {
         Hdy.init ();
         icon_name = Build.PROJECT_NAME;
-        set_size_request (910, 640);
+        set_default_size (910, 640);
+        set_size_request (500, 500);
 
         title = _(Build.APP_NAME);
 

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -23,10 +23,12 @@ namespace AppCenter.Views {
       * Does not show Uninstall Button **/
     public class AppListUpdateView : AbstractAppList {
         private Gtk.SizeGroup action_button_group;
+        private Gtk.SizeGroup release_size_group;
         private bool updating_all_apps = false;
 
         construct {
             action_button_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
+            release_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
 
             var loading_view = new Granite.Widgets.AlertView (
                 _("Checking for Updates"),
@@ -97,7 +99,7 @@ namespace AppCenter.Views {
         }
 
         protected override AppRowInterface construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.installed (package, info_grid_group, action_button_group);
+            return new Widgets.PackageRow.installed (package, info_grid_group, action_button_group, release_size_group);
         }
 
         [CCode (instance_pos = -1)]

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -71,7 +71,7 @@ public class AppCenter.Homepage : AbstractView {
             row_spacing = 12,
             homogeneous = true,
             max_children_per_line = 5,
-            min_children_per_line = 3
+            min_children_per_line = 1
         };
 
         var recently_updated_grid = new Gtk.Grid () {

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -70,8 +70,7 @@ public class AppCenter.Homepage : AbstractView {
             column_spacing = 12,
             row_spacing = 12,
             homogeneous = true,
-            max_children_per_line = 5,
-            min_children_per_line = 1
+            max_children_per_line = 5
         };
 
         var recently_updated_grid = new Gtk.Grid () {

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -111,7 +111,7 @@ namespace AppCenter {
             action_button_group.add_widget (open_button);
 
             action_stack = new Gtk.Stack ();
-            action_stack.hexpand = true;
+            action_stack.hexpand = false;
             action_stack.hhomogeneous = false;
             action_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
             action_stack.add_named (button_grid, "buttons");

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -111,7 +111,6 @@ namespace AppCenter {
             action_button_group.add_widget (open_button);
 
             action_stack = new Gtk.Stack ();
-            action_stack.hexpand = false;
             action_stack.hhomogeneous = false;
             action_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
             action_stack.add_named (button_grid, "buttons");

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -32,7 +32,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
     private Gtk.Grid info_grid;
 
-    public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
+    public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, Gtk.SizeGroup? release_size_group) {
         base (package);
 
         if (action_size_group != null) {
@@ -42,6 +42,10 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
         if (info_size_group != null) {
             info_size_group.add_widget (info_grid);
+        }
+
+        if (release_size_group != null) {
+            release_size_group.add_widget (release_stack_revealer);
         }
 
         set_up_package ();
@@ -91,11 +95,11 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
         release_stack_revealer = new Gtk.Revealer ();
         release_stack_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+        release_stack_revealer.hexpand = true;
         release_stack_revealer.add (release_stack);
 
         info_grid = new Gtk.Grid () {
             column_spacing = 12,
-            hexpand = true,
             row_spacing = 6,
             valign = Gtk.Align.START
         };
@@ -107,12 +111,14 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         action_stack.margin_top = 10;
         action_stack.valign = Gtk.Align.START;
 
-        var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 24);
-        box.pack_start (info_grid);
-        box.pack_end (action_stack);
-        box.set_center_widget (release_stack_revealer);
+        var grid = new Gtk.Grid () {
+            column_spacing = 24
+        };
+        grid.attach (info_grid, 0, 0);
+        grid.attach (release_stack_revealer, 2, 0, 1, 2);
+        grid.attach (action_stack, 3, 0);
 
-        add (box);
+        add (grid);
     }
 
     protected override void set_up_package () {

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -107,14 +107,12 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         action_stack.margin_top = 10;
         action_stack.valign = Gtk.Align.START;
 
-        var grid = new Gtk.Grid () {
-            column_spacing = 24
-        };
-        grid.attach (info_grid, 0, 0);
-        grid.attach (release_stack_revealer, 2, 0, 1, 2);
-        grid.attach (action_stack, 3, 0);
+        var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 24);
+        box.pack_start (info_grid);
+        box.pack_end (action_stack);
+        box.set_center_widget (release_stack_revealer);
 
-        add (grid);
+        add (box);
     }
 
     protected override void set_up_package () {

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -95,6 +95,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
         info_grid = new Gtk.Grid () {
             column_spacing = 12,
+            hexpand = true,
             row_spacing = 6,
             valign = Gtk.Align.START
         };

--- a/src/Widgets/AppContainers/ListPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/ListPackageRowGrid.vala
@@ -29,7 +29,11 @@ public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
         package_summary = new Gtk.Label (null) {
             ellipsize = Pango.EllipsizeMode.END,
             valign = Gtk.Align.START,
-            xalign = 0
+            xalign = 0,
+            yalign = 0,
+            max_width_chars = 1,
+            wrap = true,
+            lines = 3
         };
         package_summary.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 

--- a/src/Widgets/AppContainers/ListPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/ListPackageRowGrid.vala
@@ -29,7 +29,7 @@ public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
         package_summary = new Gtk.Label (null) {
             ellipsize = Pango.EllipsizeMode.END,
             hexpand = true,
-            lines = 3,
+            lines = 2,
             max_width_chars = 1,
             valign = Gtk.Align.START,
             wrap = true,

--- a/src/Widgets/AppContainers/ListPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/ListPackageRowGrid.vala
@@ -28,12 +28,13 @@ public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
     construct {
         package_summary = new Gtk.Label (null) {
             ellipsize = Pango.EllipsizeMode.END,
+            hexpand = true,
+            lines = 3,
+            max_width_chars = 1,
             valign = Gtk.Align.START,
+            wrap = true,
             xalign = 0,
             yalign = 0,
-            max_width_chars = 1,
-            wrap = true,
-            lines = 3
         };
         package_summary.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -23,7 +23,7 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         activate_on_single_click = true;
         homogeneous = true;
         margin_bottom = 12;
-        min_children_per_line = 2;
+        min_children_per_line = 1;
 
         add (get_category (_("Accessories"), "applications-accessories", {"Utility"}, "accessories"));
         add (get_category (_("Audio"), "applications-audio-symbolic", {"Audio", "Music"}, "audio"));

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -22,8 +22,8 @@ namespace AppCenter.Widgets {
     public class PackageRow : Gtk.ListBoxRow, AppRowInterface {
         AbstractPackageRowGrid grid;
 
-        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
-            grid = new InstalledPackageRowGrid (package, info_size_group, action_size_group);
+        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, Gtk.SizeGroup? release_size_group) {
+            grid = new InstalledPackageRowGrid (package, info_size_group, action_size_group, release_size_group);
             add (grid);
             ((InstalledPackageRowGrid) grid).changed.connect (() => {
                 changed ();


### PR DESCRIPTION
Updates the layout for ListPackageRowGrid to better wrap at narrow sizes and to reflow at larger sizes. This allows the Homepage flowboxes to each be set at 1 min children per row, allowing the Homepage to shrink to much narrower sizes.