### PR TITLE
Client: auto update non-native apps

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -172,7 +172,7 @@ public class AppCenterCore.Client : Object {
                 debug ("Update Flatpaks");
                 var installed_apps = yield FlatpakBackend.get_default ().get_installed_applications (cancellable);
                 foreach (var app in installed_apps) {
-                    if (app.is_native && app.update_available && !app.should_pay) {
+                    if (app.update_available && !app.should_pay) {
                         debug ("Update: %s", app.get_name ());
                         try {
                             yield app.update (false);

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -96,13 +96,15 @@ public class AppCenterCore.UpdateManager : Object {
         var flatpak_updates = yield fp_client.get_updates ();
         debug ("Flatpak backend reports %d updates", flatpak_updates.size);
 
+        var auto_update_enabled = AppCenter.App.settings.get_boolean ("automatic-updates");
+
         foreach (var flatpak_update in flatpak_updates) {
             var appcenter_package = fp_client.lookup_package_by_id (flatpak_update);
             if (appcenter_package != null) {
                 debug ("Added %s to app updates", flatpak_update);
                 apps_with_updates.add (appcenter_package);
 
-                if (!(AppCenter.App.settings.get_boolean ("automatic-updates"))) {
+                if (!auto_update_enabled || appcenter_package.should_pay) {
                     count++;
                 }
 

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -102,7 +102,7 @@ public class AppCenterCore.UpdateManager : Object {
                 debug ("Added %s to app updates", flatpak_update);
                 apps_with_updates.add (appcenter_package);
 
-                if (!(AppCenter.App.settings.get_boolean ("automatic-updates") && appcenter_package.is_native)) {
+                if (!(AppCenter.App.settings.get_boolean ("automatic-updates"))) {
                     count++;
                 }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -215,8 +215,8 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
 
         spinner = new Gtk.Spinner ();
 
-        var automatic_updates_button = new Granite.SwitchModelButton (_("Automatic Updates")) {
-            description = _("Automatically update free and paid-for curated apps")
+        var automatic_updates_button = new Granite.SwitchModelButton (_("Automatic App Updates")) {
+            description = _("System updates and unpaid apps will not update automatically")
         };
 
         automatic_updates_button.notify["active"].connect (() => {


### PR DESCRIPTION
Fixes #1833

* Make copy more clear that this is for app updates only, not operating system updates
* Notify for unpaid apps, and don't recheck settings on every loop