### PR TITLE
AppInfoView: get newest releases in this class

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -879,59 +879,6 @@ public class AppCenterCore.Package : Object {
         return app_info != null;
     }
 
-    public Gee.ArrayList<AppStream.Release> get_newest_releases (int min_releases, int max_releases) {
-        var list = new Gee.ArrayList<AppStream.Release> ();
-
-        var releases = component.get_releases ();
-        uint index = 0;
-        while (index < releases.length) {
-            if (releases[index].get_version () == null) {
-                releases.remove_index (index);
-                if (index >= releases.length) {
-                    break;
-                }
-
-                continue;
-            }
-
-            index++;
-        }
-
-        if (releases.length < min_releases) {
-            return list;
-        }
-
-        releases.sort_with_data ((a, b) => {
-            return b.vercmp (a);
-        });
-
-        string installed_version = get_version ();
-
-        int start_index = 0;
-        int end_index = min_releases;
-
-        if (installed) {
-            for (int i = 0; i < releases.length; i++) {
-                var release = releases.@get (i);
-                unowned string release_version = release.get_version ();
-                if (release_version == null) {
-                    continue;
-                }
-
-                if (AppStream.utils_compare_versions (release_version, installed_version) == 0) {
-                    end_index = i.clamp (min_releases, max_releases);
-                    break;
-                }
-            }
-        }
-
-        for (int j = start_index; j < end_index; j++) {
-            list.add (releases.get (j));
-        }
-
-        return list;
-    }
-
     public AppStream.Release? get_newest_release () {
         var releases = component.get_releases ();
         releases.sort_with_data ((a, b) => {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -951,15 +951,10 @@ namespace AppCenter.Views {
                         });
 
                         foreach (unowned var release in releases) {
-                            unowned var release_version = release.get_version ();
-                            if (release_version == null) {
-                                continue;
-                            }
-
                             var row = new AppCenter.Widgets.ReleaseRow (release);
                             release_list_box.add (row);
 
-                            if (package.installed && AppStream.utils_compare_versions (release_version, package.get_version ()) <= 0) {
+                            if (package.installed && AppStream.utils_compare_versions (release.get_version (), package.get_version ()) <= 0) {
                                 break;
                             }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -937,13 +937,37 @@ namespace AppCenter.Views {
                 get_app_download_size.begin ();
 
                 Idle.add (() => {
-                    var releases = package.get_newest_releases (1, 5);
-                    foreach (var release in releases) {
-                        var row = new AppCenter.Widgets.ReleaseRow (release);
-                        release_list_box.add (row);
+                    var releases = package.component.get_releases ();
+
+                    foreach (unowned var release in releases) {
+                        if (release.get_version () == null) {
+                            releases.remove (release);
+                        }
                     }
 
-                    if (releases.size > 0) {
+                    if (releases.length > 0) {
+                        releases.sort_with_data ((a, b) => {
+                            return b.vercmp (a);
+                        });
+
+                        foreach (unowned var release in releases) {
+                            unowned var release_version = release.get_version ();
+                            if (release_version == null) {
+                                continue;
+                            }
+
+                            var row = new AppCenter.Widgets.ReleaseRow (release);
+                            release_list_box.add (row);
+
+                            if (package.installed && AppStream.utils_compare_versions (release_version, package.get_version ()) <= 0) {
+                                break;
+                            }
+
+                            if (release_list_box.get_children ().length () == 5) {
+                                break;
+                            }
+                        }
+
                         release_grid.no_show_all = false;
                         release_grid.show_all ();
                     }


### PR DESCRIPTION
Fixes #1033

* Move this out of Package since it's only used in AppInfoView
* Use foreach functions to simplify
* Actually show up to 5 releases since the installed version
* Handle the case where the installed package is newer than the latest release info (such as in daily)
* Remove a redundant null check