### PR TITLE
AppInfoView: rework vertical spacing

### DIFF
--- a/data/io.elementary.appcenter.gresource.xml
+++ b/data/io.elementary.appcenter.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/io/elementary/appcenter">
     <file alias="application.css" compressed="true">styles/application.css</file>
+    <file alias="AppInfoView.css" compressed="true">styles/AppInfoView.css</file>
     <file alias="AppListUpdateView.css" compressed="true">styles/AppListUpdateView.css</file>
     <file alias="arrow.css" compressed="true">styles/arrow.css</file>
     <file alias="badge.css" compressed="true">styles/badge.css</file>
@@ -10,6 +11,5 @@
     <file alias="fallback.css" compressed="true">styles/fallback.css</file>
     <file alias="loading.css" compressed="true">styles/loading.css</file>
     <file alias="ProgressButton.css" compressed="true">styles/ProgressButton.css</file>
-    <file alias="Screenshot.css" compressed="true">styles/Screenshot.css</file>
   </gresource>
 </gresources>

--- a/data/styles/AppInfoView.css
+++ b/data/styles/AppInfoView.css
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2023 elementary, Inc. (https://elementary.io)
+ */
+
+appinfoview .banner clamp {
+    padding: 1.333rem; /*12px*/;
+}
+
+appinfoview .banner combobox {
+    margin-top: 1.333rem; /*12px*/;
+}
+
+appinfoview .content-warning-box {
+    margin: 1.333rem 1.333rem 0; /*12px 12px 0*/;
+}
+
+appinfoview .screenshot {
+    background: @selected_bg_color;
+    border-radius: 0.666rem; /*6px*/
+    color: @selected_fg_color;
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin: 1.333rem; /*12px*/
+    padding: 1.333rem; /*12px*/
+}
+
+appinfoview .content-box {
+    margin: 0 1.333rem 1.333rem 1.333rem; /*12px*/;
+}
+
+appinfoview .content-box > label {
+    font-size: 1.25em;
+}

--- a/data/styles/Screenshot.css
+++ b/data/styles/Screenshot.css
@@ -1,9 +1,0 @@
-.screenshot {
-    background: @selected_bg_color;
-    border-radius: 0.666rem; /*6px*/
-    color: @selected_fg_color;
-    font-size: 1.5rem;
-    font-weight: bold;
-    margin: 1.333rem; /*12px*/
-    padding: 1.333rem; /*12px*/
-}

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -70,7 +70,7 @@ namespace AppCenter {
             };
             cancel_button.clicked.connect (() => action_cancelled ());
 
-            action_button_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
+            action_button_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
             action_button_group.add_widget (action_button);
             action_button_group.add_widget (cancel_button);
             action_button_group.add_widget (open_button);

--- a/src/Widgets/SizeLabel.vala
+++ b/src/Widgets/SizeLabel.vala
@@ -16,7 +16,7 @@
 *
 */
 
-public class AppCenter.Widgets.SizeLabel : Gtk.Grid {
+public class AppCenter.Widgets.SizeLabel : Gtk.Box {
     public bool using_flatpak { get; construct; }
     public uint64 size { get; construct; }
 
@@ -35,15 +35,15 @@ public class AppCenter.Widgets.SizeLabel : Gtk.Grid {
             _("Actual Download Size Likely to Be Smaller"),
             _("Only the parts of apps and updates that are needed will be downloaded.")
         );
+
         size_label = new Gtk.Label (null);
-        size_label.hexpand = true;
-        size_label.xalign = 1;
 
         var icon = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.BUTTON);
         icon.margin_start = 6;
 
-        icon_revealer = new Gtk.Revealer ();
-        icon_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
+        icon_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.NONE
+        };
         icon_revealer.add (icon);
 
         add (size_label);


### PR DESCRIPTION
Meant to address some concerns about app descriptions being really far down the page. Also helps out at small window widths and just makes some of the padding and margins more consistent and pleasant, alignment of buttons etc as well

## BEFORE

![Screenshot from 2023-05-02 18 19 10](https://user-images.githubusercontent.com/7277719/235817198-bdfb5537-6be3-423c-af45-81d6b1ac7a5d.png)
![Screenshot from 2023-05-02 18 18 47](https://user-images.githubusercontent.com/7277719/235817201-6e169338-7e48-4b34-8f71-878213a9af67.png)

## AFTER
![Screenshot from 2023-05-02 18 19 48](https://user-images.githubusercontent.com/7277719/235817195-c68100b7-7f32-4d65-961d-cdbcc49685c8.png)

![Screenshot from 2023-05-02 18 13 10](https://user-images.githubusercontent.com/7277719/235817205-e95c9e55-bd61-43be-8800-e944a222c06f.png)