### PR TITLE
MainWindow: Adw.Leaflet → Adw.NavigationView

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -507,11 +507,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void show_category (AppStream.Category category) {
-        if (navigation_view.find_page (category.name) != null) {
-            navigation_view.push_by_tag (category.name);
-            return;
-        }
-
         var category_view = new CategoryView (category);
 
         navigation_view.push (category_view);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -27,7 +27,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     private Gtk.Revealer updates_badge_revealer;
     private Granite.Toast toast;
     private Granite.OverlayBar overlaybar;
-    private Adw.Leaflet leaflet;
+    private Adw.NavigationView navigation_view;
 
     private AppCenterCore.Package? last_installed_package;
 
@@ -41,14 +41,14 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         search_entry.grab_focus ();
 
         var go_back = new SimpleAction ("go-back", null);
-        go_back.activate.connect (() => leaflet.navigate (BACK));
+        go_back.activate.connect (() => navigation_view.pop ());
         add_action (go_back);
 
         var focus_search = new SimpleAction ("focus-search", null);
         focus_search.activate.connect (() => search_entry.grab_focus ());
         add_action (focus_search);
 
-        app.set_accels_for_action ("win.go-back", {"<Alt>Left", "Back"});
+        app.set_accels_for_action ("win.go-back", {"<Alt>Left"});
         app.set_accels_for_action ("win.focus-search", {"<Ctrl>f"});
 
         search_entry.search_changed.connect (() => trigger_search ());
@@ -194,14 +194,12 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         var homepage = new Homepage ();
         installed_view = new Views.AppListUpdateView ();
 
-        leaflet = new Adw.Leaflet () {
-            can_navigate_back = true,
-            can_unfold = false
-        };
-        leaflet.append (homepage);
+        navigation_view = new Adw.NavigationView ();
+        navigation_view.add (homepage);
+        navigation_view.add (installed_view);
 
         var overlay = new Gtk.Overlay () {
-            child = leaflet
+            child = navigation_view
         };
         overlay.add_overlay (toast);
 
@@ -291,17 +289,8 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             show_package (package);
         });
 
-        leaflet.notify["visible-child"].connect (() => {
-            if (!leaflet.child_transition_running) {
-                update_navigation ();
-            }
-        });
-
-        leaflet.notify["child-transition-running"].connect (() => {
-            if (!leaflet.child_transition_running) {
-                update_navigation ();
-            }
-        });
+        navigation_view.popped.connect (update_navigation);
+        navigation_view.pushed.connect (update_navigation);
 
         search_entry_eventcontrollerkey.key_released.connect ((keyval, keycode, state) => {
             switch (keyval) {
@@ -351,63 +340,38 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         });
     }
 
