### PR TITLE
Package: use AppCenter origin in should_pay

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -149,7 +149,7 @@ public class AppCenterCore.Package : Object {
 
     public bool should_pay {
         get {
-            if (!is_native || is_os_updates) {
+            if (component.get_origin () != APPCENTER_PACKAGE_ORIGIN) {
                 return false;
             }
 


### PR DESCRIPTION
`is_native` is kind of a roundabout way of checking package origin, and `is_os_updates` would always be false for the `APPCENTER` origin, so just check that