### PR TITLE
Package: get branding from appstream

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -791,7 +791,7 @@ public class AppCenterCore.Package : Object {
         } else {
             var branding = component.get_branding ();
             if (branding != null) {
-                color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.LIGHT);
+                color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.UNKNOWN);
             }
 
             if (color_primary == null) {

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -789,17 +789,16 @@ public class AppCenterCore.Package : Object {
         if (color_primary != null) {
             return color_primary;
         } else {
-            color_primary = component.get_custom_value ("x-appcenter-color-primary");
-            return color_primary;
-        }
-    }
+            var branding = component.get_branding ();
+            if (branding != null) {
+                color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.LIGHT);
+            }
 
-    public string? get_color_primary_text () {
-        if (color_primary_text != null) {
-            return color_primary_text;
-        } else {
-            color_primary_text = component.get_custom_value ("x-appcenter-color-primary-text");
-            return color_primary_text;
+            if (color_primary == null) {
+                color_primary = component.get_custom_value ("x-appcenter-color-primary");
+            }
+
+            return color_primary;
         }
     }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -97,7 +97,6 @@ namespace AppCenter.Views {
                         bg_color = primary_color;
                         text_color = Granite.contrasting_foreground_color (bg_rgba).to_string ();
 
-                        //FIXME: Update to use AppStream's new accent color
                         accent_css = "@define-color accent_color %s;".printf (primary_color);
                         accent_provider.load_from_data (accent_css, accent_css.length);
                     }


### PR DESCRIPTION
Get brand color from AppStream and fall back to our custom key if it's not available. Also remove now unused text color method

![Screenshot from 2022-08-24 12 26 06](https://user-images.githubusercontent.com/7277719/186506049-123db916-e150-44aa-8eec-66641e9b82f8.png)

![Screenshot from 2022-08-24 12 27 54](https://user-images.githubusercontent.com/7277719/186506157-46fa348d-af3f-4f81-85b5-f12cae5f9c28.png)
