### PR TITLE
Application: don't try to get parent when backgrounding

### DIFF
--- a/data/appcenter.metainfo.xml.in
+++ b/data/appcenter.metainfo.xml.in
@@ -87,6 +87,7 @@
         <issue url="https://github.com/elementary/appcenter/issues/2035">Only show update info icon when there is info available</issue>
         <issue url="https://github.com/elementary/appcenter/issues/2088">Don't check for updates in the guest session</issue>
         <issue url="https://github.com/elementary/appcenter/issues/2134">AppCenter says an app is "Not Translated" that provides translation info</issue>
+        <issue url="https://github.com/elementary/appcenter/issues/2166">Segfault on wayland</issue>
       </issues>
     </release>
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -233,15 +233,13 @@ public class AppCenter.App : Gtk.Application {
     public async void request_background () {
         var portal = new Xdp.Portal ();
 
-        Xdp.Parent? parent = active_window != null ? Xdp.parent_new_gtk (active_window) : null;
-
         var command = new GenericArray<weak string> ();
         command.add ("io.elementary.appcenter");
         command.add ("--silent");
 
         try {
             if (!yield portal.request_background (
-                parent,
+                null,
                 _("AppCenter will automatically start when this device turns on and run when its window is closed so that it can automatically check and install updates."),
                 (owned) command,
                 Xdp.BackgroundFlags.AUTOSTART,


### PR DESCRIPTION
Fixes #2166 

It seems like this is pretty much always going to be null? Maybe the background request should be moved to when the window is shown or something? But the way it is right now I don't think this can ever get a valid window