### PR TITLE
Desktop: organize, add singlemainwindow

### DIFF
--- a/data/io.elementary.appcenter.desktop.in.in
+++ b/data/io.elementary.appcenter.desktop.in.in
@@ -1,16 +1,23 @@
 [Desktop Entry]
+Version=1.0
+Type=Application
+
 Name=AppCenter
 Comment=Browse and manage apps
-Exec=@EXEC_NAME@ %U
-Icon=@PROJECT_NAME@
-Keywords=install;uninstall;remove;catalogue;store;apps;software;
-Actions=ShowUpdates;
-Terminal=false
-Type=Application
-StartupNotify=true
 Categories=GNOME;GTK;System;PackageManager;
+Keywords=install;uninstall;remove;catalogue;store;apps;software;
+
+Icon=@PROJECT_NAME@
+Exec=@EXEC_NAME@ %U
+SingleMainWindow=true
+StartupNotify=true
+Terminal=false
+
 MimeType=x-scheme-handler/appstream;
+
 X-GNOME-UsesNotifications=true
+
+Actions=ShowUpdates;
 
 [Desktop Action ShowUpdates]
 Exec=@EXEC_NAME@ --show-updates

--- a/data/io.elementary.appcenter.desktop.in.in
+++ b/data/io.elementary.appcenter.desktop.in.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0
+Version=1.5
 Type=Application
 
 Name=AppCenter


### PR DESCRIPTION
Update to look more like what appstream generator gives us with spaces between sections:

* Add desktop entry version
* Add SingleMainWindow to hint to the shell this app is not multi-window