### PR TITLE
AbstractAppList: Remove sort func

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -37,6 +37,7 @@ namespace AppCenter.Views {
             );
             loading_view.show_all ();
 
+            list_box.set_sort_func ((Gtk.ListBoxSortFunc) package_row_compare);
             list_box.set_header_func ((Gtk.ListBoxUpdateHeaderFunc) row_update_header);
             list_box.set_placeholder (loading_view);
 
@@ -129,7 +130,7 @@ namespace AppCenter.Views {
         }
 
         [CCode (instance_pos = -1)]
-        protected override int package_row_compare (Widgets.PackageRow row1, Widgets.PackageRow row2) {
+        private int package_row_compare (Widgets.PackageRow row1, Widgets.PackageRow row2) {
             var row1_package = row1.get_package ();
             var row2_package = row2.get_package ();
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -34,6 +34,7 @@ public class AppCenter.SearchView : AbstractAppList {
         alert_view.show_all ();
 
         list_box.set_placeholder (alert_view);
+        list_box.set_sort_func ((Gtk.ListBoxSortFunc) package_row_compare);
 
         list_store = new GLib.ListStore (typeof (AppCenterCore.Package));
         scrolled.edge_reached.connect ((position) => {
@@ -138,7 +139,7 @@ public class AppCenter.SearchView : AbstractAppList {
     }
 
     [CCode (instance_pos = -1)]
-    protected override int package_row_compare (Widgets.PackageRow row1, Widgets.PackageRow row2) {
+    private int package_row_compare (Widgets.PackageRow row1, Widgets.PackageRow row2) {
         return compare_packages (row1.get_package (), row2.get_package ());
     }
 }

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -33,7 +33,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
             vexpand = true
         };
 
-        list_box.set_sort_func ((Gtk.ListBoxSortFunc) package_row_compare);
         list_box.row_activated.connect ((r) => {
             var row = (Widgets.PackageRow)r;
             show_app (row.get_package ());
@@ -93,11 +92,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
         }
 
         return tree_set;
-    }
-
-    [CCode (instance_pos = -1)]
-    protected virtual int package_row_compare (Widgets.PackageRow row1, Widgets.PackageRow row2) {
-        return row1.get_package ().get_name ().collate (row2.get_package ().get_name ());
     }
 
     protected virtual void on_package_changing (AppCenterCore.Package package, bool is_changing) {


### PR DESCRIPTION
Neither implementation uses the abstract sort function, so remove it