### PR TITLE
UpdateManager: Fix auto updates, liststore

### DIFF
--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -252,7 +252,6 @@ public class AppCenterCore.UpdateManager : Object {
         }
 
         debug ("New refresh task");
-
         refresh_in_progress = true;
         try {
             success = yield FlatpakBackend.get_default ().refresh_cache (cancellable);

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -148,7 +148,27 @@ public class AppCenterCore.UpdateManager : Object {
 
         debug ("%u app updates found", updates_number);
 
-        if (!AppCenter.App.settings.get_boolean ("automatic-updates")) {
+        runtime_updates.update_state ();
+
+        if (AppCenter.App.settings.get_boolean ("automatic-updates")) {
+            debug ("Update Flatpaks");
+            for (int i = 0; i < updates_liststore.n_items; i++) {
+                var package = (Package) updates_liststore.get_item (i);
+                if (!package.should_pay) {
+                    debug ("Update: %s", package.get_name ());
+                    try {
+                        yield package.update (false);
+
+                        updates_liststore.remove (i);
+                        i--;
+
+                        updates_size -= package.change_information.size;
+                    } catch (Error e) {
+                        warning ("Updating %s failed: %s", package.get_name (), e.message);
+                    }
+                }
+            }
+        } else {
             var application = Application.get_default ();
             if (updates_number > 0) {
                 var title = ngettext ("Update Available", "Updates Available", updates_number);
@@ -175,8 +195,6 @@ public class AppCenterCore.UpdateManager : Object {
                 warning ("Error setting updates badge: %s", e.message);
             }
         }
-
-        runtime_updates.update_state ();
 
         installed_apps_changed ();
 
@@ -234,6 +252,7 @@ public class AppCenterCore.UpdateManager : Object {
         }
 
         debug ("New refresh task");
+
         refresh_in_progress = true;
         try {
             success = yield FlatpakBackend.get_default ().refresh_cache (cancellable);
@@ -262,23 +281,7 @@ public class AppCenterCore.UpdateManager : Object {
             return GLib.Source.REMOVE;
         });
 
-        if (AppCenter.App.settings.get_boolean ("automatic-updates")) {
-            yield get_updates ();
-            debug ("Update Flatpaks");
-            for (int i = 0; i < updates_liststore.n_items; i++) {
-                var package = (Package) updates_liststore.get_item (i);
-                if (!package.should_pay) {
-                    debug ("Update: %s", package.get_name ());
-                    try {
-                        yield package.update (false);
-                    } catch (Error e) {
-                        warning ("Updating %s failed: %s", package.get_name (), e.message);
-                    }
-                }
-            }
-
-            get_updates.begin ();
-        }
+        get_updates ();
     }
 
     private int compare_package_func (Object object1, Object object2) {


### PR DESCRIPTION
* Fixes a regression where the update list would not be populated at all
* Moves auto updating all to `get_updates` and make it mutually exclusive with notifying
* Remove packages from the liststore as updates are installed instead of getting the list of updates twice