### PR TITLE
Move get_packages from AbstractAppList to AppListUpdateView

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -329,12 +329,9 @@ namespace AppCenter.Views {
         private Gee.Collection<AppCenterCore.Package> get_packages () {
             var tree_set = new Gee.TreeSet<AppCenterCore.Package> ();
             foreach (unowned var child in list_box.get_children ()) {
-                unowned var row = child as Widgets.PackageRow;
-                if (row == null) {
-                    continue;
+                if (child is Widgets.PackageRow) {
+                    tree_set.add (((Widgets.PackageRow) child).get_package ());
                 }
-
-                tree_set.add (row.get_package ());
             }
 
             return tree_set;
@@ -354,11 +351,13 @@ namespace AppCenter.Views {
         public async void remove_app (AppCenterCore.Package package) {
             package.changing.disconnect (on_package_changing);
             foreach (unowned var child in list_box.get_children ()) {
-                unowned var row = (Widgets.PackageRow) child;
+                if (child is Widgets.PackageRow) {
+                    unowned var row = (Widgets.PackageRow) child;
 
-                if (row.get_package () == package) {
-                    row.destroy ();
-                    break;
+                    if (row.get_package () == package) {
+                        row.destroy ();
+                        break;
+                    }
                 }
             }
 

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -325,6 +325,20 @@ namespace AppCenter.Views {
             updating_all_apps = false;
         }
 
+        private Gee.Collection<AppCenterCore.Package> get_packages () {
+            var tree_set = new Gee.TreeSet<AppCenterCore.Package> ();
+            foreach (unowned var child in list_box.get_children ()) {
+                unowned var row = child as Widgets.PackageRow;
+                if (row == null) {
+                    continue;
+                }
+
+                tree_set.add (row.get_package ());
+            }
+
+            return tree_set;
+        }
+
         public async void add_app (AppCenterCore.Package package) {
             unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
             var installed_apps = yield client.get_installed_applications ();

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -76,20 +76,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
         list_box.invalidate_sort ();
     }
 
-    protected virtual Gee.Collection<AppCenterCore.Package> get_packages () {
-        var tree_set = new Gee.TreeSet<AppCenterCore.Package> ();
-        foreach (weak Gtk.Widget r in list_box.get_children ()) {
-            weak Widgets.PackageRow row = r as Widgets.PackageRow;
-            if (row == null) {
-                continue;
-            }
-
-            tree_set.add (row.get_package ());
-        }
-
-        return tree_set;
-    }
-
     [CCode (instance_pos = -1)]
     protected virtual int package_row_compare (Widgets.PackageRow row1, Widgets.PackageRow row2) {
         return row1.get_package ().get_name ().collate (row2.get_package ().get_name ());


### PR DESCRIPTION
Only used in one implementation so move it from the abstract list. We have a null check with a continue here so I'm assuming this type of cast is intentional, maybe because row headers are listbox children?