### PR TITLE
Update Action Button when Uninstalling an App with Available Update

### DIFF
--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -73,7 +73,10 @@ namespace AppCenter {
             uninstall_button_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
             uninstall_button_revealer.add (uninstall_button);
 
-            uninstall_button.clicked.connect (() => uninstall_clicked.begin ());
+            uninstall_button.clicked.connect (() => {
+            	uninstall_clicked.begin ();
+            	action_button.free_string = _("Install");
+            });
 
             open_button = new Gtk.Button.with_label (_("Open"));
 


### PR DESCRIPTION
The Action Button which says "Install", "Update", "Uninstall", or "Free" should be updated to say "Install" should there be an instance where an app has an update and the user uninstalls the app instead. The previous event still shows "Update" even when there is nothing to update anymore as the app is no longer installed.