### PR TITLE
Show ongoing operations

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -436,15 +436,8 @@ namespace AppCenter.Views {
             updating_all_apps = false;
         }
 
-        public async void add_app (AppCenterCore.Package package) {
-            unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
-            var installed_apps = yield client.get_installed_applications ();
-            foreach (var app in installed_apps) {
-                if (app == package) {
-                    updates_liststore.insert_sorted (package, compare_package_func);
-                    break;
-                }
-            }
+        public void add_app (AppCenterCore.Package package) {
+            updates_liststore.insert_sorted (package, compare_package_func);
         }
 
         public void clear () {

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -278,9 +278,8 @@ public abstract class AppCenter.AbstractAppContainer : Gtk.Box {
                 }
             }
         } else {
-            if (yield package.install ()) {
-                MainWindow.installed_view.add_app.begin (package);
-            }
+            MainWindow.installed_view.add_app (package);
+            yield package.install ();
         }
     }
 }


### PR DESCRIPTION
Whenever a install button is clicked we add the app to the updates ListStore on the AppListUpdateView. There it shows a progressbutton with cancel ability and gets added to the installed apps list once its done as then the `installed_apps_changed` signal gets fired and the view updated shortly after.

Regarding the current behavior I'm not sure but I think it's wrong anyways because currently an app gets added to the update liststore only after it was installed and the installed_apps_changed signal was then already fired so that it also doesn't get removed but stays there.

To test this you might want to use a large app like GNOME Builder etc. to have enough time to switch over