### PR TITLE
fix: Segfault from error message being freed in dialogs

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -307,7 +307,7 @@ public class AppCenter.App : Gtk.Application {
                         break;
                     }
 
-                    var dialog = new InstallFailDialog (package, error);
+                    var dialog = new InstallFailDialog (package, (owned) error.message);
                     dialog.present ();
                 }
 

--- a/src/Dialogs/InstallFailDialog.vala
+++ b/src/Dialogs/InstallFailDialog.vala
@@ -17,16 +17,16 @@
 
 public class InstallFailDialog : Granite.MessageDialog {
     public AppCenterCore.Package? package { get; construct; }
-    public Error error { get; construct; }
+    public string error_message { get; construct; }
     private const string FALLBACK_ICON = "application-default-icon";
 
-    public InstallFailDialog (AppCenterCore.Package? package, Error error) {
+    public InstallFailDialog (AppCenterCore.Package? package, string error_message) {
         Object (
             title: "",
             secondary_text: _("This may be a temporary issue or could have been caused by external or manually compiled software."),
             buttons: Gtk.ButtonsType.CLOSE,
             badge_icon: new ThemedIcon ("dialog-error"),
-            error: error,
+            error_message: error_message,
             package: package
         );
     }
@@ -42,6 +42,6 @@ public class InstallFailDialog : Granite.MessageDialog {
 
         response.connect (() => destroy ());
 
-        show_error_details (error.message);
+        show_error_details (error_message);
     }
 }

--- a/src/Dialogs/UninstallFailDialog.vala
+++ b/src/Dialogs/UninstallFailDialog.vala
@@ -17,16 +17,16 @@
 
 public class UninstallFailDialog : Granite.MessageDialog {
     public AppCenterCore.Package? package { get; construct; }
-    public Error error { get; construct; }
+    public string error_message { get; construct; }
     private const string FALLBACK_ICON = "application-default-icon";
 
-    public UninstallFailDialog (AppCenterCore.Package? package, Error error) {
+    public UninstallFailDialog (AppCenterCore.Package? package, string error_message) {
         Object (
             title: "",
             secondary_text: _("This may have been caused by external or manually compiled software."),
             buttons: Gtk.ButtonsType.CLOSE,
             badge_icon: new ThemedIcon ("dialog-error"),
-            error: error,
+            error_message: error_message,
             package: package
         );
     }
@@ -42,6 +42,6 @@ public class UninstallFailDialog : Granite.MessageDialog {
 
         response.connect (() => destroy ());
 
-        show_error_details (error.message);
+        show_error_details (error_message);
     }
 }

--- a/src/Services/DBusServer.vala
+++ b/src/Services/DBusServer.vala
@@ -53,7 +53,7 @@ public class DBusServer : Object {
 
         if (package == null) {
             var error = new IOError.FAILED ("Failed to find package for '%s' component ID".printf (component_id));
-            new UninstallFailDialog (package, error).present ();
+            new UninstallFailDialog (package, (owned) error.message).present ();
             throw error;
         }
 
@@ -69,7 +69,7 @@ public class DBusServer : Object {
                         // Disable error dialog for if user clicks cancel. Reason: Failed to obtain authentication
                         // Pk ErrorEnums are mapped to the error code at an offset of 0xFF (see packagekit-glib2/pk-client.h)
                         if (!(e is Pk.ClientError) || e.code != Pk.ErrorEnum.NOT_AUTHORIZED + 0xFF) {
-                            new UninstallFailDialog (package, e).present ();
+                            new UninstallFailDialog (package, (owned) e.message).present ();
                         }
                     }
                 });

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -1190,7 +1190,7 @@ namespace AppCenter.Views {
                     // Disable error dialog for if user clicks cancel. Reason: Failed to obtain authentication
                     // Pk ErrorEnums are mapped to the error code at an offset of 0xFF (see packagekit-glib2/pk-client.h)
                     if (!(e is Pk.ClientError) || e.code != Pk.ErrorEnum.NOT_AUTHORIZED + 0xFF) {
-                        new UninstallFailDialog (package, e).present ();
+                        new UninstallFailDialog (package, (owned) e.message).present ();
                     }
                 }
             });


### PR DESCRIPTION
These error dialogs will cause the appcenter to crash from a memory safety violation if there's a dependency conflict or network error. It seems that `show_error_details (error.message)` is consistently given an error whose `message` has already been freed. This change will take the message string into the object initialization to ensure the string survives. Dialogs are only using the string anyway.

Can be easily replicated by editing the `/etc/hosts` file and setting the apt repository to localhost.