### PR TITLE
Dynamic Links to FlatHub

### DIFF
--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -22,14 +22,13 @@
 namespace AppCenter.Views {
     /** AppList for Category and Search Views.  Sorts by name and does not show Uninstall Button **/
     public class AppListView : AbstractAppList {
-        private Granite.Widgets.AlertView alert_view;
-        public string? current_search_term = null;
+        public string? current_search_term { get; set; default = null; }
         private uint current_visible_index = 0U;
         private GLib.ListStore list_store;
 
         construct {
             var flathub_link = "<a href='https://flathub.org'>%s</a>".printf (_("Flathub"));
-            alert_view = new Granite.Widgets.AlertView (
+            var alert_view = new Granite.Widgets.AlertView (
                 _("No Apps Found"),
                 _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (flathub_link),
                 "edit-find-symbolic"
@@ -49,12 +48,11 @@ namespace AppCenter.Views {
             });
 
             add (scrolled);
-        }
-        
-        notify["current-search-term"].connect (() => {
-            var dyn_flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (uri, _("Flathub"));        
-            alert_view.description = _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (dyn_flathub_link);
-            alert_view.show_all ();            
+
+            notify["current-search-term"].connect (() => {
+                var dyn_flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (current_search_term, _("Flathub"));
+                alert_view.description = _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (dyn_flathub_link);
+            });
         }
 
         public override void add_packages (Gee.Collection<AppCenterCore.Package> packages) {

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -51,7 +51,7 @@ namespace AppCenter.Views {
             add (scrolled);
         }
         
-        public void set_flathub_uri (string uri) {
+        notify["current-search-term"].connect (() => {
             /*
                 Atheesh Thirumalairajan (@candiedoperation)
                 https://github.com/candiedoperation

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -36,7 +36,6 @@ namespace AppCenter.Views {
             );
             
             alert_view.show_all ();        
-        
 #if CURATED
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
 #endif

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -34,8 +34,7 @@ namespace AppCenter.Views {
                 _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf ("https://flathub.org"),
                 "edit-find-symbolic"
             );
-            
-            alert_view.show_all ();        
+            alert_view.show_all ();       
 #if CURATED
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
 #endif

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -31,7 +31,7 @@ namespace AppCenter.Views {
             var flathub_link = "<a href='https://flathub.org'>%s</a>".printf (_("Flathub"));
             alert_view = new Granite.Widgets.AlertView (
                 _("No Apps Found"),
-                _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf ("https://flathub.org"),
+                _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (flathub_link),
                 "edit-find-symbolic"
             );
             alert_view.show_all ();

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -26,7 +26,7 @@ namespace AppCenter.Views {
         private GLib.ListStore list_store;
 
         construct {
-            var flathub_link = "<a href='https://flathub.org'>%s</a>".printf (_("Flathub"));
+            var flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (_(current_search_term, "Flathub"));
             var alert_view = new Granite.Widgets.AlertView (
                 _("No Apps Found"),
                 _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (flathub_link),

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -21,19 +21,21 @@
 namespace AppCenter.Views {
     /** AppList for Category and Search Views.  Sorts by name and does not show Uninstall Button **/
     public class AppListView : AbstractAppList {
+        private Granite.Widgets.AlertView alert_view;
         public string? current_search_term = null;
         private uint current_visible_index = 0U;
         private GLib.ListStore list_store;
 
         construct {
-            var flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (_(current_search_term, "Flathub"));
-            var alert_view = new Granite.Widgets.AlertView (
+            var flathub_link = "<a href='https://flathub.org'>%s</a>".printf (_("Flathub"));
+            alert_view = new Granite.Widgets.AlertView (
                 _("No Apps Found"),
-                _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (flathub_link),
+                _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf ("https://flathub.org"),
                 "edit-find-symbolic"
             );
-            alert_view.show_all ();
-
+            
+            alert_view.show_all ();        
+        
 #if CURATED
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
 #endif
@@ -47,6 +49,21 @@ namespace AppCenter.Views {
             });
 
             add (scrolled);
+        }
+        
+        public void set_flathub_uri (string uri) {
+            /*
+                Atheesh Thirumalairajan (@candiedoperation)
+                https://github.com/candiedoperation
+                
+                This Method has been added in order to provide
+                dynamic flathub.org links for current searched
+                text in the App Search Box
+            */
+            
+            var dyn_flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (uri, _("Flathub"));        
+            alert_view.description = _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (dyn_flathub_link);
+            alert_view.show_all ();            
         }
 
         public override void add_packages (Gee.Collection<AppCenterCore.Package> packages) {

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -34,7 +34,8 @@ namespace AppCenter.Views {
                 _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf ("https://flathub.org"),
                 "edit-find-symbolic"
             );
-            alert_view.show_all ();       
+            alert_view.show_all ();
+
 #if CURATED
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
 #endif

--- a/src/Views/AppListView.vala
+++ b/src/Views/AppListView.vala
@@ -16,6 +16,7 @@
  *
  * Authored by: Corentin Noël <corentin@elementary.io>
  *              Jeremy Wootten <jeremy@elementaryos.org>
+ *              Atheesh Thirumalairajan <candiedoperation@icloud.com>
  */
 
 namespace AppCenter.Views {
@@ -52,15 +53,6 @@ namespace AppCenter.Views {
         }
         
         notify["current-search-term"].connect (() => {
-            /*
-                Atheesh Thirumalairajan (@candiedoperation)
-                https://github.com/candiedoperation
-                
-                This Method has been added in order to provide
-                dynamic flathub.org links for current searched
-                text in the App Search Box
-            */
-            
             var dyn_flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (uri, _("Flathub"));        
             alert_view.description = _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (dyn_flathub_link);
             alert_view.show_all ();            

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -70,7 +70,7 @@ public class AppCenter.Views.SearchView : AbstractView {
         current_category = category;
 
         app_list_view.clear ();
-        app_list_view.set_flathub_uri(current_search_term); //Refer Annotation 01       
+        app_list_view.set_flathub_uri(current_search_term);
         app_list_view.current_search_term = current_search_term;
         unowned Client client = Client.get_default ();
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -66,10 +66,21 @@ public class AppCenter.Views.SearchView : AbstractView {
     }
 
     public void search (string search_term, AppStream.Category? category, bool mimetype = false) {
+        /*
+            Annotation 01
+            Atheesh Thirumalairajan (@candiedoperation)
+            https://github.com/candiedoperation
+            
+            This Method has been implement in order to
+            update the dynamic FlatHub Link if no apps
+            match the search term.
+        */
+        
         current_search_term = search_term;
         current_category = category;
 
         app_list_view.clear ();
+        app_list_view.set_flathub_uri(current_search_term); //Refer Annotation 01       
         app_list_view.current_search_term = current_search_term;
         unowned Client client = Client.get_default ();
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -70,7 +70,7 @@ public class AppCenter.Views.SearchView : AbstractView {
         current_category = category;
 
         app_list_view.clear ();
-        app_list_view.set_flathub_uri(current_search_term);
+        app_list_view.set_flathub_uri (current_search_term);
         app_list_view.current_search_term = current_search_term;
         unowned Client client = Client.get_default ();
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -66,16 +66,6 @@ public class AppCenter.Views.SearchView : AbstractView {
     }
 
     public void search (string search_term, AppStream.Category? category, bool mimetype = false) {
-        /*
-            Annotation 01
-            Atheesh Thirumalairajan (@candiedoperation)
-            https://github.com/candiedoperation
-            
-            This Method has been implement in order to
-            update the dynamic FlatHub Link if no apps
-            match the search term.
-        */
-        
         current_search_term = search_term;
         current_category = category;
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -70,7 +70,6 @@ public class AppCenter.Views.SearchView : AbstractView {
         current_category = category;
 
         app_list_view.clear ();
-        app_list_view.set_flathub_uri (current_search_term);
         app_list_view.current_search_term = current_search_term;
         unowned Client client = Client.get_default ();
 


### PR DESCRIPTION
# Overview
AppCenter refers to a FlatHub Link (https://flathub.org) if no apps match the search term.
This pull request dynamically changes the URL with the currently searched term in the text box.

# Result
On Search `filez` in the Search Box, if no apps match the Link for the FlatHub URL becomes https://flathub.org/apps/search/filez instead of the static https://flathub.org

# How is it Useful?
Until at least one app is installed by Side-loading from FlatHub, AppCenter does not load them automatically. It is convenient for users to click the link and directly navigate to the FlatHub App Search Page instead of Navigating through the FlatHub Website for Searching the App of their need.
