### PR TITLE
AbstractAppList: Remove list.add connect

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -116,6 +116,8 @@ namespace AppCenter.Views {
         public override void add_package (AppCenterCore.Package package) {
             add_row_for_package (package);
             list_box.invalidate_sort ();
+
+            package.changing.connect (on_package_changing);
         }
 
         private void add_row_for_package (AppCenterCore.Package package) {
@@ -124,6 +126,8 @@ namespace AppCenter.Views {
             // Only add row if this package needs an update or it's not a font or plugin
             if (needs_update || (package.kind != AppStream.ComponentKind.ADDON && package.kind != AppStream.ComponentKind.FONT)) {
                 var row = new Widgets.PackageRow.installed (package, action_button_group);
+                row.show_all ();
+
                 list_box.add (row);
             }
         }

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -91,7 +91,11 @@ public class AppCenter.SearchView : AbstractAppList {
         uint old_index = current_visible_index;
         while (current_visible_index < list_store.get_n_items ()) {
             var package = (AppCenterCore.Package?) list_store.get_object (current_visible_index);
+            package.changing.connect (on_package_changing);
+
             var row = new Widgets.PackageRow.list (package);
+            row.show_all ();
+
             list_box.add (row);
 
             current_visible_index++;

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -42,11 +42,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
         scrolled = new Gtk.ScrolledWindow (null, null);
         scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scrolled.add (list_box);
-
-        list_box.add.connect ((row) => {
-            row.show_all ();
-            ((Widgets.PackageRow) row).get_package ().changing.connect (on_package_changing);
-        });
     }
 
     public abstract void add_packages (Gee.Collection<AppCenterCore.Package> packages);


### PR DESCRIPTION
Can't connect to `add` in Gtk 4, so just make sure we do these things when we add