### PR TITLE
Dialogs: use present and connect to response

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -318,10 +318,7 @@ public class AppCenter.App : Gtk.Application {
                     }
 
                     var dialog = new InstallFailDialog (package, error);
-
-                    dialog.show_all ();
-                    dialog.run ();
-                    dialog.destroy ();
+                    dialog.present ();
                 }
 
                 break;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -124,7 +124,7 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
                     message_dialog.badge_icon = new ThemedIcon ("dialog-error");
                     message_dialog.transient_for = this;
 
-                    message_dialog.show_all ();
+                    message_dialog.present ();
                     message_dialog.response.connect ((response_id) => {
                         message_dialog.destroy ();
                     });

--- a/src/Services/DBusServer.vala
+++ b/src/Services/DBusServer.vala
@@ -58,22 +58,25 @@ public class DBusServer : Object {
         }
 
         var uninstall_confirm_dialog = new UninstallConfirmDialog (package);
+        uninstall_confirm_dialog.present ();
 
-        if (uninstall_confirm_dialog.run () == Gtk.ResponseType.ACCEPT) {
-            package.uninstall.begin ((obj, res) => {
-                try {
-                    package.uninstall.end (res);
-                } catch (Error e) {
-                    // Disable error dialog for if user clicks cancel. Reason: Failed to obtain authentication
-                    // Pk ErrorEnums are mapped to the error code at an offset of 0xFF (see packagekit-glib2/pk-client.h)
-                    if (!(e is Pk.ClientError) || e.code != Pk.ErrorEnum.NOT_AUTHORIZED + 0xFF) {
-                        new UninstallFailDialog (package, e).present ();
+        uninstall_confirm_dialog.response.connect ((response) => {
+            if (response == Gtk.ResponseType.ACCEPT) {
+                package.uninstall.begin ((obj, res) => {
+                    try {
+                        package.uninstall.end (res);
+                    } catch (Error e) {
+                        // Disable error dialog for if user clicks cancel. Reason: Failed to obtain authentication
+                        // Pk ErrorEnums are mapped to the error code at an offset of 0xFF (see packagekit-glib2/pk-client.h)
+                        if (!(e is Pk.ClientError) || e.code != Pk.ErrorEnum.NOT_AUTHORIZED + 0xFF) {
+                            new UninstallFailDialog (package, e).present ();
+                        }
                     }
-                }
-            });
-        }
+                });
+            }
 
-        uninstall_confirm_dialog.destroy ();
+            uninstall_confirm_dialog.destroy ();
+        });
     }
 
     /**

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -81,7 +81,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
             var releases_dialog = new ReleaseDialog (package) {
                 transient_for = (Gtk.Window) get_toplevel ()
             };
-            releases_dialog.show_all ();
+            releases_dialog.present ();
         });
     }
 
@@ -121,7 +121,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         changed ();
     }
 
-    private class ReleaseDialog : Hdy.Window {
+    private class ReleaseDialog : Granite.Dialog {
         public AppCenterCore.Package package { get; construct; }
 
         public ReleaseDialog (AppCenterCore.Package package) {
@@ -130,7 +130,6 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
         construct {
             title = _("What's new in %s %s").printf (package.get_name (), package.get_version ());
-            type_hint = Gdk.WindowTypeHint.DIALOG;
             modal = true;
 
             var releases_title = new Gtk.Label (title) {
@@ -147,26 +146,20 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
                 xalign = 0
             };
 
-            var dialog_close_button = new Gtk.Button.with_label (_("Close")) {
-                halign = Gtk.Align.END,
-                valign = Gtk.Align.END,
-                vexpand = true,
-                margin_top = 12
-            };
-
             var releases_dialog_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
-                margin_top = 12,
                 margin_end = 12,
-                margin_bottom = 12,
-                margin_start = 12
+                margin_start = 12,
+                vexpand = true
             };
             releases_dialog_box.add (releases_title);
             releases_dialog_box.add (release_description);
-            releases_dialog_box.add (dialog_close_button);
+            releases_dialog_box.show_all ();
 
-            add (releases_dialog_box);
+            get_content_area ().add (releases_dialog_box);
 
-            dialog_close_button.clicked.connect (() => {
+            add_button (_("Close"), Gtk.ResponseType.CLOSE);
+
+            response.connect (() => {
                 close ();
             });
         }


### PR DESCRIPTION
`dialog.run ()` and `show_all ()` no longer exist in Gtk 4. Can be rebase merged

Application: you can see InstallFailDialog already connects its response to `destroy ()`

InstalledPackageRowGrid: use a Granite.Dialog instead of a Hdy.Window. Don't know why it wasn't this way in the first place. Brain must have fell out of my head :upside_down_face: Saves a few lines and window type hints aren't available in Gtk 4 anyways