### PR TITLE
Fix deletion of search term when replacing text with text

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -34,7 +34,7 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
 
     private bool mimetype;
 
-    private const int VALID_QUERY_LENGTH = 3;
+    public const int VALID_QUERY_LENGTH = 3;
 
     public static Views.AppListUpdateView installed_view { get; private set; }
 
@@ -577,7 +577,17 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
         } else {
             // Prevent navigating away from category views when backspacing
             if (deck.visible_child == search_view) {
-                deck.navigate (Hdy.NavigationDirection.BACK);
+                search_view.clear ();
+                search_view.current_search_term = search_entry.text;
+
+                // When replacing text with text don't go back
+                Idle.add (() => {
+                    if (search_entry.text.length == 0) {
+                        deck.navigate (Hdy.NavigationDirection.BACK);
+                    }
+
+                    return Source.REMOVE;
+                });
             }
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -15,6 +15,8 @@
 */
 
 public class AppCenter.MainWindow : Hdy.ApplicationWindow {
+    public const int VALID_QUERY_LENGTH = 3;
+
     public bool working { get; set; }
 
     private AppCenter.SearchView search_view;
@@ -33,8 +35,6 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
     private uint configure_id;
 
     private bool mimetype;
-
-    public const int VALID_QUERY_LENGTH = 3;
 
     public static Views.AppListUpdateView installed_view { get; private set; }
 

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -55,8 +55,16 @@ public class AppCenter.SearchView : Gtk.Box {
         add (scrolled);
 
         notify["current-search-term"].connect (() => {
-            var dyn_flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (current_search_term, _("Flathub"));
-            alert_view.description = _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (dyn_flathub_link);
+            if (current_search_term == null) {
+                return;
+            }
+
+            if (current_search_term.length < MainWindow.VALID_QUERY_LENGTH) {
+                alert_view.description = _("The search term must be at least 3 characters long.");
+            } else {
+                var dyn_flathub_link = "<a href='https://flathub.org/apps/search/%s'>%s</a>".printf (current_search_term, _("Flathub"));
+                alert_view.description = _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (dyn_flathub_link);
+            }
         });
 
         list_box.row_activated.connect ((row) => {


### PR DESCRIPTION
Fixes #2059 
Fixes #1987 

It changes placeholder description to "The search term must be at least 3 characters long" when searching for something and then replacing that text with something else that is < 3 characters long.