### PR TITLE
Do not show another package before transition complete

### DIFF
--- a/src/Views/AbstractView.vala
+++ b/src/Views/AbstractView.vala
@@ -43,6 +43,10 @@ public abstract class AppCenter.AbstractView : Hdy.Deck {
     }
 
     public virtual void show_package (AppCenterCore.Package package, bool remember_history = true) {
+        if (transition_running) {
+            return;
+        }
+
         previous_package = null;
 
         package_selected (package);


### PR DESCRIPTION
This prevents a second click on e.g. the banner or a recently updated item on the Home Page from loading duplicate views.