### PR TITLE
AppListUpdateView: DRY Update All

### DIFF
--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -185,7 +185,7 @@ public class AppCenterCore.UpdateManager : Object {
         return updates_number;
     }
 
-    public async void update_all (Cancellable? cancellable = null) throws Error {
+    public async void update_all (Cancellable? cancellable) throws Error {
         for (int i = 0; i < updates_liststore.n_items; i++) {
             if (cancellable != null && cancellable.is_cancelled ()) {
                 return;

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -293,7 +293,7 @@ public class AppCenterCore.UpdateManager : Object {
             return GLib.Source.REMOVE;
         });
 
-        get_updates ();
+        get_updates (cancellable);
     }
 
     private int compare_package_func (Object object1, Object object2) {

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -151,11 +151,7 @@ public class AppCenterCore.UpdateManager : Object {
         runtime_updates.update_state ();
 
         if (AppCenter.App.settings.get_boolean ("automatic-updates")) {
-            try {
-                yield update_all (cancellable);
-            } catch (Error e) {
-                warning ("Automatic updates failed: %s", e.message);
-            }
+            yield update_all (cancellable);
         } else {
             var application = Application.get_default ();
             if (updates_number > 0) {
@@ -206,6 +202,7 @@ public class AppCenterCore.UpdateManager : Object {
                         break;
                     }
 
+                    warning ("Updating %s failed: %s", package.get_name (), e.message);
                     throw (e);
                 }
 


### PR DESCRIPTION
UpdateManager:
* Make `update_all` its own function that is cancellable
* Make sure to use class-wide cancellable for auto updates

AppListUpdateView:
* Use update_all function from update_manager
* Make sure to set action buttons back to sensitive if update_all is canceled or errors