### PR TITLE
CategoryView: change append to add_package

### DIFF
--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -101,19 +101,18 @@ public class AppCenter.CategoryView : Gtk.Stack {
 
             var packages = get_packages.end (res);
             foreach (var package in packages) {
-                var package_row = new AppCenter.Widgets.ListPackageRowGrid (package);
 #if CURATED
                 if (package.is_native) {
                     if (package.get_payments_key () != null && package.get_suggested_amount () != "0") {
-                        paid_flowbox.append (package_row);
+                        paid_flowbox.add_package (package);
                     } else {
-                        free_flowbox.append (package_row);
+                        free_flowbox.add_package (package);
                     }
                 } else {
-                    uncurated_flowbox.append (package_row);
+                    uncurated_flowbox.add_package (package);
                 }
 #else
-                uncurated_flowbox.append (package_row);
+                uncurated_flowbox.add_package (package);
 #endif
             }
 
@@ -146,8 +145,7 @@ public class AppCenter.CategoryView : Gtk.Stack {
                 }
 
                 if (!recent_package.installed) {
-                    var package_row = new AppCenter.Widgets.ListPackageRowGrid (recent_package);
-                    recently_updated_flowbox.append (package_row);
+                    recently_updated_flowbox.add_package (recent_package);
                     recent_count++;
                 }
             }
@@ -244,9 +242,11 @@ public class AppCenter.CategoryView : Gtk.Stack {
             });
         }
 
-        public void append (Gtk.Widget widget) {
-            size_group.add_widget (widget);
-            flowbox.add (widget);
+        public void add_package (AppCenterCore.Package package) {
+            var package_row = new Widgets.ListPackageRowGrid (package);
+
+            size_group.add_widget (package_row);
+            flowbox.add (package_row);
         }
 
         public void clear () {


### PR DESCRIPTION
Want to make sure we don't have to override `append` actually because we need to use it during `construct`. This simplifies things anyways because we don't need to construct the package row in `populate` because it's only used in the flowbox