### PR TITLE
AbstractAppList: Remove redundant package_changing

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -117,8 +117,6 @@ namespace AppCenter.Views {
         public void add_package (AppCenterCore.Package package) {
             add_row_for_package (package);
             list_box.invalidate_sort ();
-
-            package.changing.connect (on_package_changing);
         }
 
         private void add_row_for_package (AppCenterCore.Package package) {
@@ -338,7 +336,6 @@ namespace AppCenter.Views {
         }
 
         public async void remove_app (AppCenterCore.Package package) {
-            package.changing.disconnect (on_package_changing);
             foreach (unowned var child in list_box.get_children ()) {
                 unowned var row = (Widgets.PackageRow) child;
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -84,7 +84,6 @@ public class AppCenter.SearchView : AbstractAppList {
         uint old_index = current_visible_index;
         while (current_visible_index < list_store.get_n_items ()) {
             var package = (AppCenterCore.Package?) list_store.get_object (current_visible_index);
-            package.changing.connect (on_package_changing);
 
             var row = new Widgets.PackageRow.list (package);
             row.show_all ();

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -53,7 +53,6 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
             }
 
             var package = row.get_package ();
-            package.changing.disconnect (on_package_changing);
             row.destroy ();
         };
 
@@ -72,18 +71,5 @@ public abstract class AppCenter.AbstractAppList : Gtk.Box {
         }
 
         return tree_set;
-    }
-
-    protected virtual void on_package_changing (AppCenterCore.Package package, bool is_changing) {
-        if (is_changing) {
-            packages_changing++;
-        } else {
-            packages_changing--;
-        }
-
-        assert (packages_changing >= 0);
-        if (packages_changing == 0) {
-            list_box.invalidate_sort ();
-        }
     }
 }


### PR DESCRIPTION
It looks like this only thing this does is call `invalidate_sort ()`, but we already send the `changed ()` signal in `PackageRow` which automatically calls `invalidate_sort ()` on the ListBox, so it doesn't seem like there's a need to call it twice.

I tested installing a package and manually checking for updates and afaict the listbox sorts when packages change without this