### PR TITLE
Size information for Runtime Updates

### DIFF
--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -161,6 +161,7 @@ public class AppCenterCore.UpdateManager : Object {
 
                 if (!AppCenter.App.settings.get_boolean ("automatic-updates")) {
                     runtime_count++;
+                    has_flatpak_updates = true;
                 }
 
                 runtime_desc += Markup.printf_escaped (

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -54,7 +54,7 @@ public class AppCenterCore.UpdateManager : Object {
         runtime_updates_component.summary = _("Updates to app runtimes");
         runtime_updates_component.add_icon (runtime_icon);
 
-        runtime_updates = new AppCenterCore.Package (FlatpakBackend.get_default (), runtime_updates_component);
+        runtime_updates = new AppCenterCore.Package (BackendAggregator.get_default (), runtime_updates_component);
     }
 
     public async uint get_updates (Cancellable? cancellable = null) {


### PR DESCRIPTION
Follow-up PR for https://github.com/elementary/appcenter/pull/1956.

fb9f35f3461d10856ceb46403febb166f60091a7 improves the display of size information in the overview page:

| Before  | After  |
|:---:|:---:|
|![](https://user-images.githubusercontent.com/10796736/208844056-4a0e9f81-d82a-4d6e-b507-7d4e0e67171c.png)  | ![](https://user-images.githubusercontent.com/10796736/208844076-47a84ae7-140e-4aad-ac8e-d962fd3e74d0.png) |

92014a5006c40cb44a8fff07d5a0bacd4a6fb401 ensures that size information is displayed in the details page for Runtime Updates:

| Before  | After  |
|:---:|:---:|
|![](https://user-images.githubusercontent.com/10796736/208844109-bb4fdd43-af13-45c0-9109-fc2d225d61fa.png)  | ![](https://user-images.githubusercontent.com/10796736/208844122-5da9a940-09a3-499b-9b7d-a54356bf1f08.png) |
