### PR TITLE
Core: Pass the ChangeInformation object around instead of its callback

### DIFF
--- a/src/Core/BackendInterface.vala
+++ b/src/Core/BackendInterface.vala
@@ -38,7 +38,7 @@ public interface AppCenterCore.Backend : Object {
     public abstract async uint64 get_download_size (Package package, Cancellable? cancellable, bool is_update = false) throws GLib.Error;
     public abstract async bool is_package_installed (Package package) throws GLib.Error;
     public abstract async PackageDetails get_package_details (Package package) throws GLib.Error;
-    public abstract async bool install_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error;
-    public abstract async bool update_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error;
-    public abstract async bool remove_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error;
+    public abstract async bool install_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error;
+    public abstract async bool update_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error;
+    public abstract async bool remove_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error;
 }

--- a/src/Core/ChangeInformation.vala
+++ b/src/Core/ChangeInformation.vala
@@ -28,8 +28,6 @@ public class AppCenterCore.ChangeInformation : Object {
         FINISHED
     }
 
-    public delegate void ProgressCallback (bool can_cancel, string status_description, double progress, Status status);
-
     /**
      * This signal is likely to be fired from a non-main thread. Ensure any UI
      * logic driven from this runs on the GTK thread

--- a/src/Core/Job.vala
+++ b/src/Core/Job.vala
@@ -53,19 +53,19 @@ public class AppCenterCore.GetInstalledPackagesArgs : JobArgs {
 
 public class AppCenterCore.InstallPackageArgs : JobArgs {
     public Package package;
-    public ChangeInformation.ProgressCallback cb;
+    public ChangeInformation? change_info;
     public Cancellable? cancellable;
 }
 
 public class AppCenterCore.UpdatePackageArgs : JobArgs {
     public Package package;
-    public ChangeInformation.ProgressCallback cb;
+    public ChangeInformation? change_info;
     public Cancellable? cancellable;
 }
 
 public class AppCenterCore.RemovePackageArgs : JobArgs {
     public Package package;
-    public ChangeInformation.ProgressCallback cb;
+    public ChangeInformation? change_info;
     public Cancellable? cancellable;
 }
 

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -558,12 +558,11 @@ public class AppCenterCore.Package : Object {
     }
 
     private async bool perform_package_operation () throws GLib.Error {
-        ChangeInformation.ProgressCallback cb = change_information.callback;
         var client = AppCenterCore.Client.get_default ();
 
         switch (state) {
             case State.UPDATING:
-                var success = yield backend.update_package (this, (owned)cb, action_cancellable);
+                var success = yield backend.update_package (this, change_information, action_cancellable);
                 if (success) {
                     change_information.clear_update_info ();
                     update_state ();
@@ -571,12 +570,12 @@ public class AppCenterCore.Package : Object {
 
                 return success;
             case State.INSTALLING:
-                var success = yield backend.install_package (this, (owned)cb, action_cancellable);
+                var success = yield backend.install_package (this, change_information, action_cancellable);
                 _installed = success;
                 update_state ();
                 return success;
             case State.REMOVING:
-                var success = yield backend.remove_package (this, (owned)cb, action_cancellable);
+                var success = yield backend.remove_package (this, change_information, action_cancellable);
                 _installed = !success;
                 update_state ();
                 yield client.refresh_updates ();

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -559,7 +559,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
     private void install_package_internal (Job job) {
         unowned var args = (InstallPackageArgs)job.args;
         unowned var package = args.package;
-        unowned ChangeInformation.ProgressCallback cb = args.cb;
+        unowned ChangeInformation? change_info = args.change_info;
         unowned var cancellable = args.cancellable;
 
         reset_progress ();
@@ -591,7 +591,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
 
             results = client.install_packages_sync (packages_ids, cancellable, (progress, status) => {
                 update_progress_status (progress, status);
-                cb (can_cancel, Utils.pk_status_to_string (this.status), this.progress, pk_status_to_appcenter_status (this.status));
+                change_info.callback (can_cancel, Utils.pk_status_to_string (this.status), this.progress, pk_status_to_appcenter_status (this.status));
             });
 
             exit_status = results.get_exit_code ();
@@ -606,10 +606,10 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         job.results_ready ();
     }
 
-    public async bool install_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error {
+    public async bool install_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error {
         var job_args = new InstallPackageArgs ();
         job_args.package = package;
-        job_args.cb = (owned)cb;
+        job_args.change_info = change_info;
         job_args.cancellable = cancellable;
 
         var job = yield launch_job (Job.Type.INSTALL_PACKAGE, job_args);
@@ -624,7 +624,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         unowned var args = (UpdatePackageArgs)job.args;
         unowned var package = args.package;
         unowned var cancellable = args.cancellable;
-        unowned ChangeInformation.ProgressCallback cb = args.cb;
+        unowned ChangeInformation? change_info = args.change_info;
 
         reset_progress ();
 
@@ -642,7 +642,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         try {
             var results = client.update_packages_sync (packages_ids, cancellable, (progress, status) => {
                 update_progress_status (progress, status);
-                cb (can_cancel, Utils.pk_status_to_string (this.status), this.progress, pk_status_to_appcenter_status (this.status));
+                change_info.callback (can_cancel, Utils.pk_status_to_string (this.status), this.progress, pk_status_to_appcenter_status (this.status));
             });
 
             exit_status = results.get_exit_code ();
@@ -657,10 +657,10 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         job.results_ready ();
     }
 
-    public async bool update_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error {
+    public async bool update_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error {
         var job_args = new UpdatePackageArgs ();
         job_args.package = package;
-        job_args.cb = (owned)cb;
+        job_args.change_info = change_info;
         job_args.cancellable = cancellable;
 
         if (update_permission == null) {
@@ -686,7 +686,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         unowned var args = (RemovePackageArgs)job.args;
         unowned var package = args.package;
         unowned var cancellable = args.cancellable;
-        unowned ChangeInformation.ProgressCallback cb = args.cb;
+        unowned ChangeInformation? change_info = args.change_info;
 
         reset_progress ();
 
@@ -703,7 +703,7 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
 
             results = client.remove_packages_sync (packages_ids, true, true, cancellable, (progress, status) => {
                 update_progress_status (progress, status);
-                cb (can_cancel, Utils.pk_status_to_string (this.status), this.progress, pk_status_to_appcenter_status (this.status));
+                change_info.callback (can_cancel, Utils.pk_status_to_string (this.status), this.progress, pk_status_to_appcenter_status (this.status));
             });
 
             exit_status = results.get_exit_code ();
@@ -718,10 +718,10 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         job.results_ready ();
     }
 
-    public async bool remove_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error {
+    public async bool remove_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error {
         var job_args = new RemovePackageArgs ();
         job_args.package = package;
-        job_args.cb = (owned)cb;
+        job_args.change_info = change_info;
         job_args.cancellable = cancellable;
 
         var job = yield launch_job (Job.Type.REMOVE_PACKAGE, job_args);

--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -210,18 +210,18 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
         return true;
     }
 
-    public async bool install_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error {
+    public async bool install_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error {
         cached_packages = null;
-        return yield PackageKitBackend.get_default ().install_package (package, (owned)cb, cancellable);
+        return yield PackageKitBackend.get_default ().install_package (package, change_info, cancellable);
     }
 
-    public async bool remove_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error {
+    public async bool remove_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error {
         cached_packages = null;
-        return yield PackageKitBackend.get_default ().remove_package (package, (owned)cb, cancellable);
+        return yield PackageKitBackend.get_default ().remove_package (package, change_info, cancellable);
     }
 
-    public async bool update_package (Package package, owned ChangeInformation.ProgressCallback cb, Cancellable? cancellable) throws GLib.Error {
-        return yield PackageKitBackend.get_default ().update_package (package, (owned)cb, cancellable);
+    public async bool update_package (Package package, ChangeInformation? change_info, Cancellable? cancellable) throws GLib.Error {
+        return yield PackageKitBackend.get_default ().update_package (package, change_info, cancellable);
     }
 
     private static GLib.Once<UbuntuDriversBackend> instance;


### PR DESCRIPTION
Allows to make sure that we are safe regarding the lifetime of the ChangeInformation
and allows to pass it safely to multiple closures.