### PR TITLE
Fix inconsistent update view behavior

### DIFF
--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -165,8 +165,8 @@ namespace AppCenter.Views {
             var stack = new Gtk.Stack () {
                 transition_type = UNDER_UP
             };
-            stack.add (main_box);
             stack.add (loading_view);
+            stack.add (main_box);
 
             add (stack);
 

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -160,6 +160,7 @@ namespace AppCenter.Views {
             main_box.add (header_revealer);
             main_box.add (scrolled);
             main_box.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
+            main_box.show_all ();
 
             var stack = new Gtk.Stack () {
                 transition_type = UNDER_UP


### PR DESCRIPTION
Fixes #2096 

I guess not having a stack widget visible before adding it to the stack can cause some inconsistent behavior with changing the visible child on the stack

**This is for OS7 Horus**