### PR TITLE
AppinfoView: keep action buttons in headerbar

### DIFF
--- a/data/styles/AppInfoView.scss
+++ b/data/styles/AppInfoView.scss
@@ -33,41 +33,6 @@ appinfoview {
                 background-color: #{'@bg_color'};
             }
         }
-
-        button.text-button,
-        button.image-button {
-            background-color: #{'@banner_fg_color'};
-            background-image: none;
-            border: none;
-            box-shadow: none;
-            color: #{'@banner_bg_color'};
-            font-size: 11pt;
-            font-weight: 600;
-
-            /*Hack to make the button square-ish*/
-            &.raised {
-                padding: 0 0.333em;
-            }
-
-            &:active,
-            &:checked {
-                opacity: 0.9;
-            }
-
-            &:disabled {
-                opacity: 0.33;
-            }
-
-            &:not(.suggested-action) {
-                opacity: 0.8;
-            }
-
-            label,
-            image {
-                color: inherit;
-                font-weight: inherit;
-            }
-        }
     }
 
     .content-warning-box {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -95,11 +95,35 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
         };
         search_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
 
+        var uninstall_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic") {
+            tooltip_text = _("Uninstall"),
+            valign = CENTER
+        };
+        uninstall_button.add_css_class ("raised");
+
+        uninstall_button_revealer = new Gtk.Revealer () {
+            child = uninstall_button,
+            transition_type = SLIDE_LEFT,
+            overflow = VISIBLE
+        };
+
+        action_stack = new ActionStack (package) {
+            hexpand = false
+        };
+
+        action_stack.action_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
+        action_stack.action_button.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        action_stack.open_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
+        action_stack.open_button.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
         var headerbar = new Gtk.HeaderBar () {
             title_widget = title_revealer
         };
         headerbar.pack_start (new BackButton ());
         headerbar.pack_end (search_button);
+        headerbar.pack_end (action_stack);
+        headerbar.pack_end (uninstall_button_revealer);
 
         accent_provider = new Gtk.CssProvider ();
         try {
@@ -197,45 +221,22 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             transition_type = SLIDE_DOWN
         };
 
-        var uninstall_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic") {
-            tooltip_text = _("Uninstall"),
-            margin_end = 12
-        };
-        uninstall_button.add_css_class ("raised");
-        uninstall_button.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        uninstall_button_revealer = new Gtk.Revealer () {
-            child = uninstall_button,
-            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT,
-            overflow = VISIBLE
-        };
-
-        action_stack = new ActionStack (package);
-
-        var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
-            halign = Gtk.Align.END,
-            valign = Gtk.Align.CENTER,
-            hexpand = true
-        };
-        button_box.append (uninstall_button_revealer);
-        button_box.append (action_stack);
-
         var header_grid = new Gtk.Grid () {
             column_spacing = 12,
             valign = Gtk.Align.CENTER
         };
         header_grid.attach (app_title, 0, 0);
-        header_grid.attach (app_subtitle, 0, 1);
+        header_grid.attach (app_subtitle, 0, 1, 2);
         header_grid.attach (origin_combo_revealer, 0, 2, 2);
-        header_grid.attach (button_box, 1, 0);
 
         if (!package.is_local) {
             size_label = new Widgets.SizeLabel () {
-                halign = Gtk.Align.END
+                halign = Gtk.Align.END,
+                hexpand = true
             };
             size_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
 
-            header_grid.attach (size_label, 1, 1);
+            header_grid.attach (size_label, 1, 0);
         }
 
         var header_box = new Gtk.Box (HORIZONTAL, 6);
@@ -244,6 +245,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
         var header_clamp = new Adw.Clamp () {
             child = header_box,
+            hexpand = true,
             maximum_size = MAX_WIDTH
         };
 
@@ -254,15 +256,6 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
         header.add_css_class ("banner");
         header.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        action_stack.action_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
-        action_stack.action_button.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        action_stack.open_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
-        action_stack.open_button.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-        action_stack.cancel_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
-        action_stack.cancel_button.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var package_component = package.component;
 

--- a/src/Widgets/ActionStack.vala
+++ b/src/Widgets/ActionStack.vala
@@ -44,6 +44,7 @@ public class AppCenter.ActionStack : Gtk.Box {
 
         open_button_revealer = new Gtk.Revealer () {
             child = open_button,
+            overflow = VISIBLE,
             transition_type = SLIDE_LEFT
         };
 


### PR DESCRIPTION
Keep action buttons in the headerbar so that they're available even when you scroll

![Screenshot from 2024-06-20 13 16 37](https://github.com/elementary/appcenter/assets/7277719/b59c1e2d-e532-4e0c-9f98-8d12ea509652)
![Screenshot from 2024-06-20 13 17 02](https://github.com/elementary/appcenter/assets/7277719/97289bb7-d8b7-445c-a0ca-2dd436b72ceb)
