### PR TITLE
Avoid multiple circular references

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -130,6 +130,7 @@ public class AppCenter.Homepage : AbstractView {
             });
         }
 
+        banner_timeout_start ();
         load_banners_and_carousels.begin ();
 
         category_flow.child_activated.connect ((child) => {
@@ -184,6 +185,10 @@ public class AppCenter.Homepage : AbstractView {
 
             show_package (package_row_grid.package);
         });
+
+        destroy.connect (() => {
+            banner_timeout_stop ();
+        });
     }
 
     private async void load_banners_and_carousels () {
@@ -226,7 +231,6 @@ public class AppCenter.Homepage : AbstractView {
 
         banner_carousel.show_all ();
         banner_revealer.reveal_child = true;
-        banner_timeout_start ();
 
         foreach (var package in packages_by_release_date) {
             if (recently_updated_carousel.get_children ().length () >= MAX_PACKAGES_IN_CAROUSEL) {
@@ -310,6 +314,10 @@ public class AppCenter.Homepage : AbstractView {
     }
 
     private void banner_timeout_start () {
+        if (banner_timeout_id != 0) {
+            Source.remove (banner_timeout_id);
+        }
+
         banner_timeout_id = Timeout.add (MILLISECONDS_BETWEEN_BANNER_ITEMS, () => {
             var new_index = (uint) banner_carousel.position + 1;
             var max_index = banner_carousel.n_pages - 1; // 0-based index


### PR DESCRIPTION
The use of notify on external objects and of timeout actually increases the reference of the object, try to release it on-demand.