### PR TITLE
Suggest packages

### DIFF
--- a/src/Core/BackendAggregator.vala
+++ b/src/Core/BackendAggregator.vala
@@ -104,6 +104,22 @@ public class AppCenterCore.BackendAggregator : Backend, Object {
         return apps;
     }
 
+    public async Gee.Collection<Package> get_suggested_applications (Cancellable? cancellable = null) {
+        var apps = new Gee.TreeSet<Package> ();
+        foreach (var backend in backends) {
+            if (cancellable.is_cancelled ()) {
+                break;
+            }
+
+            var suggested = yield backend.get_suggested_applications (cancellable);
+            if (suggested != null) {
+                apps.add_all (suggested);
+            }
+        }
+
+        return apps;
+    }
+
     public async Gee.Collection<Package> get_installed_applications (Cancellable? cancellable = null) {
         var apps = new Gee.TreeSet<Package> ();
         foreach (var backend in backends) {

--- a/src/Core/BackendInterface.vala
+++ b/src/Core/BackendInterface.vala
@@ -22,6 +22,7 @@ public interface AppCenterCore.Backend : Object {
     public abstract bool working { public get; protected set; }
 
     public abstract async Gee.Collection<PackageDetails> get_prepared_applications (Cancellable? cancellable = null);
+    public abstract async Gee.Collection<Package> get_suggested_applications (Cancellable? cancellable = null);
     public abstract async Gee.Collection<Package> get_installed_applications (Cancellable? cancellable = null);
     public abstract Gee.Collection<Package> get_applications_for_category (AppStream.Category category);
     public abstract Gee.Collection<Package> search_applications (string query, AppStream.Category? category);

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -49,6 +49,10 @@ public class AppCenterCore.Client : Object {
         return yield BackendAggregator.get_default ().get_prepared_applications (cancellable);
     }
 
+    public async Gee.Collection<AppCenterCore.Package> get_suggested_applications (Cancellable? cancellable = null) {
+        return yield BackendAggregator.get_default ().get_suggested_applications (cancellable);
+    }
+
     public async Gee.Collection<AppCenterCore.Package> get_installed_applications (Cancellable? cancellable = null) {
         return yield BackendAggregator.get_default ().get_installed_applications (cancellable);
     }

--- a/src/Core/Job.vala
+++ b/src/Core/Job.vala
@@ -40,6 +40,7 @@ public class AppCenterCore.Job : Object {
         GET_PACKAGE_DEPENDENCIES,
         GET_PREPARED_PACKAGES,
         REPAIR,
+        GET_SUGGESTED_PACKAGES,
     }
 
     public Job (Type type) {
@@ -54,6 +55,10 @@ public class AppCenterCore.RepairArgs : JobArgs {
 }
 
 public class AppCenterCore.GetPreparedPackagesArgs : JobArgs {
+    public Cancellable? cancellable;
+}
+
+public class AppCenterCore.GetSuggestedPackagesArgs : JobArgs {
     public Cancellable? cancellable;
 }
 

--- a/src/Core/PackageKitBackend.vala
+++ b/src/Core/PackageKitBackend.vala
@@ -356,6 +356,12 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
         return packages;
     }
 
+    public async Gee.Collection<Package> get_suggested_applications (Cancellable? cancellable = null) {
+        var suggested_apps = new Gee.HashSet<Package> ();
+
+        return suggested_apps;
+    }
+
     public async Gee.Collection<AppCenterCore.Package> get_installed_applications (Cancellable? cancellable = null) {
         var packages = new Gee.TreeSet<AppCenterCore.Package> ();
         var installed = yield get_installed_packages (cancellable);

--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -47,6 +47,12 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
         return prepared_packages;
     }
 
+    public async Gee.Collection<Package> get_suggested_applications (Cancellable? cancellable = null) {
+        var suggested_apps = new Gee.HashSet<Package> ();
+
+        return suggested_apps;
+    }
+
     public async Gee.Collection<Package> get_installed_applications (Cancellable? cancellable = null) {
         if (cached_packages != null) {
             return cached_packages;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -658,6 +658,7 @@ public class AppCenter.MainWindow : Hdy.ApplicationWindow {
                 break;
             case GET_PREPARED_PACKAGES:
             case GET_INSTALLED_PACKAGES:
+            case GET_SUGGESTED_PACKAGES:
             case GET_UPDATES:
             case REFRESH_CACHE:
                 overlaybar.label = _("Checking for updates…");


### PR DESCRIPTION
As mentioned in https://github.com/elementary/os/discussions/651, we install our Flatpak applications via apt. This allows us to switch back to a native application if there are any issues.

However, since we now install all native packages as offline updates, this mechanism fails because we have no Internet connection during the update and therefore cannot install any Flatpak packages. This problem also blocks offline system upgrades.

This branch searches a user and a system directory for configuration files that suggest installing Flatpak packages.

You can place configuration files under `$HOME/.config/appcenter/flatpak.d/` to suggest an installation for the current user. You can also create configuration files under `/etc/appcenter/flatpak.d` to suggest system installations.

A configuration file must be formatted as follows:

```ini
[install]
origin=appcenter
type=app
id=com.github.manexim.insomnia
branch=stable
```

Currently, the packages are only suggested for installation and displayed on the update page.

I tested the changes under Fedora 38. Due to https://github.com/elementary/appcenter/pull/2094, I could not test the changes under OS 7, as I received the following error message: `libsoup2 symbols detected. Using libsoup2 and libsoup3 in the same process is not supported`. Unfortunately, I could not install a daily build of OS 8 (`elementaryos-8.0-daily.20231110.iso`).
