### PR TITLE
Add unit tests for credit card validation methods

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,26 +26,29 @@ jobs:
       run: |
         apt update
         apt install -y gettext libappstream-dev libflatpak-dev libgee-0.8-dev libgranite-dev libgtk-3-dev libhandy-1-dev libjson-glib-dev libpackagekit-glib2-dev libsoup2.4-dev libxml2-dev libxml2-utils libpolkit-gobject-1-dev meson valac
-    - name: Build
+    - name: Build and Test
       env:
         DESTDIR: out
       run: |
         meson build
         ninja -C build install
+        ninja -C build test
 
-    - name: Build (Fedora)
+    - name: Build and Test (Fedora)
       env:
         DESTDIR: out
       run: |
         meson configure -Dcurated=false -Dpayments=false build
         ninja -C build install
+        ninja -C build test
 
-    - name: Build (Pop!_Shop)
+    - name: Build and Test (Pop!_Shop)
       env:
         DESTDIR: out
       run: |
         meson configure -Dcurated=false -Dpayments=false -Dsharing=false -Dname=Pop\!_Shop build
         ninja -C build install
+        ninja -C build test
 
     - name: Build (Flatpak-only)
       env:

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ vapi_dir = join_paths(meson.current_source_dir(), 'vapi')
 add_project_arguments(['--vapidir', vapi_dir], language: 'vala')
 
 glib = dependency ('glib-2.0')
+gobject = dependency ('gobject-2.0')
 gee = dependency ('gee-0.8')
 gtk = dependency ('gtk+-3.0', version: '>=3.10')
 granite = dependency ('granite', version: '>=6.0.0')
@@ -34,8 +35,12 @@ posix = meson.get_compiler('vala').find_library('posix')
 
 dbus = dependency ('dbus-1')
 
