### PR TITLE
Allow narrower window sizes

### DIFF
--- a/data/io.elementary.appcenter.appdata.xml.in
+++ b/data/io.elementary.appcenter.appdata.xml.in
@@ -11,6 +11,15 @@
     <p>The open source, pay-what-you-want app store from elementary. Reviewed and curated by elementary to ensure a native, privacy-respecting, and secure experience. Browse by categories or search and discover new apps. AppCenter is also used for updating your system to the latest and greatest version for new features and fixes.</p>
   </description>
   <releases>
+    <release version="3.9.0" date="2021-10-28" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Allow window to shrink to much narrower sizes</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.8.2" date="2021-10-29" urgency="medium">
       <description>
         <p>Fixes:</p>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -129,7 +129,8 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
     construct {
         Hdy.init ();
         icon_name = Build.PROJECT_NAME;
-        set_size_request (910, 640);
+        set_default_size (910, 640);
+        height_request = 500;
 
         title = _(Build.APP_NAME);
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -1207,8 +1207,7 @@ namespace AppCenter.Views {
                 activate_on_single_click = true,
                 column_spacing = 12,
                 row_spacing = 12,
-                homogeneous = true,
-                min_children_per_line = 2
+                homogeneous = true
             };
 
             foreach (var author_package in author_packages) {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -97,7 +97,7 @@ namespace AppCenter.Views {
         }
 
         protected override AppRowInterface construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.installed (package, info_grid_group, action_button_group);
+            return new Widgets.PackageRow.installed (package, action_button_group);
         }
 
         [CCode (instance_pos = -1)]

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -70,8 +70,7 @@ public class AppCenter.Homepage : AbstractView {
             column_spacing = 12,
             row_spacing = 12,
             homogeneous = true,
-            max_children_per_line = 5,
-            min_children_per_line = 3
+            max_children_per_line = 5
         };
 
         var recently_updated_grid = new Gtk.Grid () {

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -22,7 +22,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
 
     protected Gtk.ScrolledWindow scrolled;
     protected Gtk.ListBox list_box;
-    protected Gtk.SizeGroup info_grid_group;
     protected uint packages_changing = 0;
 
     construct {
@@ -41,8 +40,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
         scrolled = new Gtk.ScrolledWindow (null, null);
         scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scrolled.add (list_box);
-
-        info_grid_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
     }
 
     protected abstract AppRowInterface construct_row_for_package (AppCenterCore.Package package);

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -111,7 +111,6 @@ namespace AppCenter {
             action_button_group.add_widget (open_button);
 
             action_stack = new Gtk.Stack ();
-            action_stack.hexpand = true;
             action_stack.hhomogeneous = false;
             action_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
             action_stack.add_named (button_grid, "buttons");

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -32,7 +32,9 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
     private Gtk.Grid info_grid;
 
-    public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
+    private static Gtk.SizeGroup info_size_group;
+
+    public InstalledPackageRowGrid (AppCenterCore.Package package, Gtk.SizeGroup? action_size_group) {
         base (package);
 
         if (action_size_group != null) {
@@ -40,11 +42,11 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
             action_size_group.add_widget (cancel_button);
         }
 
-        if (info_size_group != null) {
-            info_size_group.add_widget (info_grid);
-        }
-
         set_up_package ();
+    }
+
+    static construct {
+        info_size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
     }
 
     construct {
@@ -105,6 +107,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         action_stack.homogeneous = false;
         action_stack.margin_top = 10;
         action_stack.valign = Gtk.Align.START;
+        action_stack.hexpand = true;
 
         var grid = new Gtk.Grid () {
             column_spacing = 24
@@ -114,6 +117,8 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         grid.attach (action_stack, 3, 0);
 
         add (grid);
+
+        info_size_group.add_widget (info_grid);
     }
 
     protected override void set_up_package () {

--- a/src/Widgets/AppContainers/ListPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/ListPackageRowGrid.vala
@@ -32,6 +32,7 @@ public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
             lines = 2,
             max_width_chars = 1,
             valign = Gtk.Align.START,
+            width_chars = 20,
             wrap = true,
             xalign = 0
         };

--- a/src/Widgets/AppContainers/ListPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/ListPackageRowGrid.vala
@@ -28,7 +28,11 @@ public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
     construct {
         package_summary = new Gtk.Label (null) {
             ellipsize = Pango.EllipsizeMode.END,
+            hexpand = true,
+            lines = 2,
+            max_width_chars = 1,
             valign = Gtk.Align.START,
+            wrap = true,
             xalign = 0
         };
         package_summary.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
@@ -40,9 +44,12 @@ public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
         grid.attach (app_icon_overlay, 0, 0, 1, 2);
         grid.attach (package_name, 1, 0);
         grid.attach (package_summary, 1, 1);
-        grid.attach (action_stack, 2, 0, 1, 2);
 
-        add (grid);
+        var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
+        box.pack_start (grid);
+        box.pack_end (action_stack);
+
+        add (box);
     }
 
     protected override void set_up_package () {

--- a/src/Widgets/AppContainers/ListPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/ListPackageRowGrid.vala
@@ -44,12 +44,9 @@ public class AppCenter.Widgets.ListPackageRowGrid : AbstractPackageRowGrid {
         grid.attach (app_icon_overlay, 0, 0, 1, 2);
         grid.attach (package_name, 1, 0);
         grid.attach (package_summary, 1, 1);
+        grid.attach (action_stack, 2, 0, 1, 2);
 
-        var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
-        box.pack_start (grid);
-        box.pack_end (action_stack);
-
-        add (box);
+        add (grid);
     }
 
     protected override void set_up_package () {

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -23,7 +23,6 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
         activate_on_single_click = true;
         homogeneous = true;
         margin_bottom = 12;
-        min_children_per_line = 2;
 
         add (get_category (_("Accessories"), "applications-accessories", {"Utility"}, "accessories"));
         add (get_category (_("Audio"), "applications-audio-symbolic", {"Audio", "Music"}, "audio"));

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -22,8 +22,8 @@ namespace AppCenter.Widgets {
     public class PackageRow : Gtk.ListBoxRow, AppRowInterface {
         AbstractPackageRowGrid grid;
 
-        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group) {
-            grid = new InstalledPackageRowGrid (package, info_size_group, action_size_group);
+        public PackageRow.installed (AppCenterCore.Package package, Gtk.SizeGroup? action_size_group) {
+            grid = new InstalledPackageRowGrid (package, action_size_group);
             add (grid);
             ((InstalledPackageRowGrid) grid).changed.connect (() => {
                 changed ();


### PR DESCRIPTION
Supersedes #1742

* MainWindow: change size request to default size
* AppInfoView, Homepage, CategoryFlowbox: Remove minimum flowbox child number
* AbstractAppContainer.vala: Remove actionstack hexpand to allow name and summary labels to fill width

* InstalledPackageRowGrid:
  * create infosizegroup here instead of passing it through multiple constructors
  * Add hexpand back to actionstack here since we need it to left align expanders which don't preserve width for hidden children

ListPackageRowGrid: expand labels and let them wrap