### PR TITLE
MainWindow: remove window position code

### DIFF
--- a/data/io.elementary.appcenter.gschema.xml
+++ b/data/io.elementary.appcenter.gschema.xml
@@ -6,11 +6,6 @@
       <summary>Whether the window was maximized on last run</summary>
       <description>Whether the window was maximized on last run</description>
     </key>
-    <key name="window-position" type="(ii)">
-      <default>(-1, -1)</default>
-      <summary>Window position</summary>
-      <description>Most recent window position (x, y)</description>
-    </key>
     <key name="window-size" type="(ii)">
       <default>(1100, 660)</default>
       <summary>Most recent window size</summary>

--- a/src/Dialogs/InstallFailDialog.vala
+++ b/src/Dialogs/InstallFailDialog.vala
@@ -26,7 +26,6 @@ public class InstallFailDialog : Granite.MessageDialog {
             secondary_text: _("This may be a temporary issue or could have been caused by external or manually compiled software."),
             buttons: Gtk.ButtonsType.CLOSE,
             badge_icon: new ThemedIcon ("dialog-error"),
-            window_position: Gtk.WindowPosition.CENTER,
             error: error,
             package: package
         );

--- a/src/Dialogs/UninstallConfirmDialog.vala
+++ b/src/Dialogs/UninstallConfirmDialog.vala
@@ -25,7 +25,6 @@ public class UninstallConfirmDialog : Granite.MessageDialog {
             secondary_text: _("Uninstalling this app may also delete its data."),
             buttons: Gtk.ButtonsType.CANCEL,
             badge_icon: new ThemedIcon ("edit-delete"),
-            window_position: Gtk.WindowPosition.CENTER,
             package: package
         );
     }

--- a/src/Dialogs/UninstallFailDialog.vala
+++ b/src/Dialogs/UninstallFailDialog.vala
@@ -26,7 +26,6 @@ public class UninstallFailDialog : Granite.MessageDialog {
             secondary_text: _("This may have been caused by external or manually compiled software."),
             buttons: Gtk.ButtonsType.CLOSE,
             badge_icon: new ThemedIcon ("dialog-error"),
-            window_position: Gtk.WindowPosition.CENTER,
             error: error,
             package: package
         );

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -245,9 +245,7 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
 
         add (grid);
 
-        int window_x, window_y;
         int window_width, window_height;
-        App.settings.get ("window-position", "(ii)", out window_x, out window_y);
         App.settings.get ("window-size", "(ii)", out window_width, out window_height);
         App.settings.bind (
             "automatic-updates",
@@ -255,10 +253,6 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
             "active",
             SettingsBindFlags.DEFAULT
         );
-
-        if (window_x != -1 || window_y != -1) {
-            move (window_x, window_y);
-        }
 
         resize (window_width, window_height);
 
@@ -305,10 +299,6 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
                     int width, height;
                     get_size (out width, out height);
                     App.settings.set ("window-size", "(ii)", width, height);
-
-                    int root_x, root_y;
-                    get_position (out root_x, out root_y);
-                    App.settings.set ("window-position", "(ii)", root_x, root_y);
                 }
 
                 return GLib.Source.REMOVE;


### PR DESCRIPTION
Since we can't position the window anymore in Wayland/Gtk4 might as well get rid of this now