### PR TITLE
SearchView: make search_entry internal

### DIFF
--- a/data/appcenter.metainfo.xml.in
+++ b/data/appcenter.metainfo.xml.in
@@ -82,6 +82,7 @@
       <issues>
         <issue url="https://github.com/elementary/appcenter/issues/366">Cover SPDX licenses</issue>
         <issue url="https://github.com/elementary/appcenter/issues/470">Screenshots are being stretched</issue>
+        <issue url="https://github.com/elementary/appcenter/issues/554">Can't search from an external source while open on an app from search</issue>
         <issue url="https://github.com/elementary/appcenter/issues/1590">When an app installs, the cancel button is not properly highlighted at the right edge</issue>
         <issue url="https://github.com/elementary/appcenter/issues/1940">Weird previous/next buttons behaviour in screenshots carousel</issue>
         <issue url="https://github.com/elementary/appcenter/issues/2035">Only show update info icon when there is info available</issue>

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -38,7 +38,7 @@ public class AppCenter.SearchView : Adw.NavigationPage {
     construct {
         var flathub_link = "<a href='https://flathub.org'>%s</a>".printf (_("Flathub"));
         alert_view = new Granite.Placeholder (_("No Apps Found")) {
-            description = _("Try changing search terms. You can also sideload Flatpak apps e.g. from %s").printf (flathub_link),
+            description = _("The search term must be at least 3 characters long."),
             icon = new ThemedIcon ("edit-find-symbolic")
         };
 


### PR DESCRIPTION
Fixes #554

* Makes it so you can start a search from any page
* Makes more searching logic internal to the search page
* You can have multiple searches without messing up your navigation history
* Will make it easy for each page to handle its own headerbar in a future branch