### PR TITLE
UpdateManager: Get complete update number

### DIFF
--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -113,8 +113,6 @@ public class AppCenterCore.UpdateManager : Object {
         var flatpak_updates = yield fp_client.get_updates ();
         debug ("Flatpak backend reports %d updates", flatpak_updates.size);
 
-        var auto_update_enabled = AppCenter.App.settings.get_boolean ("automatic-updates");
-
         foreach (var flatpak_update in flatpak_updates) {
             var appcenter_package = fp_client.lookup_package_by_id (flatpak_update);
             if (appcenter_package != null) {
@@ -125,11 +123,9 @@ public class AppCenterCore.UpdateManager : Object {
                     unpaid_apps_number++;
                 }
 
-                if (!auto_update_enabled || appcenter_package.should_pay) {
-                    count++;
-                    updates_size += appcenter_package.change_information.size;
-                    has_flatpak_updates = true;
-                }
+                count++;
+                updates_size += appcenter_package.change_information.size;
+                has_flatpak_updates = true;
 
                 appcenter_package.change_information.updatable_packages.@set (fp_client, flatpak_update);
                 appcenter_package.update_state ();
@@ -153,10 +149,8 @@ public class AppCenterCore.UpdateManager : Object {
                     continue;
                 }
 
-                if (!AppCenter.App.settings.get_boolean ("automatic-updates")) {
-                    runtime_count++;
-                    has_flatpak_updates = true;
-                }
+                runtime_count++;
+                has_flatpak_updates = true;
 
                 runtime_desc += Markup.printf_escaped (
                     " • %s\n\t%s\n",


### PR DESCRIPTION
Don't check whether automatic updates are enabled when getting the update number. This has lead to an entry for runtime updates showing up with 0 updates available but having a download button. That's because there we check the download size not whether updates are available. 

The alternative to this PR would be to always exclude flatpaks when automatic updates are enabled however I think it's better to show the respective apps no matter whether automatic updates are enabled or not so that a manual update can always be forced and one can check progress on the automatic updates