### PR TITLE
Homepage categories

### DIFF
--- a/data/styles/categories.css
+++ b/data/styles/categories.css
@@ -179,27 +179,27 @@
     background-image:
         linear-gradient(
             to right,
-            transparent 15px,
-            alpha(white, 0.05) 15px,
-            alpha(white, 0.05) 16px,
-            transparent 16px
+            transparent calc(0.5em - 1px),
+            alpha(white, 0.05) calc(0.5em - 1px),
+            alpha(white, 0.05) 0.5em,
+            transparent 0.5em
         ),
         linear-gradient(
             to bottom,
-            transparent 15px,
-            alpha(white, 0.05) 15px,
-            alpha(white, 0.05) 16px,
-            transparent 16px
+            transparent calc(0.5em - 1px),
+            alpha(white, 0.05) calc(0.5em - 1px),
+            alpha(white, 0.05) 0.5em,
+            transparent 0.5em
         ),
         linear-gradient(
             to right,
-            transparent 31px,
-            alpha(white, 0.125) 31px
+            transparent calc(1em - 1px),
+            alpha(white, 0.125) calc(1em - 1px)
         ),
         linear-gradient(
             to bottom,
-            transparent 31px,
-            alpha(white, 0.125) 31px
+            transparent calc(1em - 1px),
+            alpha(white, 0.125) calc(1em - 1px)
         ),
         linear-gradient(
             to bottom right,
@@ -209,10 +209,10 @@
     background-position: center center;
     background-repeat: repeat;
     background-size:
-        32px 32px,
-        32px 32px,
-        32px 32px,
-        32px 32px,
+        1em 1em,
+        1em 1em,
+        1em 1em,
+        1em 1em,
         cover;
     border-color: alpha(@GRAPE_900, 0.7);
     color: white;

--- a/data/styles/categories.css
+++ b/data/styles/categories.css
@@ -179,27 +179,27 @@
     background-image:
         linear-gradient(
             to right,
-            transparent 0.47em,
-            alpha(white, 0.05) 0.47em,
-            alpha(white, 0.05) 0.5em,
-            transparent 0.5em
+            transparent 15px,
+            alpha(white, 0.05) 15px,
+            alpha(white, 0.05) 16px,
+            transparent 16px
         ),
         linear-gradient(
             to bottom,
-            transparent 0.47em,
-            alpha(white, 0.05) 0.47em,
-            alpha(white, 0.05) 0.5em,
-            transparent 0.5em
+            transparent 15px,
+            alpha(white, 0.05) 15px,
+            alpha(white, 0.05) 16px,
+            transparent 16px
         ),
         linear-gradient(
             to right,
-            transparent 0.97em,
-            alpha(white, 0.125) 0.97em
+            transparent 31px,
+            alpha(white, 0.125) 31px
         ),
         linear-gradient(
             to bottom,
-            transparent 0.97em,
-            alpha(white, 0.125) 0.97em
+            transparent 31px,
+            alpha(white, 0.125) 31px
         ),
         linear-gradient(
             to bottom right,
@@ -209,10 +209,10 @@
     background-position: center center;
     background-repeat: repeat;
     background-size:
-        1em 1em,
-        1em 1em,
-        1em 1em,
-        1em 1em,
+        32px 32px,
+        32px 32px,
+        32px 32px,
+        32px 32px,
         cover;
     border-color: alpha(@GRAPE_900, 0.7);
     color: white;

--- a/data/styles/categories.css
+++ b/data/styles/categories.css
@@ -27,6 +27,9 @@
         0 3px 5px alpha(black, 0.1);
     font-size: 32px;
     font-weight: 300;
+    margin: 1.333rem; /* 12px */
+    padding: 1.333rem;
+    min-height: 3em;
 }
 
 .category.accessibility {

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -381,19 +381,10 @@ public class AppCenter.Homepage : Gtk.Box {
         construct {
             var expanded_grid = new Gtk.Grid () {
                 hexpand = true,
-                vexpand = true,
-                margin_top = 12,
-                margin_end = 12,
-                margin_bottom = 12,
-                margin_start = 12
+                vexpand = true
             };
 
-            content_area = new Gtk.Grid () {
-                margin_top = 12,
-                margin_end = 12,
-                margin_bottom = 12,
-                margin_start = 12
-            };
+            content_area = new Gtk.Grid ();
             content_area.add (expanded_grid);
 
             style_context = content_area.get_style_context ();
@@ -423,11 +414,7 @@ public class AppCenter.Homepage : Gtk.Box {
 
             var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
                 halign = Gtk.Align.CENTER,
-                valign = Gtk.Align.CENTER,
-                margin_top = 32,
-                margin_end = 16,
-                margin_bottom = 32,
-                margin_start = 16
+                valign = Gtk.Align.CENTER
             };
 
             content_area.attach (box, 0, 0);

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -416,11 +416,6 @@ public class AppCenter.Homepage : Gtk.Box {
                 category.add_desktop_group (group);
             }
 
-            var display_image = new Gtk.Image ();
-            display_image.icon_size = Gtk.IconSize.DIALOG;
-            display_image.valign = Gtk.Align.CENTER;
-            display_image.halign = Gtk.Align.END;
-
             var name_label = new Gtk.Label (null);
             name_label.wrap = true;
             name_label.max_width_chars = 15;
@@ -434,20 +429,24 @@ public class AppCenter.Homepage : Gtk.Box {
                 margin_bottom = 32,
                 margin_start = 16
             };
-            box.add (display_image);
-            box.add (name_label);
 
             content_area.attach (box, 0, 0);
 
             if (category.icon != "") {
-                display_image.icon_name = category.icon;
+                var display_image = new Gtk.Image.from_icon_name (category.icon, Gtk.IconSize.DIALOG) {
+                     halign = Gtk.Align.END,
+                    valign = Gtk.Align.CENTER
+                };
+
+                box.add (display_image);
+
                 name_label.xalign = 0;
                 name_label.halign = Gtk.Align.START;
             } else {
-                display_image.destroy ();
                 name_label.justify = Gtk.Justification.CENTER;
             }
 
+            box.add (name_label);
             style_context.add_class (style);
 
             if (style == "accessibility") {

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -421,7 +421,7 @@ public class AppCenter.Homepage : Gtk.Box {
 
             if (category.icon != "") {
                 var display_image = new Gtk.Image.from_icon_name (category.icon, Gtk.IconSize.DIALOG) {
-                     halign = Gtk.Align.END,
+                    halign = Gtk.Align.END,
                     valign = Gtk.Align.CENTER
                 };
 


### PR DESCRIPTION
Reduces diff for Gtk4 a bit:

* Don't add an empty image widget to category cards with no icon
* Use calc to avoid rounding errors
* Set card padding and margin in CSS to make our lives a little simpler