### PR TITLE
AppInfoView: use a flowbox for links

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -529,8 +529,10 @@ namespace AppCenter.Views {
             };
             app_description.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
-            var links_grid = new Gtk.Grid () {
-                column_spacing = 12
+            var links_flowbox = new Gtk.FlowBox () {
+                column_spacing = 12,
+                row_spacing = 6,
+                hexpand = true
             };
 
             var project_license = package.component.project_license;
@@ -540,41 +542,39 @@ namespace AppCenter.Views {
 
                 parse_license (project_license, out license_copy, out license_url);
 
-                var license_button = new UrlButton (_(license_copy), license_url, "text-x-copying-symbolic") {
-                    hexpand = true
-                };
+                var license_button = new UrlButton (_(license_copy), license_url, "text-x-copying-symbolic");
 
-                links_grid.add (license_button);
+                links_flowbox.add (license_button);
             }
 
             var homepage_url = package_component.get_url (AppStream.UrlKind.HOMEPAGE);
             if (homepage_url != null) {
                 var website_button = new UrlButton (_("Homepage"), homepage_url, "web-browser-symbolic");
-                links_grid.add (website_button);
+                links_flowbox.add (website_button);
             }
 
             var translate_url = package_component.get_url (AppStream.UrlKind.TRANSLATE);
             if (translate_url != null) {
                 var translate_button = new UrlButton (_("Translate"), translate_url, "preferences-desktop-locale-symbolic");
-                links_grid.add (translate_button);
+                links_flowbox.add (translate_button);
             }
 
             var bugtracker_url = package_component.get_url (AppStream.UrlKind.BUGTRACKER);
             if (bugtracker_url != null) {
                 var bugtracker_button = new UrlButton (_("Send Feedback"), bugtracker_url, "bug-symbolic");
-                links_grid.add (bugtracker_button);
+                links_flowbox.add (bugtracker_button);
             }
 
             var help_url = package_component.get_url (AppStream.UrlKind.HELP);
             if (help_url != null) {
                 var help_button = new UrlButton (_("Help"), help_url, "dialog-question-symbolic");
-                links_grid.add (help_button);
+                links_flowbox.add (help_button);
             }
 
 #if PAYMENTS
             if (package.get_payments_key () != null) {
                 var fund_button = new FundButton (package);
-                links_grid.add (fund_button);
+                links_flowbox.add (fund_button);
             }
 #endif
 
@@ -625,7 +625,7 @@ namespace AppCenter.Views {
                 load_extensions.begin ();
             }
 
-            content_grid.add (links_grid);
+            content_grid.add (links_flowbox);
 
             origin_liststore = new Gtk.ListStore (2, typeof (AppCenterCore.Package), typeof (string));
             origin_combo = new Gtk.ComboBox.with_model (origin_liststore) {
@@ -777,7 +777,7 @@ namespace AppCenter.Views {
                     toast.send_notification ();
                 });
 
-                links_grid.add (share_button);
+                links_flowbox.add (share_button);
             }
 #endif
             view_entered ();
@@ -1175,9 +1175,7 @@ namespace AppCenter.Views {
                     valign = Gtk.Align.CENTER
                 };
 
-                var title = new Gtk.Label (label) {
-                    ellipsize = Pango.EllipsizeMode.END
-                };
+                var title = new Gtk.Label (label);
 
                 var grid = new Gtk.Grid () {
                     column_spacing = 6
@@ -1194,9 +1192,9 @@ namespace AppCenter.Views {
 
                     button.clicked.connect (() => {
                         try {
-                            AppInfo.launch_default_for_uri (uri, null);
+                            Gtk.show_uri_on_window ((Gtk.Window) get_toplevel (), uri, Gdk.CURRENT_TIME);
                         } catch (Error e) {
-                            warning ("%s\n", e.message);
+                            critical (e.message);
                         }
                     });
                 } else {


### PR DESCRIPTION
Use a flowbox so we don't get unreadable labels at small sizes. While we're here, use Gtk.show_uri_on_window to avoid focus stealing prevention

## Before
![Screenshot from 2022-08-24 12 59 22](https://user-images.githubusercontent.com/7277719/186511779-ceb59f2c-b8fb-4977-aabd-5dd110c0f4e2.png)

## After
![Screenshot from 2022-08-24 12 53 24](https://user-images.githubusercontent.com/7277719/186511474-a7f33b79-ff10-4e67-ad9d-ba16efff9d66.png)
