### PR TITLE
AppInfoView: Wrap package_name instead of ellipsize

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -418,7 +418,9 @@ namespace AppCenter.Views {
                 pixel_size = 64
             };
 
-            var app_icon_overlay = new Gtk.Overlay ();
+            var app_icon_overlay = new Gtk.Overlay () {
+                valign = Gtk.Align.START
+            };
             app_icon_overlay.add (app_icon);
 
             var scale_factor = get_scale_factor ();
@@ -439,9 +441,9 @@ namespace AppCenter.Views {
             }
 
             var package_name = new Gtk.Label (package.get_name ()) {
-                ellipsize = Pango.EllipsizeMode.MIDDLE,
                 selectable = true,
                 valign = Gtk.Align.END,
+                wrap = true,
                 xalign = 0
             };
             package_name.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);


### PR DESCRIPTION
Fixes #1864 

Wrapping is better for localization and responsive. We want to be able to see the whole app title on the app info view

![Screenshot from 2022-07-14 11 37 11](https://user-images.githubusercontent.com/7277719/179058276-f4243f84-4847-44db-b95e-15975836cf67.png)
