### PR TITLE
AbstractAppList: Remove unnecessary abstractions

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -74,12 +74,12 @@ namespace AppCenter.Views {
                 add_row_for_package (package);
             }
 
-            on_list_changed ();
+            list_box.invalidate_sort ();
         }
 
         public override void add_package (AppCenterCore.Package package) {
             add_row_for_package (package);
-            on_list_changed ();
+            list_box.invalidate_sort ();
         }
 
         private void add_row_for_package (AppCenterCore.Package package) {
@@ -87,17 +87,9 @@ namespace AppCenter.Views {
 
             // Only add row if this package needs an update or it's not a font or plugin
             if (needs_update || (!package.is_plugin && !package.is_font)) {
-                var row = construct_row_for_package (package);
-                add_row (row);
+                var row = new Widgets.PackageRow.installed (package, action_button_group);
+                list_box.add (row);
             }
-        }
-
-        protected override void on_list_changed () {
-            list_box.invalidate_sort ();
-        }
-
-        protected override AppRowInterface construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.installed (package, action_button_group);
         }
 
         [CCode (instance_pos = -1)]

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -85,24 +85,21 @@ namespace AppCenter.Views {
             current_visible_index = 0U;
         }
 
-        protected override AppRowInterface construct_row_for_package (AppCenterCore.Package package) {
-            return new Widgets.PackageRow.list (package);
-        }
-
         // Show 20 more apps on the listbox
         private void show_more_apps () {
             uint old_index = current_visible_index;
             while (current_visible_index < list_store.get_n_items ()) {
                 var package = (AppCenterCore.Package?) list_store.get_object (current_visible_index);
-                var row = construct_row_for_package (package);
-                add_row (row);
+                var row = new Widgets.PackageRow.list (package);
+                list_box.add (row);
+
                 current_visible_index++;
                 if (old_index + 20 < current_visible_index) {
                     break;
                 }
             }
 
-            on_list_changed ();
+            list_box.invalidate_sort ();
         }
 
         private int search_priority (string name) {

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -40,9 +40,12 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
         scrolled = new Gtk.ScrolledWindow (null, null);
         scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scrolled.add (list_box);
-    }
 
-    protected abstract AppRowInterface construct_row_for_package (AppCenterCore.Package package);
+        list_box.add.connect ((row) => {
+            row.show_all ();
+            ((Widgets.PackageRow) row).get_package ().changing.connect (on_package_changing);
+        });
+    }
 
     public abstract void add_packages (Gee.Collection<AppCenterCore.Package> packages);
     public abstract void add_package (AppCenterCore.Package package);
@@ -58,7 +61,7 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
             }
         }
 
-        on_list_changed ();
+        list_box.invalidate_sort ();
     }
 
     public virtual void clear () {
@@ -73,13 +76,7 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
             row.destroy ();
         };
 
-        on_list_changed ();
-    }
-
-    protected void add_row (AppRowInterface row) {
-        row.show_all ();
-        list_box.add (row);
-        row.get_package ().changing.connect (on_package_changing);
+        list_box.invalidate_sort ();
     }
 
     protected virtual Gee.Collection<AppCenterCore.Package> get_packages () {
@@ -110,11 +107,7 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
 
         assert (packages_changing >= 0);
         if (packages_changing == 0) {
-            on_list_changed ();
+            list_box.invalidate_sort ();
         }
-    }
-
-    protected virtual void on_list_changed () {
-
     }
 }


### PR DESCRIPTION
* `construct_row_for_package` is never called in the abstract class and it does a different one-liner in each implementation
* Replace `add_row` with connecting to `ListBox.add` so we make sure these things actually happen any time a widget is added to the list and not just when this special function is called
* `on_list_changed ()` only ever calls `invalidate_sort ()`, so just do that directly instead