### PR TITLE
Views: supply own headerbars

### DIFF
--- a/data/styles/HomePage.scss
+++ b/data/styles/HomePage.scss
@@ -4,6 +4,27 @@
  */
 
 homepage {
+    headerbar {
+        min-height: rem(32px);
+        padding-bottom: rem(3px);
+        padding-top: rem(3px);
+    }
+
+    .badge {
+        font-size: 0.75em;
+        margin: rem(3px);
+        min-height: rem(14px);
+        min-width: rem(14px);
+
+        &:dir(ltr) {
+            margin-right: 0;
+        }
+
+        &:dir(rtl) {
+            margin-left: 0;
+        }
+    }
+
     .banner {
         border: 1px solid #{'shade(@banner_bg_color, 0.8)'};
         box-shadow:
@@ -12,7 +33,7 @@ homepage {
             inset 0 -1px 0 0 #{'alpha(shade(@banner_bg_color, 1.7), 0.15)'},
             0 3px 2px -1px #{'alpha(shade(@banner_bg_color, 0.5), 0.2)'},
             0 3px 5px #{'alpha(shade(@banner_bg_color, 0.5), 0.15)'};
-        margin: rem(24px);
+        margin: rem(6px) rem(24px);
         padding: rem(64px) rem(24px);
 
         &:hover {

--- a/data/styles/MainWindow.scss
+++ b/data/styles/MainWindow.scss
@@ -3,27 +3,6 @@
  * SPDX-FileCopyrightText: 2024 elementary, Inc. (https://elementary.io)
  */
 
-.titlebar {
-    min-height: rem(32px);
-    padding-bottom: rem(3px);
-    padding-top: rem(3px);
-}
-
-.badge {
-    font-size: 0.75em;
-    margin: rem(3px);
-    min-height: rem(14px);
-    min-width: rem(14px);
-
-    &:dir(ltr) {
-        margin-right: 0;
-    }
-
-    &:dir(rtl) {
-        margin-left: 0;
-    }
-}
-
 .header > box {
     padding: 1rem;
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -36,7 +36,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         focus_search.activate.connect (() => search ());
         add_action (focus_search);
 
-        app.set_accels_for_action ("win.go-back", {"<Alt>Left"});
         app.set_accels_for_action ("win.search", {"<Ctrl>f"});
 
         unowned var backend = AppCenterCore.FlatpakBackend.get_default ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -121,6 +121,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         network_info_bar.add_button (_("Network Settings…"), Gtk.ResponseType.ACCEPT);
 
         var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        box.append (overlay);
         box.append (network_info_bar);
 
         if (Utils.is_running_in_demo_mode ()) {
@@ -139,8 +140,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
             box.append (demo_mode_info_bar);
         }
-
-        box.append (overlay);
 
         child = box;
         titlebar = new Gtk.Grid () { visible = false };

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -71,6 +71,19 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             to_recycle = true;
         });
 
+        var search_button = new Gtk.Button.from_icon_name ("edit-find") {
+            action_name = "win.search",
+            /// TRANSLATORS: the action of searching
+            tooltip_text = C_("action", "Search")
+        };
+        search_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
+
+        var headerbar = new Gtk.HeaderBar () {
+            title_widget = new Gtk.Grid () { visible = false }
+        };
+        headerbar.pack_start (new BackButton ());
+        headerbar.pack_end (search_button);
+
         accent_provider = new Gtk.CssProvider ();
         try {
             string bg_color = DEFAULT_BANNER_COLOR_PRIMARY;
@@ -723,7 +736,13 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
         };
         overlay.add_overlay (toast);
 
-        child = overlay;
+        var toolbar_view = new Adw.ToolbarView () {
+            content = overlay,
+            top_bar_style = RAISED
+        };
+        toolbar_view.add_top_bar (headerbar);
+
+        child = toolbar_view;
         title = package.get_name ();
         tag = package.hash;
 

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -91,12 +91,14 @@ namespace AppCenter.Views {
                 vexpand = true
             };
             list_box.bind_model (update_manager.updates_liststore, create_row_from_package);
+            list_box.set_placeholder (loading_view);
 
             var installed_header = new Granite.HeaderLabel (_("Up to Date")) {
                 margin_top = 12,
                 margin_end = 12,
                 margin_bottom = 12,
                 margin_start = 12,
+                visible = false
             };
 
             installed_flowbox = new Gtk.FlowBox () {
@@ -120,27 +122,66 @@ namespace AppCenter.Views {
             action_button_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
             action_button_group.add_widget (update_all_button);
 
+            var automatic_updates_button = new Granite.SwitchModelButton (_("Automatically Update Free & Purchased Apps")) {
+                description = _("Apps being tried for free will not update automatically")
+            };
+
+            var refresh_accellabel = new Granite.AccelLabel.from_action_name (
+                _("Check for Updates"),
+                "app.refresh"
+            );
+
+            var refresh_menuitem = new Gtk.Button () {
+                action_name = "app.refresh",
+                child = refresh_accellabel
+            };
+            refresh_menuitem.add_css_class (Granite.STYLE_CLASS_MENUITEM);
+
+            var menu_popover_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            menu_popover_box.append (automatic_updates_button);
+            menu_popover_box.append (refresh_menuitem);
+
+            var menu_popover = new Gtk.Popover () {
+                child = menu_popover_box
+            };
+            menu_popover.add_css_class (Granite.STYLE_CLASS_MENU);
+
+            var menu_button = new Gtk.MenuButton () {
+                icon_name = "open-menu",
+                popover = menu_popover,
+                tooltip_text = _("Settings")
+            };
+            menu_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
+
+            var search_button = new Gtk.Button.from_icon_name ("edit-find") {
+                action_name = "win.search",
+                /// TRANSLATORS: the action of searching
+                tooltip_text = C_("action", "Search")
+            };
+            search_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
+
+            var headerbar = new Gtk.HeaderBar () {
+                title_widget = new Gtk.Grid () { visible = false }
+            };
+            headerbar.pack_start (new BackButton ());
+            headerbar.pack_end (menu_button);
+            headerbar.pack_end (search_button);
+
             var toolbarview = new Adw.ToolbarView () {
                 content = scrolled
             };
+            toolbarview.add_top_bar (headerbar);
             toolbarview.add_top_bar (updated_revealer);
             toolbarview.add_top_bar (header_revealer);
             toolbarview.add_css_class (Granite.STYLE_CLASS_VIEW);
 
-            var stack = new Gtk.Stack () {
-                transition_type = UNDER_UP
-            };
-            stack.add_child (toolbarview);
-            stack.add_child (loading_view);
-            stack.visible_child = loading_view;
-
-            child = stack;
+            child = toolbarview;
             /// TRANSLATORS: the name of the Installed Apps view
             title = C_("view", "Installed");
 
             on_installed_changed.begin ((obj, res) => {
                 on_installed_changed.end (res);
-                stack.visible_child = toolbarview;
+                installed_header.visible = true;
             });
 
             update_manager.updates_liststore.items_changed.connect (() => {
@@ -172,19 +213,35 @@ namespace AppCenter.Views {
             update_all_button.clicked.connect (on_update_all);
 
             unowned var aggregator = AppCenterCore.FlatpakBackend.get_default ();
-            aggregator.notify ["job-type"].connect (() => {
+            aggregator.notify ["working"].connect (() => {
                 switch (aggregator.job_type) {
                     case GET_PREPARED_PACKAGES:
-                    case GET_INSTALLED_PACKAGES:
                     case GET_UPDATES:
                     case REFRESH_CACHE:
-                    case INSTALL_PACKAGE:
                     case UPDATE_PACKAGE:
-                    case REMOVE_PACKAGE:
+                        list_box.set_placeholder (loading_view);
                         updated_revealer.reveal_child = false;
+                        break;
+                    default:
+                        list_box.set_placeholder (null);
                         break;
                 }
             });
+
+            automatic_updates_button.notify["active"].connect (() => {
+                if (automatic_updates_button.active) {
+                    update_manager.update_cache.begin (true);
+                } else {
+                    update_manager.cancel_updates (true);
+                }
+            });
+
+            App.settings.bind (
+                "automatic-updates",
+                automatic_updates_button,
+                "active",
+                SettingsBindFlags.DEFAULT
+            );
         }
 
         private void on_updates_changed () {

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -60,7 +60,14 @@ public class AppCenter.CategoryView : Adw.NavigationPage {
         stack.add_child (spinner);
         stack.add_child (scrolled);
 
-        child = stack;
+        var headerbar = new Gtk.HeaderBar ();
+
+        var toolbar_view = new Adw.ToolbarView () {
+            content = stack
+        };
+        toolbar_view.add_top_bar (headerbar);
+
+        child = toolbar_view;
         title = category.name;
 
         populate ();

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -60,7 +60,21 @@ public class AppCenter.CategoryView : Adw.NavigationPage {
         stack.add_child (spinner);
         stack.add_child (scrolled);
 
-        var headerbar = new Gtk.HeaderBar ();
+        var title_label = new Gtk.Label (category.name);
+        title_label.add_css_class (Granite.STYLE_CLASS_TITLE_LABEL);
+
+        var search_button = new Gtk.Button.from_icon_name ("edit-find") {
+            action_name = "win.search",
+            /// TRANSLATORS: the action of searching
+            tooltip_text = C_("action", "Search")
+        };
+        search_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
+
+        var headerbar = new Gtk.HeaderBar () {
+            title_widget = title_label
+        };
+        headerbar.pack_start (new BackButton ());
+        headerbar.pack_end (search_button);
 
         var toolbar_view = new Adw.ToolbarView () {
             content = stack

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -33,6 +33,12 @@ public class AppCenter.Homepage : Adw.NavigationPage {
     private Gtk.Revealer recently_updated_revealer;
     private Widgets.Banner appcenter_banner;
 
+    private Gtk.Revealer view_mode_revealer;
+    private Gtk.Button refresh_menuitem;
+    private Gtk.Button return_button;
+    private Gtk.Label updates_badge;
+    private Gtk.Revealer updates_badge_revealer;
+
     private uint banner_timeout_id;
 
     class construct {
@@ -213,7 +219,97 @@ public class AppCenter.Homepage : Adw.NavigationPage {
             hscrollbar_policy = Gtk.PolicyType.NEVER
         };
 
-        child = scrolled_window;
+        return_button = new Gtk.Button () {
+            action_name = "win.go-back",
+            valign = Gtk.Align.CENTER,
+            visible = false
+        };
+        return_button.add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
+
+        var search_button = new Gtk.Button.from_icon_name ("edit-find") {
+            action_name = "win.search",
+            /// TRANSLATORS: the action of searching
+            tooltip_text = C_("action", "Search"),
+            valign = CENTER
+        };
+        search_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
+
+        var updates_button = new Gtk.Button.from_icon_name ("software-update-available") {
+            action_name = "app.show-updates"
+        };
+        updates_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
+
+        updates_badge = new Gtk.Label ("!");
+        updates_badge.add_css_class (Granite.STYLE_CLASS_BADGE);
+
+        updates_badge_revealer = new Gtk.Revealer () {
+            can_target = false,
+            child = updates_badge,
+            halign = Gtk.Align.END,
+            valign = Gtk.Align.START,
+            transition_type = Gtk.RevealerTransitionType.CROSSFADE
+        };
+
+        var updates_overlay = new Gtk.Overlay () {
+            child = updates_button,
+            tooltip_text = C_("view", "Updates & installed apps")
+        };
+        updates_overlay.add_overlay (updates_badge_revealer);
+
+        view_mode_revealer = new Gtk.Revealer () {
+            child = updates_overlay,
+            reveal_child = true,
+            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT
+        };
+
+        var automatic_updates_button = new Granite.SwitchModelButton (_("Automatically Update Free & Purchased Apps")) {
+            description = _("Apps being tried for free will not update automatically")
+        };
+
+        var refresh_accellabel = new Granite.AccelLabel.from_action_name (
+            _("Check for Updates"),
+            "app.refresh"
+        );
+
+        refresh_menuitem = new Gtk.Button () {
+            action_name = "app.refresh",
+            child = refresh_accellabel
+        };
+        refresh_menuitem.add_css_class (Granite.STYLE_CLASS_MENUITEM);
+
+        var menu_popover_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        menu_popover_box.append (automatic_updates_button);
+        menu_popover_box.append (refresh_menuitem);
+
+        var menu_popover = new Gtk.Popover () {
+            child = menu_popover_box
+        };
+        menu_popover.add_css_class (Granite.STYLE_CLASS_MENU);
+
+        var menu_button = new Gtk.MenuButton () {
+            icon_name = "open-menu",
+            popover = menu_popover,
+            tooltip_text = _("Settings"),
+            valign = Gtk.Align.CENTER
+        };
+        menu_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
+
+        var headerbar = new Gtk.HeaderBar () {
+            show_title_buttons = true
+        };
+        headerbar.pack_start (return_button);
+        if (!Utils.is_running_in_guest_session ()) {
+            headerbar.pack_end (menu_button);
+            headerbar.pack_end (view_mode_revealer);
+        }
+        headerbar.pack_end (search_button);
+
+        var toolbar_view = new Adw.ToolbarView () {
+            content = scrolled_window
+        };
+        toolbar_view.add_top_bar (headerbar);
+
+        child = toolbar_view;
         title = _("Home");
 
         var local_package = App.local_package;
@@ -260,6 +356,26 @@ public class AppCenter.Homepage : Adw.NavigationPage {
             var package_row_grid = (AppCenter.Widgets.ListPackageRowGrid) child.get_child ();
 
             show_package (package_row_grid.package);
+        });
+
+        App.settings.bind (
+            "automatic-updates",
+            automatic_updates_button,
+            "active",
+            SettingsBindFlags.DEFAULT
+        );
+
+        unowned var update_manager = AppCenterCore.UpdateManager.get_default ();
+        automatic_updates_button.notify["active"].connect (() => {
+            if (automatic_updates_button.active) {
+                update_manager.update_cache.begin (true);
+            } else {
+                update_manager.cancel_updates (true);
+            }
+        });
+
+        update_manager.notify["updates-number"].connect (() => {
+            show_update_badge (update_manager.updates_number);
         });
 
         destroy.connect (() => {
@@ -366,6 +482,19 @@ public class AppCenter.Homepage : Adw.NavigationPage {
             Source.remove (banner_timeout_id);
             banner_timeout_id = 0;
         }
+    }
+
+    private void show_update_badge (uint updates_number) {
+        Idle.add (() => {
+            if (updates_number == 0U) {
+                updates_badge_revealer.reveal_child = false;
+            } else {
+                updates_badge.label = updates_number.to_string ();
+                updates_badge_revealer.reveal_child = true;
+            }
+
+            return GLib.Source.REMOVE;
+        });
     }
 
     private abstract class AbstractCategoryCard : Gtk.FlowBoxChild {

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -33,8 +33,6 @@ public class AppCenter.Homepage : Adw.NavigationPage {
     private Gtk.Revealer recently_updated_revealer;
     private Widgets.Banner appcenter_banner;
 
-    private Gtk.Revealer view_mode_revealer;
-    private Gtk.Button refresh_menuitem;
     private Gtk.Button return_button;
     private Gtk.Label updates_badge;
     private Gtk.Revealer updates_badge_revealer;
@@ -219,13 +217,6 @@ public class AppCenter.Homepage : Adw.NavigationPage {
             hscrollbar_policy = Gtk.PolicyType.NEVER
         };
 
-        return_button = new Gtk.Button () {
-            action_name = "win.go-back",
-            valign = Gtk.Align.CENTER,
-            visible = false
-        };
-        return_button.add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
-
         var search_button = new Gtk.Button.from_icon_name ("edit-find") {
             action_name = "win.search",
             /// TRANSLATORS: the action of searching
@@ -256,51 +247,12 @@ public class AppCenter.Homepage : Adw.NavigationPage {
         };
         updates_overlay.add_overlay (updates_badge_revealer);
 
-        view_mode_revealer = new Gtk.Revealer () {
-            child = updates_overlay,
-            reveal_child = true,
-            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT
-        };
-
-        var automatic_updates_button = new Granite.SwitchModelButton (_("Automatically Update Free & Purchased Apps")) {
-            description = _("Apps being tried for free will not update automatically")
-        };
-
-        var refresh_accellabel = new Granite.AccelLabel.from_action_name (
-            _("Check for Updates"),
-            "app.refresh"
-        );
-
-        refresh_menuitem = new Gtk.Button () {
-            action_name = "app.refresh",
-            child = refresh_accellabel
-        };
-        refresh_menuitem.add_css_class (Granite.STYLE_CLASS_MENUITEM);
-
-        var menu_popover_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        menu_popover_box.append (automatic_updates_button);
-        menu_popover_box.append (refresh_menuitem);
-
-        var menu_popover = new Gtk.Popover () {
-            child = menu_popover_box
-        };
-        menu_popover.add_css_class (Granite.STYLE_CLASS_MENU);
-
-        var menu_button = new Gtk.MenuButton () {
-            icon_name = "open-menu",
-            popover = menu_popover,
-            tooltip_text = _("Settings"),
-            valign = Gtk.Align.CENTER
-        };
-        menu_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
-
         var headerbar = new Gtk.HeaderBar () {
             show_title_buttons = true
         };
         headerbar.pack_start (return_button);
         if (!Utils.is_running_in_guest_session ()) {
-            headerbar.pack_end (menu_button);
-            headerbar.pack_end (view_mode_revealer);
+            headerbar.pack_end (updates_overlay);
         }
         headerbar.pack_end (search_button);
 
@@ -358,22 +310,7 @@ public class AppCenter.Homepage : Adw.NavigationPage {
             show_package (package_row_grid.package);
         });
 
-        App.settings.bind (
-            "automatic-updates",
-            automatic_updates_button,
-            "active",
-            SettingsBindFlags.DEFAULT
-        );
-
-        unowned var update_manager = AppCenterCore.UpdateManager.get_default ();
-        automatic_updates_button.notify["active"].connect (() => {
-            if (automatic_updates_button.active) {
-                update_manager.update_cache.begin (true);
-            } else {
-                update_manager.cancel_updates (true);
-            }
-        });
-
+        var update_manager = AppCenterCore.UpdateManager.get_default ();
         update_manager.notify["updates-number"].connect (() => {
             show_update_badge (update_manager.updates_number);
         });

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -53,12 +53,13 @@ public class AppCenter.SearchView : Adw.NavigationPage {
         search_entry.set_key_capture_widget (this);
 
         var search_clamp = new Adw.Clamp () {
-            child = search_entry,
-            margin_top = 6,
-            margin_bottom = 6,
-            margin_end = 12,
-            margin_start = 12
+            child = search_entry
         };
+
+        var headerbar = new Gtk.HeaderBar () {
+            title_widget = search_clamp
+        };
+        headerbar.pack_start (new BackButton ());
 
         list_store = new GLib.ListStore (typeof (AppCenterCore.Package));
 
@@ -78,7 +79,7 @@ public class AppCenter.SearchView : Adw.NavigationPage {
         var toolbarview = new Adw.ToolbarView () {
             content = scrolled
         };
-        toolbarview.add_top_bar (search_clamp);
+        toolbarview.add_top_bar (headerbar);
 
         add_css_class (Granite.STYLE_CLASS_VIEW);
         child = toolbarview;

--- a/src/Widgets/BackButton.vala
+++ b/src/Widgets/BackButton.vala
@@ -17,6 +17,7 @@ public class AppCenter.BackButton : Gtk.Button {
 
         action_name = "win.go-back";
         child = box;
+        tooltip_markup = Granite.markup_accel_tooltip ({"<alt>Left"});
         valign = CENTER;
 
         map.connect (() => {

--- a/src/Widgets/BackButton.vala
+++ b/src/Widgets/BackButton.vala
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-FileCopyrightText: 2016-2024 elementary, Inc. (https://elementary.io)
+ */
+
+public class AppCenter.BackButton : Gtk.Button {
+    construct {
+        var back_icon = new Gtk.Image.from_icon_name ("go-previous-symbolic");
+
+        var label_widget = new Gtk.Label ("") {
+            mnemonic_widget = this
+        };
+
+        var box = new Gtk.Box (HORIZONTAL, 0);
+        box.append (back_icon);
+        box.append (label_widget);
+
+        action_name = "win.go-back";
+        child = box;
+        valign = CENTER;
+
+        map.connect (() => {
+            var current_page = (Adw.NavigationPage) get_ancestor (typeof (Adw.NavigationPage));
+            var navigation_view = (Adw.NavigationView) get_ancestor (typeof (Adw.NavigationView));
+            var previous_page = navigation_view.get_previous_page (current_page);
+            label_widget.label = previous_page.title;
+        });
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,6 +31,7 @@ appcenter_files = files(
     'Views/Homepage.vala',
     'Views/SearchView.vala',
     'Widgets/ActionStack.vala',
+    'Widgets/BackButton.vala',
     'Widgets/Banner.vala',
     'Widgets/CardNumberEntry.vala',
     'Widgets/HumbleButton.vala',


### PR DESCRIPTION
There's still a lot we can do to make better use of space in views like AppInfoView, but this gives us a canvas to pursue those things at least

![Screenshot from 2024-06-16 12 29 16](https://github.com/elementary/appcenter/assets/7277719/99e9a40a-c338-409c-a650-694535cb7b01)
![Screenshot from 2024-06-16 12 29 40](https://github.com/elementary/appcenter/assets/7277719/0020e46e-29f0-42f1-bb26-3c2f127ef37e)
![Screenshot from 2024-06-16 12 29 52](https://github.com/elementary/appcenter/assets/7277719/7e4660e6-cb01-46c7-ac16-69371fb767c2)
![Screenshot from 2024-06-16 12 30 07](https://github.com/elementary/appcenter/assets/7277719/465e9b88-37b1-4fc4-a3d4-b2d6817bdba6)
![Screenshot from 2024-06-16 12 30 19](https://github.com/elementary/appcenter/assets/7277719/215e2584-a2ee-466b-aa0f-63e680764ea9)


Todo:
- [x] Add headerbars to all the views
- [x] Move updates settings to updates view
- [x] Category title on category views
- [x] Back buttons