-    public void show_package (AppCenterCore.Package package, bool remember_history = true) {
-        if (leaflet.child_transition_running) {
-            return;
-        }
-
-        var package_hash = package.hash;
-
-        var pk_child = leaflet.get_child_by_name (package_hash) as Views.AppInfoView;
-        if (pk_child != null && pk_child.to_recycle) {
-            // Don't switch to a view that needs recycling
-            pk_child.destroy ();
-            pk_child = null;
-        }
-
+    public void show_package (AppCenterCore.Package package) {
+        var pk_child = navigation_view.find_page (package.hash);
         if (pk_child != null) {
-            leaflet.visible_child = pk_child;
+            navigation_view.pop_to_page (pk_child);
             return;
         }
 
         var app_info_view = new Views.AppInfoView (package);
+        navigation_view.push (app_info_view);
 
-        leaflet.append (app_info_view);
-        leaflet.visible_child = app_info_view;
-
-        if (leaflet.get_adjacent_child (BACK) is Views.AppInfoView) {
-            var adjacent_app_info_view = (Views.AppInfoView)leaflet.get_adjacent_child (BACK);
-            if (
-                !remember_history &&
-                adjacent_app_info_view.package.normalized_component_id == package.normalized_component_id
-            ) {
-                leaflet.remove (adjacent_app_info_view);
-                update_navigation ();
-            }
-        }
-
-        app_info_view.show_other_package.connect ((_package, remember_history, transition) => {
+        app_info_view.show_other_package.connect ((_package, transition) => {
             if (!transition) {
-                leaflet.mode_transition_duration = 0;
+                navigation_view.animate_transitions = false;
             }
 
-            show_package (_package, remember_history);
+            show_package (_package);
 
-            leaflet.mode_transition_duration = 200;
+            navigation_view.animate_transitions = true;
         });
     }
 
     private void update_navigation () {
-        var previous_child = leaflet.get_adjacent_child (BACK);
+        var previous_child = navigation_view.get_previous_page (navigation_view.visible_page);
 
-        if (leaflet.visible_child is Homepage) {
+        if (navigation_view.visible_page is Homepage) {
             view_mode_revealer.reveal_child = true;
             configure_search (true, _("Search Apps"), "");
-        } else if (leaflet.visible_child is CategoryView) {
-            var current_category = ((CategoryView) leaflet.visible_child).category;
+        } else if (navigation_view.visible_page is CategoryView) {
+            var current_category = ((CategoryView) navigation_view.visible_page).category;
             view_mode_revealer.reveal_child = false;
             configure_search (true, _("Search %s").printf (current_category.name), "");
-        } else if (leaflet.visible_child == search_view) {
+        } else if (navigation_view.visible_page == search_view) {
             if (previous_child is CategoryView) {
                 var previous_category = ((CategoryView) previous_child).category;
                 configure_search (true, _("Search %s").printf (previous_category.name));
@@ -416,36 +380,23 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
                 configure_search (true);
                 view_mode_revealer.reveal_child = true;
             }
-        } else if (leaflet.visible_child is Views.AppInfoView) {
+        } else if (navigation_view.visible_page is Views.AppInfoView) {
             view_mode_revealer.reveal_child = false;
             configure_search (false);
-        } else if (leaflet.visible_child is Views.AppListUpdateView) {
+        } else if (navigation_view.visible_page is Views.AppListUpdateView) {
             view_mode_revealer.reveal_child = true;
             configure_search (false);
         }
 
         if (previous_child == null) {
             set_return_name (null);
-        } else if (previous_child is Adw.NavigationPage) {
+        } else {
             set_return_name (previous_child.title);
-        }
-
-        while (leaflet.get_adjacent_child (FORWARD) != null) {
-            var next_child = leaflet.get_adjacent_child (FORWARD);
-            leaflet.remove (next_child);
-
-            if (!(next_child is AppCenter.Views.AppListUpdateView)) {
-                next_child.destroy ();
-            }
         }
     }
 
     public void go_to_installed () {
-        if (installed_view.parent == null) {
-            leaflet.append (installed_view);
-        }
-
-        leaflet.visible_child = installed_view;
+        navigation_view.push (installed_view);
     }
 
     public void search (string term, bool mimetype = false) {
@@ -457,7 +408,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         last_installed_package = package;
 
         // Only show a toast when we're not on the installed app's page
-        if (leaflet.visible_child is Views.AppInfoView && ((Views.AppInfoView) leaflet.visible_child).package == package) {
+        if (navigation_view.visible_page is Views.AppInfoView && ((Views.AppInfoView) navigation_view.visible_page).package == package) {
             return;
         }
 
@@ -480,15 +431,14 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         view_mode_revealer.reveal_child = !query_valid;
 
         if (query_valid) {
-            if (leaflet.visible_child != search_view) {
+            if (navigation_view.visible_page != search_view) {
                 search_view = new AppCenter.SearchView ();
 
                 search_view.show_app.connect ((package) => {
                     show_package (package);
                 });
 
-                leaflet.append (search_view);
-                leaflet.visible_child = search_view;
+                navigation_view.push (search_view);
             }
 
             search_view.clear ();
@@ -504,7 +454,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             } else {
                 AppStream.Category current_category = null;
 
-                var previous_child = leaflet.get_adjacent_child (BACK);
+                var previous_child = navigation_view.get_previous_page (navigation_view.visible_page);
                 if (previous_child is CategoryView) {
                     current_category = ((CategoryView) previous_child).category;
                 }
@@ -515,14 +465,14 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
         } else {
             // Prevent navigating away from category views when backspacing
-            if (leaflet.visible_child == search_view) {
+            if (navigation_view.visible_page == search_view) {
                 search_view.clear ();
                 search_view.current_search_term = search_entry.text;
 
                 // When replacing text with text don't go back
                 Idle.add (() => {
                     if (search_entry.text.length == 0) {
-                        leaflet.navigate (BACK);
+                        navigation_view.pop ();
                     }
 
                     return Source.REMOVE;
@@ -557,16 +507,14 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void show_category (AppStream.Category category) {
-        var child = leaflet.get_child_by_name (category.name);
-        if (child != null) {
-            leaflet.visible_child = child;
+        if (navigation_view.find_page (category.name) != null) {
+            navigation_view.push_by_tag (category.name);
             return;
         }
 
         var category_view = new CategoryView (category);
 
-        leaflet.append (category_view);
-        leaflet.visible_child = category_view;
+        navigation_view.push (category_view);
 
         category_view.show_app.connect ((package) => {
             show_package (package);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -347,6 +347,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             return;
         }
 
+        // Remove old pages when switching package origins
         if (navigation_view.visible_page is Views.AppInfoView) {
             var visible_page = (Views.AppInfoView) navigation_view.visible_page;
             if (visible_page.package.normalized_component_id == package.normalized_component_id) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -351,22 +351,16 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         if (navigation_view.visible_page is Views.AppInfoView) {
             var visible_page = (Views.AppInfoView) navigation_view.visible_page;
             if (visible_page.package.normalized_component_id == package.normalized_component_id) {
+                navigation_view.animate_transitions = false;
                 navigation_view.pop ();
             }
         }
 
         var app_info_view = new Views.AppInfoView (package);
         navigation_view.push (app_info_view);
+        navigation_view.animate_transitions = true;
 
-        app_info_view.show_other_package.connect ((_package, transition) => {
-            if (!transition) {
-                navigation_view.animate_transitions = false;
-            }
-
-            show_package (_package);
-
-            navigation_view.animate_transitions = true;
-        });
+        app_info_view.show_other_package.connect (show_package);
     }
 
     private void update_navigation () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -347,6 +347,13 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             return;
         }
 
+        if (navigation_view.visible_page is Views.AppInfoView) {
+            var visible_page = (Views.AppInfoView) navigation_view.visible_page;
+            if (visible_page.package.normalized_component_id == package.normalized_component_id) {
+                navigation_view.pop ();
+            }
+        }
+
         var app_info_view = new Views.AppInfoView (package);
         navigation_view.push (app_info_view);
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -20,10 +20,7 @@
 public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
     public const int MAX_WIDTH = 800;
 
-    public signal void show_other_package (
-        AppCenterCore.Package package,
-        bool transition = true
-    );
+    public signal void show_other_package (AppCenterCore.Package package);
 
     public AppCenterCore.Package package { get; construct set; }
 
@@ -772,7 +769,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
         origin_dropdown.notify["selected-item"].connect (() => {
             var selected_origin_package = (AppCenterCore.Package) origin_dropdown.selected_item;
             if (selected_origin_package != null && selected_origin_package != package) {
-                show_other_package (selected_origin_package, false);
+                show_other_package (selected_origin_package);
             }
         });
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -22,7 +22,6 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
     public signal void show_other_package (
         AppCenterCore.Package package,
-        bool remember_history = true,
         bool transition = true
     );
 
@@ -729,6 +728,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
         child = overlay;
         title = package.get_name ();
+        tag = package.hash;
 
 #if SHARING
         if (package.is_shareable) {
@@ -772,7 +772,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
         origin_dropdown.notify["selected-item"].connect (() => {
             var selected_origin_package = (AppCenterCore.Package) origin_dropdown.selected_item;
             if (selected_origin_package != null && selected_origin_package != package) {
-                show_other_package (selected_origin_package, false, false);
+                show_other_package (selected_origin_package, false);
             }
         });
 

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -62,6 +62,7 @@ public class AppCenter.CategoryView : Adw.NavigationPage {
 
         child = stack;
         title = category.name;
+        tag = category.name;
 
         populate ();
 

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -62,7 +62,6 @@ public class AppCenter.CategoryView : Adw.NavigationPage {
 
         child = stack;
         title = category.name;
-        tag = category.name;
 
         populate ();
 


### PR DESCRIPTION
Replaces deprecated Adw.Leaflet with Adw.NavigationView

* Handles mouse buttons already
* Knows not to remove pages with `add` when they're popped
* Can't remove/pop arbitrary children, can only navigate back to that page
* Automatically removes popped children