### PR TITLE
AppListUpdateView: use flowboxes

### DIFF
--- a/src/Widgets/UpdateHeaderRow.vala
+++ b/src/Widgets/UpdateHeaderRow.vala
@@ -55,8 +55,4 @@ public class AppCenter.Widgets.UpdateHeaderRow : Gtk.Box {
     public UpdateHeaderRow.drivers () {
         Object (label_text: _("Drivers"));
     }
-
-    public UpdateHeaderRow.up_to_date () {
-        Object (label_text: _("Up to Date"));
-    }
 }


### PR DESCRIPTION
Use flowboxes instead of a list to show updates and installed apps.
* Simplify sort and header handling
* Show more apps on screen at once
* Easier to see which info and update button goes to which app

## BEFORE
![Screenshot from 2022-09-04 13 14 58](https://user-images.githubusercontent.com/7277719/188331809-025b2a05-ebec-46d5-990a-26ea11ee4a75.png)

## AFTER
![Screenshot from 2022-09-04 13 13 12](https://user-images.githubusercontent.com/7277719/188331813-015ec773-382a-4aeb-b5c9-c18de0d2cc84.png)
