### PR TITLE
Add support for new developer id

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -592,13 +592,6 @@ public class AppCenterCore.FlatpakBackend : Object {
                 continue;
             }
 
-            if (package.component.get_developer ().get_id () != null) {
-                warning (package.component.id);
-                warning (package.component.get_developer ().get_id ());
-                warning (author_id);
-                warning ("------------------------------------");
-            }
-
             if (package.component.get_developer ().get_id () == author_id) {
                 package_ids.add (package.component.id);
 

--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -579,6 +579,48 @@ public class AppCenterCore.FlatpakBackend : Object {
         return packages;
     }
 
+    public Gee.Collection<Package> get_packages_by_author_id (string author_id, int max) {
+        var packages = new Gee.ArrayList<AppCenterCore.Package> ();
+        var package_ids = new Gee.ArrayList<string> ();
+
+        foreach (var package in package_list.values) {
+            if (packages.size > max) {
+                break;
+            }
+
+            if (package.component.id in package_ids) {
+                continue;
+            }
+
+            if (package.component.get_developer ().get_id () != null) {
+                warning (package.component.id);
+                warning (package.component.get_developer ().get_id ());
+                warning (author_id);
+                warning ("------------------------------------");
+            }
+
+            if (package.component.get_developer ().get_id () == author_id) {
+                package_ids.add (package.component.id);
+
+                AppCenterCore.Package? user_package = null;
+                foreach (var origin_package in package.origin_packages) {
+                    if (((FlatpakPackage) origin_package).installation == user_installation) {
+                        user_package = origin_package;
+                        break;
+                    }
+                }
+
+                if (user_package != null) {
+                    packages.add (user_package);
+                } else {
+                    packages.add (package);
+                }
+            }
+        }
+
+        return packages;
+    }
+
     public async uint64 get_download_size (Package package, Cancellable? cancellable, bool is_update = false) throws GLib.Error {
         var bundle = package.component.get_bundle (AppStream.BundleKind.FLATPAK);
         if (bundle == null) {

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -297,6 +297,23 @@ public class AppCenterCore.Package : Object {
         }
     }
 
+    private string? _author_id = null;
+    public string? author_id {
+        get {
+            if (_author_id != null) {
+                return _author_id;
+            }
+
+            _author = component.get_developer ().get_id ();
+
+            if (_author_id == null) {
+                return _author;
+            }
+
+            return _author_id;
+        }
+    }
+
     private string? _author_title = null;
     public string author_title {
         get {

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -304,7 +304,9 @@ public class AppCenterCore.Package : Object {
                 return _author_id;
             }
 
-            return component.get_developer ().get_id ();
+            author_id = component.get_developer ().get_id ();
+
+            return author_id;
         }
     }
 

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -304,9 +304,9 @@ public class AppCenterCore.Package : Object {
                 return _author_id;
             }
 
-            author_id = component.get_developer ().get_id ();
+            _author_id = component.get_developer ().get_id ();
 
-            return author_id;
+            return _author_id;
         }
     }
 

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -304,13 +304,7 @@ public class AppCenterCore.Package : Object {
                 return _author_id;
             }
 
-            _author = component.get_developer ().get_id ();
-
-            if (_author_id == null) {
-                return _author;
-            }
-
-            return _author_id;
+            return component.get_developer ().get_id ();
         }
     }
 

--- a/src/Views/AuthorView.vala
+++ b/src/Views/AuthorView.vala
@@ -23,9 +23,7 @@ private class AppCenter.AuthorView : Gtk.Box {
             return;
         }
 
-        Gee.Collection<AppCenterCore.Package> author_packages;
-
-        author_packages = package.author_id == null
+        var author_packages = package.author_id == null
             ? AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author (package.author, AUTHOR_OTHER_APPS_MAX)
             : AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author_id (package.author_id, AUTHOR_OTHER_APPS_MAX);
 

--- a/src/Views/AuthorView.vala
+++ b/src/Views/AuthorView.vala
@@ -23,11 +23,11 @@ private class AppCenter.AuthorView : Gtk.Box {
             return;
         }
 
-        var author_packages = AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author_id (package.author_id, AUTHOR_OTHER_APPS_MAX);
+        Gee.Collection<AppCenterCore.Package> author_packages;
 
-        if (author_packages.size <= 1) {
-            author_packages = AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author (package.author, AUTHOR_OTHER_APPS_MAX);
-        }
+        author_packages = package.author_id == null
+            ? AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author (package.author, AUTHOR_OTHER_APPS_MAX)
+            : AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author_id (package.author_id, AUTHOR_OTHER_APPS_MAX);
 
         if (author_packages.size <= 1) {
             return;

--- a/src/Views/AuthorView.vala
+++ b/src/Views/AuthorView.vala
@@ -23,7 +23,10 @@ private class AppCenter.AuthorView : Gtk.Box {
             return;
         }
 
-        var author_packages = AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author (package.author, AUTHOR_OTHER_APPS_MAX);
+        var author_packages = package.author_id == null ?
+            AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author (package.author, AUTHOR_OTHER_APPS_MAX) :
+            AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author_id (package.author_id, AUTHOR_OTHER_APPS_MAX);
+
         if (author_packages.size <= 1) {
             return;
         }

--- a/src/Views/AuthorView.vala
+++ b/src/Views/AuthorView.vala
@@ -23,9 +23,11 @@ private class AppCenter.AuthorView : Gtk.Box {
             return;
         }
 
-        var author_packages = package.author_id == null ?
-            AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author (package.author, AUTHOR_OTHER_APPS_MAX) :
-            AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author_id (package.author_id, AUTHOR_OTHER_APPS_MAX);
+        var author_packages = AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author_id (package.author_id, AUTHOR_OTHER_APPS_MAX);
+
+        if (author_packages.size <= 1) {
+            author_packages = AppCenterCore.FlatpakBackend.get_default ().get_packages_by_author (package.author, AUTHOR_OTHER_APPS_MAX);
+        }
 
         if (author_packages.size <= 1) {
             return;


### PR DESCRIPTION
This is a first approach to support the new developer id (closes #2102). Although I added a new property to `Package.vala` populating that id, it is really uncommon that this info is available.

The "More apps from this developer" feature is kind of broken right now because of this... Should I search by author name like before in case no more apps are found?

I left some `warning` logs just to check the realted properties to this functionality in `FlatpakBackend.vala`. 