### PR TITLE
Fix deprecations for AppStream 0.16

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -1043,7 +1043,10 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
     private void reload_appstream_pool () {
         var new_package_list = new Gee.HashMap<string, Package> ();
 
-#if HAS_APPSTREAM_0_15
+#if HAS_APPSTREAM_0_16
+        user_appstream_pool.reset_extra_data_locations ();
+        user_appstream_pool.add_extra_data_location (user_metadata_path, AppStream.FormatStyle.CATALOG);
+#elif HAS_APPSTREAM_0_15
         user_appstream_pool.reset_extra_data_locations ();
         user_appstream_pool.add_extra_data_location (user_metadata_path, AppStream.FormatStyle.COLLECTION);
 #else
@@ -1078,7 +1081,10 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
             });
         }
 
-#if HAS_APPSTREAM_0_15
+#if HAS_APPSTREAM_0_16
+        system_appstream_pool.reset_extra_data_locations ();
+        system_appstream_pool.add_extra_data_location (system_metadata_path, AppStream.FormatStyle.CATALOG);
+#elif HAS_APPSTREAM_0_15
         system_appstream_pool.reset_extra_data_locations ();
         system_appstream_pool.add_extra_data_location (system_metadata_path, AppStream.FormatStyle.COLLECTION);
 #else

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -129,7 +129,9 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
     construct {
         worker_thread = new Thread<bool> ("flatpak-worker", worker_func);
         user_appstream_pool = new AppStream.Pool ();
-#if HAS_APPSTREAM_0_15
+#if HAS_APPSTREAM_0_16
+        user_appstream_pool.set_flags (AppStream.PoolFlags.LOAD_OS_CATALOG);
+#elif HAS_APPSTREAM_0_15
         user_appstream_pool.set_flags (AppStream.PoolFlags.LOAD_OS_COLLECTION);
 #else
         user_appstream_pool.set_flags (AppStream.PoolFlags.READ_COLLECTION);
@@ -137,7 +139,9 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
 #endif
 
         system_appstream_pool = new AppStream.Pool ();
-#if HAS_APPSTREAM_0_15
+#if HAS_APPSTREAM_0_16
+        system_appstream_pool.set_flags (AppStream.PoolFlags.LOAD_OS_CATALOG);
+#elif HAS_APPSTREAM_0_15
         system_appstream_pool.set_flags (AppStream.PoolFlags.LOAD_OS_COLLECTION);
 #else
         system_appstream_pool.set_flags (AppStream.PoolFlags.READ_COLLECTION);

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -165,7 +165,12 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         // Clear out the default set of metadata locations and only use the folder that gets populated
         // with elementary's AppStream data.
 #if HIDE_UPSTREAM_DISTRO_APPS
-#if HAS_APPSTREAM_0_15
+#if HAS_APPSTREAM_0_16
+        // Don't load Ubuntu components
+        appstream_pool.set_load_std_data_locations (false);
+        appstream_pool.reset_extra_data_locations ();
+        appstream_pool.add_extra_data_location ("/usr/share/app-info", AppStream.FormatStyle.CATALOG);
+#elif HAS_APPSTREAM_0_15
         // Don't load Ubuntu components
         appstream_pool.set_load_std_data_locations (false);
         appstream_pool.reset_extra_data_locations ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -72,6 +72,10 @@ if appstream.version().version_compare('>=0.15')
     args += '--define=HAS_APPSTREAM_0_15'
 endif
 
+if appstream.version().version_compare('>=0.16')
+    args += '--define=HAS_APPSTREAM_0_16'
+endif
+
 executable(
     meson.project_name(),
     appcenter_files,


### PR DESCRIPTION
Since AppStream 0.16 AppCenter could no longer be compiled:

```sh
../../../downloads/elementary/appcenter/master/https_github.com_elementary_appcenter/src/Core/FlatpakBackend.vala:1044.74-1044.105: error: The name `COLLECTION' does not exist in the context of `AppStream.FormatStyle' (appstream)
 1044 |         user_appstream_pool.add_extra_data_location (user_metadata_path, AppStream.FormatStyle.COLLECTION);
      |                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../downloads/elementary/appcenter/master/https_github.com_elementary_appcenter/src/Core/FlatpakBackend.vala:1079.78-1079.109: error: The name `COLLECTION' does not exist in the context of `AppStream.FormatStyle' (appstream)
 1079 |         system_appstream_pool.add_extra_data_location (system_metadata_path, AppStream.FormatStyle.COLLECTION);
      |                                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../downloads/elementary/appcenter/master/https_github.com_elementary_appcenter/src/Core/FlatpakBackend.vala:133.40-133.77: warning: `AppStream.PoolFlags.LOAD_OS_COLLECTION' is deprecated. Use LOAD_OS_CATALOG
  133 |         user_appstream_pool.set_flags (AppStream.PoolFlags.LOAD_OS_COLLECTION);
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../downloads/elementary/appcenter/master/https_github.com_elementary_appcenter/src/Core/FlatpakBackend.vala:141.42-141.79: warning: `AppStream.PoolFlags.LOAD_OS_COLLECTION' is deprecated. Use LOAD_OS_CATALOG
  141 |         system_appstream_pool.set_flags (AppStream.PoolFlags.LOAD_OS_COLLECTION);
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../downloads/elementary/appcenter/master/https_github.com_elementary_appcenter/src/Core/PackageKitBackend.vala:172.72-172.103: error: The name `COLLECTION' does not exist in the context of `AppStream.FormatStyle' (appstream)
  172 |         appstream_pool.add_extra_data_location ("/usr/share/app-info", AppStream.FormatStyle.COLLECTION);
      |                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Compilation failed: 3 error(s), 2 warning(s)
```

Building for Fedora 37:

[Before](https://github.com/meisenzahl/distro-agnostic/actions/runs/4630298197/jobs/8191697449)

[After](https://github.com/meisenzahl/distro-agnostic/actions/runs/4664205519/jobs/8256826304)