-dependencies = [
+core_deps = [
     glib,
+    gobject,
+]
+
+dependencies = core_deps + [
     gee,
     gtk,
     granite,
@@ -69,5 +74,6 @@ conf_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedi
 subdir('data')
 subdir('src')
 subdir('po')
+subdir('test')
 
 gnome.post_install(glib_compile_schemas: true)

--- a/src/Core/CardUtils.vala
+++ b/src/Core/CardUtils.vala
@@ -1,0 +1,119 @@
+/*-
+ * Copyright (c) 2023 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+public class AppCenterCore.CardUtils {
+    public enum CardType {
+        UNKNOWN,
+        VISA,
+        MASTERCARD,
+        AMERICAN_EXPRESS,
+        UNIONPAY,
+        DINERS_CLUB,
+        DISCOVER,
+        JCB;
+
+        // The numbers represents the position of the spaces
+        public int[] get_pattern () {
+            switch (this) {
+                case AppCenterCore.CardUtils.CardType.AMERICAN_EXPRESS:
+                case AppCenterCore.CardUtils.CardType.DINERS_CLUB:
+                    return {4, 10};
+                case AppCenterCore.CardUtils.CardType.VISA:
+                case AppCenterCore.CardUtils.CardType.MASTERCARD:
+                case AppCenterCore.CardUtils.CardType.DISCOVER:
+                case AppCenterCore.CardUtils.CardType.JCB:
+                case AppCenterCore.CardUtils.CardType.UNIONPAY:
+                default:
+                    return {4, 8, 12};
+            }
+        }
+
+        public int get_max_length () {
+            switch (this) {
+                case AppCenterCore.CardUtils.CardType.AMERICAN_EXPRESS:
+                    return 15;
+                case AppCenterCore.CardUtils.CardType.MASTERCARD:
+                    return 16;
+                case AppCenterCore.CardUtils.CardType.VISA:
+                case AppCenterCore.CardUtils.CardType.DISCOVER:
+                case AppCenterCore.CardUtils.CardType.DINERS_CLUB:
+                case AppCenterCore.CardUtils.CardType.JCB:
+                case AppCenterCore.CardUtils.CardType.UNIONPAY:
+                default:
+                    return 19;
+            }
+        }
+    }
+
+    public static CardType detect_card_type (string number) {
+        if (number.has_prefix ("4")) {
+            return CardType.VISA;
+        }
+
+        if (GLib.Regex.match_simple ("^(?:5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[01]|2720)", number)) {
+            return CardType.MASTERCARD;
+        }
+
+        if (number.has_prefix ("34") || number.has_prefix ("37")) {
+            return CardType.AMERICAN_EXPRESS;
+        }
+
+        if (number.has_prefix ("62")) {
+            return CardType.UNIONPAY;
+        }
+
+        if (GLib.Regex.match_simple ("^(2[01]([2-4]|1[4-9])|36|30([0-5]|95)|3[89])", number)) {
+            return CardType.DINERS_CLUB;
+        }
+
+        if (GLib.Regex.match_simple ("^(6011|6[45])", number)) {
+            return CardType.DISCOVER;
+        }
+
+        if (GLib.Regex.match_simple ("^(35([3-8]|2[89]))", number)) {
+            return CardType.JCB;
+        }
+
+        return CardType.UNKNOWN;
+    }
+
+    // Checks whether a credit card number is valid
+    public static bool is_card_valid (string numbers) {
+        var char_count = numbers.char_count ();
+
+        if (char_count < 14) return false;
+
+        int hash = int.parse (numbers[char_count - 1:char_count]);
+
+        int j = 1;
+        int sum = 0;
+        for (int i = char_count - 1; i > 0; i--) {
+            var number = int.parse (numbers[i - 1:i]);
+            if (j++ % 2 == 1) {
+                number = number * 2;
+                if (number > 9) {
+                    number = number - 9;
+                }
+            }
+
+            sum += number;
+        }
+
+        return (10 - (sum % 10)) % 10 == hash;
+    }
+}

--- a/src/Dialogs/StripeDialog.vala
+++ b/src/Dialogs/StripeDialog.vala
@@ -285,7 +285,7 @@ public class AppCenter.Widgets.StripeDialog : Granite.Dialog {
         });
 
         card_number_entry.changed.connect (() => {
-            card_valid = is_card_valid (card_number_entry.card_number);
+            card_valid = AppCenterCore.CardUtils.is_card_valid (card_number_entry.card_number);
             is_payment_sensitive ();
         });
 
@@ -423,30 +423,6 @@ public class AppCenter.Widgets.StripeDialog : Granite.Dialog {
         } else {
             pay_button.sensitive = false;
         }
-    }
-
-    private bool is_card_valid (string numbers) {
-        var char_count = numbers.char_count ();
-
-        if (char_count < 14) return false;
-
-        int hash = int.parse (numbers[char_count - 1:char_count]);
-
-        int j = 1;
-        int sum = 0;
-        for (int i = char_count - 1; i > 0; i--) {
-            var number = int.parse (numbers[i - 1:i]);
-            if (j++ % 2 == 1) {
-                number = number * 2;
-                if (number > 9) {
-                    number = number - 9;
-                }
-            }
-
-            sum += number;
-        }
-
-        return (10 - (sum % 10)) % 10 == hash;
     }
 
     private void on_response (Gtk.Dialog source, int response_id) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ appcenter_files = files(
     'Utils.vala',
     'Core/BackendAggregator.vala',
     'Core/BackendInterface.vala',
+    'Core/CardUtils.vala',
     'Core/ChangeInformation.vala',
     'Core/Client.vala',
     'Core/ComponentValidator.vala',

--- a/test/Core/CardUtils.vala
+++ b/test/Core/CardUtils.vala
@@ -1,0 +1,137 @@
+/*-
+ * Copyright (c) 2023 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+void add_card_tests () {
+    Test.add_func ("/detect_card_type/amex", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("375556917985515") == AppCenterCore.CardUtils.CardType.AMERICAN_EXPRESS);
+        assert (AppCenterCore.CardUtils.detect_card_type ("378282246310005") == AppCenterCore.CardUtils.CardType.AMERICAN_EXPRESS);
+    });
+
+    Test.add_func ("/detect_card_type/diners_club", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("30569309025904") == AppCenterCore.CardUtils.CardType.DINERS_CLUB);
+        assert (AppCenterCore.CardUtils.detect_card_type ("36050234196908") == AppCenterCore.CardUtils.CardType.DINERS_CLUB);
+    });
+
+    Test.add_func ("/detect_card_type/visa", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("4716461583322103") == AppCenterCore.CardUtils.CardType.VISA);
+        assert (AppCenterCore.CardUtils.detect_card_type ("4716989580001715211") == AppCenterCore.CardUtils.CardType.VISA);
+        assert (AppCenterCore.CardUtils.detect_card_type ("4716221051885662") == AppCenterCore.CardUtils.CardType.VISA);
+        assert (AppCenterCore.CardUtils.detect_card_type ("4929722653797141") == AppCenterCore.CardUtils.CardType.VISA);
+    });
+
+    Test.add_func ("/detect_card_type/mastercard", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("5555555555554444") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("5105105105105100") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223000048400011") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223016768739313") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223026768739312") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223036768739311") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223046768739310") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223056768739319") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223066768739318") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223076768739317") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223086768739316") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223096768739315") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223806768739314") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223816768739313") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2223826768739312") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("5398228707871527") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2222155765072228") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2225855203075256") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2718760626256570") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+        assert (AppCenterCore.CardUtils.detect_card_type ("2720428011723762") == AppCenterCore.CardUtils.CardType.MASTERCARD);
+    });
+
+    Test.add_func ("/detect_card_type/jcb", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("3530111333300000") == AppCenterCore.CardUtils.CardType.JCB);
+        assert (AppCenterCore.CardUtils.detect_card_type ("3566002020360505") == AppCenterCore.CardUtils.CardType.JCB);
+    });
+
+    Test.add_func ("/detect_card_type/discover", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("6011111111111117") == AppCenterCore.CardUtils.CardType.DISCOVER);
+        assert (AppCenterCore.CardUtils.detect_card_type ("6011000990139424") == AppCenterCore.CardUtils.CardType.DISCOVER);
+    });
+
+    Test.add_func ("/detect_card_type/unionpay", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("6228223624220258") == AppCenterCore.CardUtils.CardType.UNIONPAY);
+        assert (AppCenterCore.CardUtils.detect_card_type ("6226050967750613") == AppCenterCore.CardUtils.CardType.UNIONPAY);
+        assert (AppCenterCore.CardUtils.detect_card_type ("6234917882863855") == AppCenterCore.CardUtils.CardType.UNIONPAY);
+        assert (AppCenterCore.CardUtils.detect_card_type ("6234698580215388") == AppCenterCore.CardUtils.CardType.UNIONPAY);
+        assert (AppCenterCore.CardUtils.detect_card_type ("6246281879460688") == AppCenterCore.CardUtils.CardType.UNIONPAY);
+        assert (AppCenterCore.CardUtils.detect_card_type ("6263892624162870") == AppCenterCore.CardUtils.CardType.UNIONPAY);
+        assert (AppCenterCore.CardUtils.detect_card_type ("6283875070985593") == AppCenterCore.CardUtils.CardType.UNIONPAY);
+    });
+
+    Test.add_func ("/detect_card_type/unknown", () => {
+        assert (AppCenterCore.CardUtils.detect_card_type ("1234567890123456") == AppCenterCore.CardUtils.CardType.UNKNOWN);
+    });
+
+    Test.add_func ("/is_card_valid/valid_numbers", () => {
+        assert (AppCenterCore.CardUtils.is_card_valid ("375556917985515") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("378282246310005") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("30569309025904") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("36050234196908") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("4716461583322103") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("4716989580001715211") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("4716221051885662") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("4929722653797141") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("5555555555554444") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("5105105105105100") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223000048400011") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223016768739313") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223026768739312") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223036768739311") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223046768739310") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223056768739319") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223066768739318") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223076768739317") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223086768739316") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223096768739315") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("5398228707871527") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2222155765072228") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2225855203075256") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2718760626256570") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2720428011723762") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("3530111333300000") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("3566002020360505") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6011111111111117") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6011000990139424") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6228223624220258") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6226050967750613") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6234917882863855") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6234698580215388") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6246281879460688") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6263892624162870") == true);
+        assert (AppCenterCore.CardUtils.is_card_valid ("6283875070985593") == true);
+    });
+
+    Test.add_func ("/is_card_valid/invalid_numbers", () => {
+        assert (AppCenterCore.CardUtils.is_card_valid ("1234567890123456") == false);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223806768739314") == false);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223816768739313") == false);
+        assert (AppCenterCore.CardUtils.is_card_valid ("2223826768739312") == false);
+    });
+
+    Test.add_func ("/is_card_valid/short", () => {
+        assert (AppCenterCore.CardUtils.is_card_valid ("41111111111") == false);
+    });
+
+    Test.add_func ("/is_card_valid/empty", () => {
+        assert (AppCenterCore.CardUtils.is_card_valid ("") == false);
+    });
+}

--- a/test/CoreTest.vala
+++ b/test/CoreTest.vala
@@ -1,0 +1,5 @@
+void main (string[] args) {
+    Test.init (ref args);
+    add_card_tests ();
+    Test.run ();
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,9 @@
+core_tests = executable(
+    meson.project_name() + '-core-tests',
+    'Core/CardUtils.vala',
+    'CoreTest.vala',
+    meson.project_source_root() + '/src/Core/CardUtils.vala',
+    dependencies: core_deps
+)
+
+test('AppCenter core tests', core_tests)


### PR DESCRIPTION
I've been meaning to start adding unit tests for a bunch of stuff in AppCenter for a while.

This code is unlikely to ever get re-factored so not too important to have tests, but it seems like a good place to set up the initial test structure.

No changes to logic here, just moving into a separate class for separation of UI and logic.