### PR TITLE
AppInfoView: Add scalable, full-width screenshots

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -916,12 +916,12 @@ namespace AppCenter.Views {
                 Idle.add (() => {
                     var number_of_screenshots = app_screenshots.get_children ().length ();
 
-                    
+
                     if (number_of_screenshots > 0) {
                         screenshot_stack.visible_child = screenshot_overlay;
                         stack_context.remove_class ("loading");
-                        
-                        
+
+
                         if (number_of_screenshots > 1) {
                             screenshot_next.no_show_all = false;
                             screenshot_next.show_all ();
@@ -929,15 +929,15 @@ namespace AppCenter.Views {
                             screenshot_previous.show_all ();
                         }
 
-                        /* 
+                        /*
                         * There's some weird bug where Apps with just one
                         * screenshot load the screenshot very small. For some
                         * reason, hiding and re-showing the screenhot makes it
                         * large again, but it only happens with one screenshot
                         * in the carousel. As a workaround, we can add an
-                        * extra copy of the first screenshot and disable all 
-                        * navigation to make it look/work like a single 
-                        * screenshot. 
+                        * extra copy of the first screenshot and disable all
+                        * navigation to make it look/work like a single
+                        * screenshot.
                         */
                         if (number_of_screenshots == 1) {
                             load_screenshot (screenshot_files[0]);
@@ -961,7 +961,7 @@ namespace AppCenter.Views {
             try {
                 AppCenter.Widgets.AppScreenshot image = new AppCenter.Widgets.AppScreenshot ();
                 image.set_path (path);
-                
+
 
                 Idle.add (() => {
                     image.show ();

--- a/src/Widgets/AppScreenshot.vala
+++ b/src/Widgets/AppScreenshot.vala
@@ -1,0 +1,79 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2014-2016 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Ian Santopietro <ian@system76.com>
+ */
+ public class AppCenter.Widgets.AppScreenshot : Gtk.DrawingArea {
+    private string file_path;
+    private Gdk.Pixbuf? pixbuf;
+    private int pixbuf_width {
+    get { return pixbuf != null ? pixbuf.width : 1; }
+    }
+    private int pixbuf_height {
+    get { return pixbuf != null ? pixbuf.height : 1; }
+    }
+    
+    public void set_path (string path_text) {
+        file_path = path_text;
+        try {
+            pixbuf = new Gdk.Pixbuf.from_file (file_path);
+        }
+        catch (Error e) {
+            critical ("Couldn't load pixbuf: %s", e.message);
+            pixbuf = null;
+        }
+    }
+    
+    protected override bool draw (Cairo.Context cr) {
+        if (pixbuf == null)
+            return Gdk.EVENT_PROPAGATE;
+        int height = get_allocated_height ();
+        int width = get_allocated_width ();
+        if (width > 800) {
+            width = 800;
+        }
+        double scale = double.min((double) height / pixbuf_height, (double) width / pixbuf_width);
+        cr.scale (scale, scale);
+        Gdk.cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
+        cr.paint ();
+        return Gdk.EVENT_PROPAGATE;
+    }
+    
+    protected override Gtk.SizeRequestMode get_request_mode () {
+        return Gtk.SizeRequestMode.HEIGHT_FOR_WIDTH;
+    }
+
+    protected override void get_preferred_width (out int min, out int nat) {
+    min = 0;
+    nat = pixbuf_width;
+    }
+    
+    protected override void get_preferred_height (out int min, out int nat) {
+    min = 0;
+    nat = pixbuf_height;
+    }
+    
+    protected override void get_preferred_height_for_width (int width, out int min, out int nat) {
+        min = width * pixbuf_height / pixbuf_width;
+    nat = min;
+    }
+
+    protected override void get_preferred_width_for_height (int height, out int min, out int nat) {
+        min = height * pixbuf_width / pixbuf_height;
+    nat = min;
+    }
+}

--- a/src/Widgets/AppScreenshot.vala
+++ b/src/Widgets/AppScreenshot.vala
@@ -26,7 +26,7 @@
     private int pixbuf_height {
     get { return pixbuf != null ? pixbuf.height : 1; }
     }
-    
+
     public void set_path (string path_text) {
         file_path = path_text;
         try {
@@ -37,7 +37,7 @@
             pixbuf = null;
         }
     }
-    
+
     protected override bool draw (Cairo.Context cr) {
         if (pixbuf == null)
             return Gdk.EVENT_PROPAGATE;
@@ -46,13 +46,13 @@
         if (width > 800) {
             width = 800;
         }
-        double scale = double.min((double) height / pixbuf_height, (double) width / pixbuf_width);
+        double scale = double.min ((double) height / pixbuf_height, (double) width / pixbuf_width);
         cr.scale (scale, scale);
         Gdk.cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
         cr.paint ();
         return Gdk.EVENT_PROPAGATE;
     }
-    
+
     protected override Gtk.SizeRequestMode get_request_mode () {
         return Gtk.SizeRequestMode.HEIGHT_FOR_WIDTH;
     }
@@ -61,12 +61,12 @@
     min = 0;
     nat = pixbuf_width;
     }
-    
+
     protected override void get_preferred_height (out int min, out int nat) {
     min = 0;
     nat = pixbuf_height;
     }
-    
+
     protected override void get_preferred_height_for_width (int width, out int min, out int nat) {
         min = width * pixbuf_height / pixbuf_width;
     nat = min;

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,6 +35,7 @@ appcenter_files = files(
     'Views/SearchView.vala',
     'Views/AbstractView.vala',
     'Widgets/AbstractAppList.vala',
+    'Widgets/AppScreenshot.vala',
     'Widgets/Banner.vala',
     'Widgets/CardNumberEntry.vala',
     'Widgets/CategoryFlowBox.vala',


### PR DESCRIPTION
Adds scalable full-width screenshots to the AppInfoView. This allows the screenshots to shrink at narrow window sizes while still displaying large, beautiful screenhots at larger sizes.

Requires #1743 