### PR TITLE
Screenshot bg accents

### DIFF
--- a/data/io.elementary.appcenter.gresource.xml
+++ b/data/io.elementary.appcenter.gresource.xml
@@ -10,5 +10,6 @@
     <file alias="loading.css" compressed="true">styles/loading.css</file>
     <file alias="NonCuratedWarningDialog.css" compressed="true">styles/NonCuratedWarningDialog.css</file>
     <file alias="ProgressButton.css" compressed="true">styles/ProgressButton.css</file>
+    <file alias="Screenshot.css" compressed="true">styles/Screenshot.css</file>
   </gresource>
 </gresources>

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -1019,31 +1019,21 @@ namespace AppCenter.Views {
 
         // We need to first download the screenshot locally so that it doesn't freeze the interface.
         private void load_screenshot (string? caption, string path) {
-            var scale_factor = get_scale_factor ();
-            try {
-                var pixbuf = new Gdk.Pixbuf.from_file_at_scale (path, MAX_WIDTH * scale_factor, 600 * scale_factor, true);
+            var image = new Screenshot (path) {
+                halign = Gtk.Align.CENTER
+            };
 
-                var image = new Gtk.Image () {
-                    halign = Gtk.Align.CENTER,
-                    height_request = 500,
-                    icon_name = "image-x-generic"
-                };
-
-                image.gicon = pixbuf;
-                if (caption != null) {
-                    // AppStream spec says "ideally not more than 100 characters"
-                    int max_caption_len = 200;
-                    image.tooltip_text = ellipsize (caption, max_caption_len);
-                }
-
-                Idle.add (() => {
-                    image.show ();
-                    app_screenshots.add (image);
-                    return GLib.Source.REMOVE;
-                });
-            } catch (Error e) {
-                critical (e.message);
+            if (caption != null) {
+                // AppStream spec says "ideally not more than 100 characters"
+                int max_caption_len = 200;
+                image.tooltip_text = ellipsize (caption, max_caption_len);
             }
+
+            Idle.add (() => {
+                image.show ();
+                app_screenshots.add (image);
+                return GLib.Source.REMOVE;
+            });
         }
 
         private string ellipsize (string long_text, int max_length) {

--- a/src/Widgets/Screenshot.vala
+++ b/src/Widgets/Screenshot.vala
@@ -1,0 +1,86 @@
+/*-
+ * Copyright 2022 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Ian Santopietro <ian@system76.com>
+ */
+ public class AppCenter.Screenshot : Gtk.DrawingArea {
+    public string file_path { get; construct; }
+
+    private Gdk.Pixbuf? pixbuf;
+    private int pixbuf_width {
+        get {
+            return pixbuf != null ? pixbuf.width : 1;
+        }
+    }
+
+    private int pixbuf_height {
+        get {
+            return pixbuf != null ? pixbuf.height : 1;
+        }
+    }
+
+    public Screenshot (string path) {
+        Object (file_path: path);
+    }
+
+    construct {
+        try {
+            pixbuf = new Gdk.Pixbuf.from_file (file_path);
+        } catch (Error e) {
+            critical ("Couldn't load pixbuf: %s", e.message);
+            pixbuf = null;
+        }
+    }
+
+    protected override bool draw (Cairo.Context cr) {
+        if (pixbuf == null) {
+            return Gdk.EVENT_PROPAGATE;
+        }
+
+        int height = get_allocated_height ();
+        int width = get_allocated_width ();
+
+        double scale = double.min ((double) height / pixbuf_height, (double) width / pixbuf_width);
+        cr.scale (scale, scale);
+        Gdk.cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
+        cr.paint ();
+        return Gdk.EVENT_PROPAGATE;
+    }
+
+    protected override Gtk.SizeRequestMode get_request_mode () {
+        return Gtk.SizeRequestMode.HEIGHT_FOR_WIDTH;
+    }
+
+    protected override void get_preferred_width (out int min, out int nat) {
+        min = 0;
+        nat = pixbuf_width;
+    }
+
+    protected override void get_preferred_height (out int min, out int nat) {
+        min = 0;
+        nat = pixbuf_height;
+    }
+
+    protected override void get_preferred_height_for_width (int width, out int min, out int nat) {
+        min = width * pixbuf_height / pixbuf_width;
+        nat = min;
+    }
+
+    protected override void get_preferred_width_for_height (int height, out int min, out int nat) {
+        min = height * pixbuf_width / pixbuf_height;
+        nat = min;
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,7 @@ appcenter_files = files(
     'Widgets/PackageRow.vala',
     'Widgets/ReleaseListBox.vala',
     'Widgets/ReleaseRow.vala',
+    'Widgets/Screenshot.vala',
     'Widgets/SharePopover.vala',
     'Widgets/SizeLabel.vala',
     'Widgets/UpdateHeaderRow.vala',


### PR DESCRIPTION
Looking at bringing captions into a label instead of in a tooltip. The vast majority of the top apps in the iOS app store have screenshots that have the caption on a colored card above their actual screenshot. We can do that in a way that works with the dark style and can be localized:

![Screenshot from 2022-08-13 15 23 33](https://user-images.githubusercontent.com/7277719/184515910-777f2a79-4293-4319-8547-ba1e77f89655.png)
![Screenshot from 2022-08-13 15 23 50](https://user-images.githubusercontent.com/7277719/184515909-a57d4b7f-d93c-47c0-a5ae-3a8b556c5307.png)
![Screenshot from 2022-08-13 15 24 39](https://user-images.githubusercontent.com/7277719/184515908-60ec6eee-5470-4fab-8cc1-73cee35fc8ae.png)

