### PR TITLE
PackagekitBackend: Make nullable state of cancellables consistent

### DIFF
--- a/src/Core/Job.vala
+++ b/src/Core/Job.vala
@@ -48,7 +48,7 @@ public class AppCenterCore.Job : Object {
 public abstract class AppCenterCore.JobArgs { }
 
 public class AppCenterCore.GetInstalledPackagesArgs : JobArgs {
-    public Cancellable cancellable;
+    public Cancellable? cancellable;
 }
 
 public class AppCenterCore.InstallPackageArgs : JobArgs {
@@ -71,15 +71,15 @@ public class AppCenterCore.RemovePackageArgs : JobArgs {
 
 public class AppCenterCore.GetDownloadSizeArgs : JobArgs {
     public Package package;
-    public Cancellable cancellable;
+    public Cancellable? cancellable;
 }
 
 public class AppCenterCore.GetUpdatesArgs : JobArgs {
-    public Cancellable cancellable;
+    public Cancellable? cancellable;
 }
 
 public class AppCenterCore.RefreshCacheArgs : JobArgs {
-    public Cancellable cancellable;
+    public Cancellable? cancellable;
 }
 
 public class AppCenterCore.IsPackageInstalledArgs : JobArgs {
@@ -92,5 +92,5 @@ public class AppCenterCore.GetPackageDetailsArgs : JobArgs {
 
 public class AppCenterCore.GetPackageDependenciesArgs : JobArgs {
     public Package package;
-    public Cancellable cancellable;
+    public Cancellable? cancellable;
 }

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -800,7 +800,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         job.results_ready ();
     }
 
-    public async Pk.Results get_updates (Cancellable cancellable) throws GLib.Error {
+    public async Pk.Results get_updates (Cancellable? cancellable) throws GLib.Error {
         var job_args = new GetUpdatesArgs ();
         job_args.cancellable = cancellable;
 


### PR DESCRIPTION
We can pass `null` to `get_updates`, so ensure we reflect that with a nullable.

Also mark the cancellables as nullable in the args containers for the methods where we can pass null.