### PR TITLE
Homepage: use own headerbar

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -88,12 +88,6 @@ namespace AppCenter.Views {
             };
             back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
-            var headerbar = new Hdy.HeaderBar () {
-                show_close_button = true
-            };
-            headerbar.pack_start (back_button);
-            headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
             accent_provider = new Gtk.CssProvider ();
             try {
                 string bg_color = DEFAULT_BANNER_COLOR_PRIMARY;
@@ -675,6 +669,13 @@ namespace AppCenter.Views {
             button_box.add (uninstall_button_revealer);
             button_box.add (action_stack);
 
+            var headerbar = new Hdy.HeaderBar () {
+                show_close_button = true
+            };
+            headerbar.pack_start (back_button);
+            headerbar.pack_end (button_box);
+            headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
             var header_grid = new Gtk.Grid () {
                 column_spacing = 12,
                 row_spacing = 6,
@@ -684,7 +685,6 @@ namespace AppCenter.Views {
             header_grid.attach (package_name, 1, 0);
             header_grid.attach (author_label, 1, 1);
             header_grid.attach (origin_combo_revealer, 1, 2, 3);
-            header_grid.attach (button_box, 3, 0);
 
             if (!package.is_local) {
                 size_label = new Widgets.SizeLabel () {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -92,6 +92,7 @@ namespace AppCenter.Views {
                 show_close_button = true
             };
             headerbar.pack_start (back_button);
+            headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
             accent_provider = new Gtk.CssProvider ();
             try {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -83,6 +83,7 @@ namespace AppCenter.Views {
             };
             headerbar.pack_start (back_button);
             headerbar.pack_end (menu_button);
+            headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
             var loading_view = new Granite.Widgets.AlertView (
                 _("Checking for Updates"),

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -44,6 +44,7 @@ public class AppCenter.CategoryView : Gtk.Box {
         };
         // headerbar.set_custom_title (search_clamp);
         headerbar.pack_start (back_button);
+        headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         recently_updated_flowbox = new SubcategoryFlowbox (_("Recently Updated"));
 

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -15,13 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class AppCenter.CategoryView : Gtk.Stack {
+public class AppCenter.CategoryView : Gtk.Box {
     public signal void show_app (AppCenterCore.Package package);
 
     public AppStream.Category category { get; construct; }
 
     private Gtk.ScrolledWindow scrolled;
     private Gtk.Box box;
+    private Gtk.Stack stack;
     private SubcategoryFlowbox free_flowbox;
     private SubcategoryFlowbox paid_flowbox;
     private SubcategoryFlowbox recently_updated_flowbox;
@@ -32,6 +33,18 @@ public class AppCenter.CategoryView : Gtk.Stack {
     }
 
     construct {
+        var back_button = new Gtk.Button.with_label (_("Home")) {
+            action_name = "win.go-back",
+            valign = Gtk.Align.CENTER
+        };
+        back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
+
+        var headerbar = new Hdy.HeaderBar () {
+            show_close_button = true
+        };
+        // headerbar.set_custom_title (search_clamp);
+        headerbar.pack_start (back_button);
+
         recently_updated_flowbox = new SubcategoryFlowbox (_("Recently Updated"));
 
         paid_flowbox = new SubcategoryFlowbox (_("Paid Apps"));
@@ -61,8 +74,15 @@ public class AppCenter.CategoryView : Gtk.Stack {
         };
         spinner.start ();
 
-        add (spinner);
-        add (scrolled);
+        stack = new Gtk.Stack () {
+            expand = true
+        };
+        stack.add (spinner);
+        stack.add (scrolled);
+
+        orientation = Gtk.Orientation.VERTICAL;
+        add (headerbar);
+        add (stack);
         show_all ();
 
         populate ();
@@ -171,7 +191,7 @@ public class AppCenter.CategoryView : Gtk.Stack {
 #endif
 
             show_all ();
-            visible_child = scrolled;
+            stack.visible_child = scrolled;
         });
     }
 

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -77,6 +77,7 @@ public class AppCenter.Homepage : Gtk.Box {
         };
         // headerbar.set_custom_title (search_clamp);
         headerbar.pack_end (updates_overlay);
+        headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         banner_carousel = new Hdy.Carousel () {
             allow_long_swipes = true


### PR DESCRIPTION
Working towards stuff like https://github.com/elementary/appcenter/discussions/1467#discussioncomment-2677121

Todo:
- [ ] Homepage: clicking updates badge doesn't switch to updates view
- [ ] DRY labeling back_button
- [ ] Re-add search
- [ ] Move stuff into headerbar

![Screenshot from 2022-12-09 13 19 26](https://user-images.githubusercontent.com/7277719/206797938-c0ebac02-0b7f-41ea-bec6-cdb39a173660.png)
![Screenshot from 2022-12-09 13 19 13](https://user-images.githubusercontent.com/7277719/206797942-bd4f6ddb-238b-4879-b509-bf1091986101.png)
![Screenshot from 2022-12-09 13 19 02](https://user-images.githubusercontent.com/7277719/206797947-c1d5eaa3-6342-4d90-87f5-c1b0d366ef66.png)
![Screenshot from 2022-12-09 13 18 54](https://user-images.githubusercontent.com/7277719/206797951-70990db3-47f4-494b-a085-a348396ca1b3.png)
