### PR TITLE
PackageKitBackend: don't load Ubuntu components with AppStream 0.15

### DIFF
--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -159,6 +159,8 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         // with elementary's AppStream data.
 #if HIDE_UPSTREAM_DISTRO_APPS
 #if HAS_APPSTREAM_0_15
+        // OS Collection contains Ubuntu components
+        appstream_pool.remove_flags (AppStream.PoolFlags.LOAD_OS_COLLECTION);
         appstream_pool.reset_extra_data_locations ();
         appstream_pool.add_extra_data_location ("/usr/share/app-info", AppStream.FormatStyle.COLLECTION);
 #else

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -159,8 +159,8 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         // with elementary's AppStream data.
 #if HIDE_UPSTREAM_DISTRO_APPS
 #if HAS_APPSTREAM_0_15
-        // OS Collection contains Ubuntu components
-        appstream_pool.remove_flags (AppStream.PoolFlags.LOAD_OS_COLLECTION);
+        // Don't load Ubuntu components
+        appstream_pool.set_load_std_data_locations (false);
         appstream_pool.reset_extra_data_locations ();
         appstream_pool.add_extra_data_location ("/usr/share/app-info", AppStream.FormatStyle.COLLECTION);
 #else


### PR DESCRIPTION
Fixes #1849 

Verify this by opening AppCenter to Accessories and seeing if apps like "0Install" appear. Also check that non-Flatpak elementary apps like Photos still appear