### PR TITLE
AppListUpdateView: move list population from InstalledView to here

### DIFF
--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -18,32 +18,15 @@
  */
 
 public class AppCenter.Views.InstalledView : AbstractView {
-    private Cancellable refresh_cancellable;
-
     private AppListUpdateView app_list_view;
 
-    private AsyncMutex refresh_mutex = new AsyncMutex ();
-
     construct {
-        refresh_cancellable = new Cancellable ();
-
         app_list_view = new AppListUpdateView ();
         app_list_view.show_app.connect ((package) => {
             show_package (package);
         });
 
         add (app_list_view);
-
-        unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
-
-        get_apps.begin ();
-
-        client.installed_apps_changed.connect (() => {
-            Idle.add (() => {
-                get_apps.begin ();
-                return GLib.Source.REMOVE;
-            });
-        });
 
         destroy.connect (() => {
            app_list_view.clear ();
@@ -61,28 +44,6 @@ public class AppCenter.Views.InstalledView : AbstractView {
         if (get_adjacent_child (Hdy.NavigationDirection.BACK) == app_list_view) {
             main_window.set_return_name (C_("view", "Installed"));
         }
-    }
-
-    public async void get_apps () {
-        refresh_cancellable.cancel ();
-
-        yield refresh_mutex.lock ();
-
-        refresh_cancellable.reset ();
-
-        unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
-
-        var installed_apps = yield client.get_installed_applications (refresh_cancellable);
-
-        if (!refresh_cancellable.is_cancelled ()) {
-            app_list_view.clear ();
-
-            var os_updates = AppCenterCore.UpdateManager.get_default ().os_updates;
-            app_list_view.add_package (os_updates);
-            app_list_view.add_packages (installed_apps);
-        }
-
-        refresh_mutex.unlock ();
     }
 
     public async void add_app (AppCenterCore.Package package) {


### PR DESCRIPTION
`InstalledView` only handles navigation while `AppListUpdateView` is the real view. Move populating the list to the list itself. In the future branch this makes it easier to removed `InstalledView` so that we only have one Hdy.Deck to navigate all views