### PR TITLE
AppInfoView: warn about direct geoclue access

### DIFF
--- a/data/icons/categories.gresource.xml
+++ b/data/icons/categories.gresource.xml
@@ -20,6 +20,7 @@
     <file alias="16x16/mimetypes/text-x-copying-symbolic.svg" compressed="true" preprocess="xml-stripblanks">text-x-copying-symbolic.svg</file>
 
     <file alias="scalable/categories/flatpak-eol-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/old-runtime.svg</file>
+    <file alias="scalable/categories/sandbox-location-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/sandbox-location.svg</file>
 
     <file alias="scalable/categories/oars-chat-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/chat.svg</file>
     <file alias="scalable/categories/oars-conflict-symbolic.svg" compressed="true" preprocess="xml-stripblanks">oars/conflict.svg</file>

--- a/data/icons/oars/sandbox-location.svg
+++ b/data/icons/oars/sandbox-location.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="32"
+   height="32"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <g
+     id="g4"
+     transform="translate(-872,-552)"
+     color="#000000" />
+  <path
+     id="path2"
+     style="color:#000000;font-variation-settings:normal;overflow:visible;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 5,1 C 2.7840022,1 1,2.8084357 1,5 V 9 H 3 V 5 C 3,3.8920011 3.8920011,3 5,3 H 9 V 1 Z m 18,0 v 2 h 4 c 1.107999,0 1.731271,0.9250832 2,2 v 4 h 2 V 5 C 31,2.7840022 29.215998,1 27,1 Z m -0.48043,7.060508 c -0.21248,0.00526 -0.420621,0.060068 -0.609375,0.15625 L 6.2598047,15.316367 c -0.4708426,0.238387 -0.7786575,0.722941 -0.7792968,1.263672 0,0.784183 0.6357384,1.419922 1.4199218,1.419922 h 7.0996093 v 7.099609 c 0,0.784184 0.635739,1.419922 1.419922,1.419922 0.553131,0 1.031225,-0.317715 1.265625,-0.779297 l 7.134765,-15.693359 c 0.07597,-0.1733542 0.118748,-0.3658591 0.119141,-0.5664061 0,-0.784183 -0.635738,-1.4199219 -1.419922,-1.4199219 z M 1,23 v 4 c 0,2.215998 1.7840022,4 4,4 H 9 V 29 H 5 C 3.8920011,29 3,28.107999 3,27 v -4 z m 28,0 v 4 c 0,1.107999 -0.892001,2 -2,2 h -4 v 2 h 4 c 2.215998,0 4,-1.759601 4,-4 v -4 z" />
+</svg>

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -713,92 +713,113 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
     private void set_permissionflags_from_metadata (KeyFile keyfile, Package package) {
         try {
             if (keyfile.has_group ("Context")) {
-                var sockets_context = keyfile.get_string_list ("Context", "sockets");
-                if (sockets_context != null) {
-                    if ("system-bus" in sockets_context) {
-                        package.permissions_flags |= Package.PermissionsFlags.SYSTEM_BUS;
-                    }
-                    if ("session-bus" in sockets_context) {
-                        package.permissions_flags |= Package.PermissionsFlags.SESSION_BUS;
-                    }
-                    if (!("fallback-x11" in sockets_context) && "x11" in sockets_context) {
-                        package.permissions_flags |= Package.PermissionsFlags.X11;
-                    }
-                }
-
-                var devices_context = keyfile.get_string_list ("Context", "devices");
-                if (devices_context != null && "all" in devices_context) {
-                    package.permissions_flags |= Package.PermissionsFlags.DEVICES;
-                }
-
-                var shared_context = keyfile.get_string_list ("Context", "shared");
-                if (shared_context != null && "network" in shared_context) {
-                    package.permissions_flags |= Package.PermissionsFlags.NETWORK;
-                }
-
-                var filesystems_context = keyfile.get_string_list ("Context", "filesystems");
-                if (filesystems_context != null) {
-                    FilesystemsAccess filesystems_access[] = {
-                        /* Reference: https://docs.flatpak.org/en/latest/flatpak-command-reference.html#idm45858571325264 */
-                        { "home", Package.PermissionsFlags.HOME_FULL },
-                        { "home:rw", Package.PermissionsFlags.HOME_FULL },
-                        { "home:ro", Package.PermissionsFlags.HOME_READ },
-                        { "~", Package.PermissionsFlags.HOME_FULL },
-                        { "~:rw", Package.PermissionsFlags.HOME_FULL },
-                        { "~:ro", Package.PermissionsFlags.HOME_READ },
-                        { "host", Package.PermissionsFlags.FILESYSTEM_FULL },
-                        { "host:rw", Package.PermissionsFlags.FILESYSTEM_FULL },
-                        { "host:ro", Package.PermissionsFlags.FILESYSTEM_READ },
-                        { "xdg-download", Package.PermissionsFlags.DOWNLOADS_FULL },
-                        { "xdg-download:rw", Package.PermissionsFlags.DOWNLOADS_FULL },
-                        { "xdg-download:ro", Package.PermissionsFlags.DOWNLOADS_READ },
-                        { "xdg-data/flatpak/overrides:create", Package.PermissionsFlags.ESCAPE_SANDBOX }
-                    };
-
-                    var filesystems_hits = 0;
-                    for (int i = 0; i < filesystems_access.length; i++) {
-                        if (filesystems_access[i].key in filesystems_context) {
-                            package.permissions_flags |= filesystems_access[i].permission;
-                            filesystems_hits++;
+                if (keyfile.has_key ("Context", "sockets")) {
+                    var sockets_context = keyfile.get_string_list ("Context", "sockets");
+                    if (sockets_context != null) {
+                        if ("system-bus" in sockets_context) {
+                            package.permissions_flags |= Package.PermissionsFlags.SYSTEM_BUS;
+                        }
+                        if ("session-bus" in sockets_context) {
+                            package.permissions_flags |= Package.PermissionsFlags.SESSION_BUS;
+                        }
+                        if (!("fallback-x11" in sockets_context) && "x11" in sockets_context) {
+                            package.permissions_flags |= Package.PermissionsFlags.X11;
                         }
                     }
+                }
 
-                    if (filesystems_context.length > filesystems_hits) {
-                        package.permissions_flags |= Package.PermissionsFlags.FILESYSTEM_OTHER;
+                if (keyfile.has_key ("Context", "devices")) {
+                    var devices_context = keyfile.get_string_list ("Context", "devices");
+                    if (devices_context != null && "all" in devices_context) {
+                        package.permissions_flags |= Package.PermissionsFlags.DEVICES;
                     }
+                }
 
-                    if ((package.permissions_flags & Package.PermissionsFlags.HOME_FULL) != 0) {
-                        package.permissions_flags = package.permissions_flags & ~Package.PermissionsFlags.HOME_READ;
+                if (keyfile.has_key ("Context", "shared")) {
+                    var shared_context = keyfile.get_string_list ("Context", "shared");
+                    if (shared_context != null && "network" in shared_context) {
+                        package.permissions_flags |= Package.PermissionsFlags.NETWORK;
                     }
+                }
 
-                    if ((package.permissions_flags & Package.PermissionsFlags.FILESYSTEM_FULL) != 0) {
-                        package.permissions_flags = package.permissions_flags & ~Package.PermissionsFlags.FILESYSTEM_READ;
-                    }
+                if (keyfile.has_key ("Context", "filesystems")) {
+                    var filesystems_context = keyfile.get_string_list ("Context", "filesystems");
+                    if (filesystems_context != null) {
+                        FilesystemsAccess filesystems_access[] = {
+                            /* Reference: https://docs.flatpak.org/en/latest/flatpak-command-reference.html#idm45858571325264 */
+                            { "home", Package.PermissionsFlags.HOME_FULL },
+                            { "home:rw", Package.PermissionsFlags.HOME_FULL },
+                            { "home:ro", Package.PermissionsFlags.HOME_READ },
+                            { "~", Package.PermissionsFlags.HOME_FULL },
+                            { "~:rw", Package.PermissionsFlags.HOME_FULL },
+                            { "~:ro", Package.PermissionsFlags.HOME_READ },
+                            { "host", Package.PermissionsFlags.FILESYSTEM_FULL },
+                            { "host:rw", Package.PermissionsFlags.FILESYSTEM_FULL },
+                            { "host:ro", Package.PermissionsFlags.FILESYSTEM_READ },
+                            { "xdg-download", Package.PermissionsFlags.DOWNLOADS_FULL },
+                            { "xdg-download:rw", Package.PermissionsFlags.DOWNLOADS_FULL },
+                            { "xdg-download:ro", Package.PermissionsFlags.DOWNLOADS_READ },
+                            { "xdg-data/flatpak/overrides:create", Package.PermissionsFlags.ESCAPE_SANDBOX }
+                        };
 
-                    if ((package.permissions_flags & Package.PermissionsFlags.DOWNLOADS_FULL) != 0) {
-                        package.permissions_flags = package.permissions_flags & ~Package.PermissionsFlags.DOWNLOADS_READ;
+                        var filesystems_hits = 0;
+                        for (int i = 0; i < filesystems_access.length; i++) {
+                            if (filesystems_access[i].key in filesystems_context) {
+                                package.permissions_flags |= filesystems_access[i].permission;
+                                filesystems_hits++;
+                            }
+                        }
+
+                        if (filesystems_context.length > filesystems_hits) {
+                            package.permissions_flags |= Package.PermissionsFlags.FILESYSTEM_OTHER;
+                        }
+
+                        if ((package.permissions_flags & Package.PermissionsFlags.HOME_FULL) != 0) {
+                            package.permissions_flags = package.permissions_flags & ~Package.PermissionsFlags.HOME_READ;
+                        }
+
+                        if ((package.permissions_flags & Package.PermissionsFlags.FILESYSTEM_FULL) != 0) {
+                            package.permissions_flags = package.permissions_flags & ~Package.PermissionsFlags.FILESYSTEM_READ;
+                        }
+
+                        if ((package.permissions_flags & Package.PermissionsFlags.DOWNLOADS_FULL) != 0) {
+                            package.permissions_flags = package.permissions_flags & ~Package.PermissionsFlags.DOWNLOADS_READ;
+                        }
                     }
                 }
             }
 
             if (keyfile.has_group ("Session Bus Policy")) {
-                var dconf_policy = keyfile.get_string ("Session Bus Policy", "ca.desrt.dconf");
-                if (dconf_policy != null && dconf_policy == "talk") {
-                    package.permissions_flags |= Package.PermissionsFlags.SETTINGS;
+                if (keyfile.has_key ("Session Bus Policy", "ca.desrt.dconf")) {
+                    var dconf_policy = keyfile.get_string ("Session Bus Policy", "ca.desrt.dconf");
+                    if (dconf_policy != null && dconf_policy == "talk") {
+                        package.permissions_flags |= Package.PermissionsFlags.SETTINGS;
+                    }
                 }
 
-                var flatpak_policy = keyfile.get_string ("Session Bus Policy", "org.freedesktop.Flatpak");
-                if (flatpak_policy != null && flatpak_policy == "talk") {
-                    package.permissions_flags |= Package.PermissionsFlags.ESCAPE_SANDBOX;
-                } else {
+                if (keyfile.has_key ("Session Bus Policy", "org.freedesktop.Flatpak")) {
+                    var flatpak_policy = keyfile.get_string ("Session Bus Policy", "org.freedesktop.Flatpak");
+                    if (flatpak_policy != null && flatpak_policy == "talk") {
+                        package.permissions_flags |= Package.PermissionsFlags.ESCAPE_SANDBOX;
+                    }
+                } else if (keyfile.has_key ("Session Bus Policy", "org.freedesktop.impl.portal.PermissionStore")) {
                     var portal_policy = keyfile.get_string ("Session Bus Policy", "org.freedesktop.impl.portal.PermissionStore");
                     if (portal_policy != null && portal_policy == "talk") {
                         package.permissions_flags |= Package.PermissionsFlags.ESCAPE_SANDBOX;
                     }
                 }
             }
+
+            if (keyfile.has_group ("System Bus Policy")) {
+                if (keyfile.has_key ("System Bus Policy", "org.freedesktop.GeoClue2")) {
+                    var geoclue_policy = keyfile.get_string ("System Bus Policy", "org.freedesktop.GeoClue2");
+                    if (geoclue_policy != null && geoclue_policy == "talk") {
+                        package.permissions_flags |= Package.PermissionsFlags.LOCATION;
+                    }
+                }
+            }
         } catch (Error e) {
-            debug ("Error getting Flatpak permissions: %s", e.message);
+            critical ("Error getting Flatpak permissions: %s", e.message);
         }
 
         // We didn't find anything, so call it NONE

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -94,6 +94,7 @@ public class AppCenterCore.Package : Object {
         FILESYSTEM_READ,
         HOME_FULL,
         HOME_READ,
+        LOCATION,
         NETWORK,
         NONE,
         SESSION_BUS,

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -914,6 +914,16 @@ public class AppCenter.Views.AppInfoView : AppCenter.AbstractAppContainer {
 
                 oars_flowbox.add (filesystem);
             }
+
+            if (AppCenterCore.Package.PermissionsFlags.LOCATION in package.permissions_flags) {
+                var location = new ContentType (
+                    _("Location Access"),
+                    _("Can see your precise location at any time without asking"),
+                    "sandbox-location-symbolic"
+                );
+
+                oars_flowbox.add (location);
+            }
         }
 
         if (runtime_warning != null && !is_runtime_warning_shown) {


### PR DESCRIPTION
![Screenshot from 2023-05-24 17 28 20](https://github.com/elementary/appcenter/assets/7277719/5c927553-d363-4c26-b609-98a460a41dd2)

Now that we have a location portal, shame apps for accessing geoclue directly.

While we're here, prevent a bunch of keyfile errors that caused permissions not to be displayed correctly