### PR TITLE
Handle more componentkinds

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -724,10 +724,28 @@ public class AppCenterCore.Package : Object {
         }
 
         if (icon == null) {
-            if (component.get_kind () == AppStream.ComponentKind.ADDON) {
-                icon = new ThemedIcon ("extension");
-            } else {
-                icon = new ThemedIcon ("application-default-icon");
+            switch (component.get_kind ()) {
+                case AppStream.ComponentKind.ADDON:
+                    icon = new ThemedIcon ("extension");
+                    break;
+                case AppStream.ComponentKind.CODEC:
+                case AppStream.ComponentKind.CONSOLE_APP:
+                case AppStream.ComponentKind.DESKTOP_APP:
+                case AppStream.ComponentKind.DRIVER:
+                case AppStream.ComponentKind.FIRMWARE:
+                case AppStream.ComponentKind.FONT:
+                case AppStream.ComponentKind.GENERIC:
+                case AppStream.ComponentKind.ICON_THEME:
+                case AppStream.ComponentKind.INPUT_METHOD: //ComponentKind.INPUTMETHOD is deprecated has same value so cannot be included
+                case AppStream.ComponentKind.LOCALIZATION:
+                case AppStream.ComponentKind.OPERATING_SYSTEM:
+                case AppStream.ComponentKind.REPOSITORY:
+                case AppStream.ComponentKind.RUNTIME:
+                case AppStream.ComponentKind.SERVICE:
+                case AppStream.ComponentKind.UNKNOWN:
+                case AppStream.ComponentKind.WEB_APP:
+                    icon = new ThemedIcon ("application-default-icon");
+                    break;
             }
         }
 

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -728,14 +728,19 @@ public class AppCenterCore.Package : Object {
                 case AppStream.ComponentKind.ADDON:
                     icon = new ThemedIcon ("extension");
                     break;
+                case AppStream.ComponentKind.FONT:
+                    icon = new ThemedIcon ("font-x-generic");
+                    break;
+                case AppStream.ComponentKind.ICON_THEME:
+                    icon = new ThemedIcon ("preferences-desktop-theme");
+                    break;
                 case AppStream.ComponentKind.CODEC:
                 case AppStream.ComponentKind.CONSOLE_APP:
                 case AppStream.ComponentKind.DESKTOP_APP:
                 case AppStream.ComponentKind.DRIVER:
                 case AppStream.ComponentKind.FIRMWARE:
-                case AppStream.ComponentKind.FONT:
                 case AppStream.ComponentKind.GENERIC:
-                case AppStream.ComponentKind.ICON_THEME:
+
                 case AppStream.ComponentKind.INPUT_METHOD: //ComponentKind.INPUTMETHOD is deprecated has same value so cannot be included
                 case AppStream.ComponentKind.LOCALIZATION:
                 case AppStream.ComponentKind.OPERATING_SYSTEM:
@@ -744,6 +749,7 @@ public class AppCenterCore.Package : Object {
                 case AppStream.ComponentKind.SERVICE:
                 case AppStream.ComponentKind.UNKNOWN:
                 case AppStream.ComponentKind.WEB_APP:
+                    debug ("component kind not handled %s", component.get_kind ().to_string ());
                     icon = new ThemedIcon ("application-default-icon");
                     break;
             }


### PR DESCRIPTION
In connection with https://github.com/elementary/icons/pull/1128, try to reduce need for a completely generic app icon, which is hard to represent, by using generic icons for categories of apps/packages.

Most apps in the AppCenter do supply their own icons.  The fallback generic icon is mainly used for system components, most of which are identified as a "generic" appstream component kind.  Presumably this is due to lack of information in the appdata?
A couple of component kinds have been given example icons but these are not ideal.

Another place the generic application icon is used extensively is when Files displays the contents of e.g. `usr/bin` for executables.  In that case it would be better to have an icon for a generic executable as these are not necessarily (desktop) apps.
