### PR TITLE
MainWindow: remove working property

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -245,6 +245,12 @@ public class AppCenterCore.FlatpakBackend : Object {
         reload_appstream_pool ();
     }
 
+    private void set_actions_enabled (bool working) {
+        var app = Application.get_default ();
+        ((SimpleAction) app.lookup_action ("refresh")).set_enabled (!working && !Utils.is_running_in_guest_session ());
+        ((SimpleAction) app.lookup_action ("repair")).set_enabled (!working);
+    }
+
     private async void trigger_update_check () {
         try {
             yield refresh_cache (null);

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -93,6 +93,7 @@ public class AppCenterCore.FlatpakBackend : Object {
             var job = jobs.pop ();
             job_type = job.operation;
             working = true;
+            set_actions_enabled (working);
 
             if (remove_inhibit_timeout != 0) {
                 Source.remove (remove_inhibit_timeout);
@@ -157,6 +158,7 @@ public class AppCenterCore.FlatpakBackend : Object {
             }
 
             working = false;
+            set_actions_enabled (working);
         }
 
         return true;


### PR DESCRIPTION
* FlatpakBackend sets actions enabled while working, no need to have MainWindow do this, especially since we might not always have a window
* MainWindow: Set overlaybar properties in construct block not in constructor
* MainWindow: in close request get backend directly instead of property that's synced to this