### PR TITLE
Filter screenshot by environment (elementary#2210)

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -945,7 +945,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             var prefer_dark_theme = Gtk.Settings.get_default ().gtk_application_prefer_dark_theme;
             screenshots.foreach ((screenshot) => {
                 var environment_id = screenshot.get_environment ();
-                if (environment_id != null) {                    
+                if (environment_id != null) {
                     var environment_split = environment_id.split (":", 2);
                     if (prefer_dark_theme && environment_split.length != 2) {
                         return;
@@ -957,7 +957,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
                         return;
                     }
                 }
-                
+
                 AppStream.Image? best_image = null;
                 screenshot.get_images ().foreach ((image) => {
                     // Image is better than no image

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -945,14 +945,15 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             var prefer_dark_theme = Gtk.Settings.get_default ().gtk_application_prefer_dark_theme;
             screenshots.foreach ((screenshot) => {
                 var environment_id = screenshot.get_environment ();
-                if (prefer_dark_theme && environment_id != null) {                    
+                if (environment_id != null) {                    
                     var environment_split = environment_id.split (":", 2);
-                    if (environment_split.length != 2) {
+                    if (prefer_dark_theme && environment_split.length != 2) {
                         return;
                     }
 
                     var color_scheme = AppStream.ColorSchemeKind.from_string (environment_split[1]);
-                    if (color_scheme != AppStream.ColorSchemeKind.DARK) {
+                    if ((prefer_dark_theme && color_scheme != AppStream.ColorSchemeKind.DARK) ||
+                        (!prefer_dark_theme && color_scheme == AppStream.ColorSchemeKind.DARK)) {
                         return;
                     }
                 }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -942,7 +942,21 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             var scale = get_scale_factor ();
             var min_screenshot_width = MAX_WIDTH * scale;
 
+            var prefer_dark_theme = Gtk.Settings.get_default ().gtk_application_prefer_dark_theme;
             screenshots.foreach ((screenshot) => {
+                var environment_id = screenshot.get_environment ();
+                if (prefer_dark_theme && environment_id != null) {                    
+                    var environment_split = environment_id.split (":", 2);
+                    if (environment_split.length != 2) {
+                        return;
+                    }
+
+                    var color_scheme = AppStream.ColorSchemeKind.from_string (environment_split[1]);
+                    if (color_scheme != AppStream.ColorSchemeKind.DARK) {
+                        return;
+                    }
+                }
+                
                 AppStream.Image? best_image = null;
                 screenshot.get_images ().foreach ((image) => {
                     // Image is better than no image


### PR DESCRIPTION
### Short summary
Aims to implement #2210 

Will read the environment property of the screenshot and will filter it out if:

* _Prefer dark mode_ is true, and the screenshot _does not_ have a dark mode environment id (i.e. 'dark' in the environment ID). 
* _Prefer dark mode_ is false, and the screenshot _does_ have a dark mode environment id.

This won't consider null environments in the screenshots.

### Tests

I have only tested this on the [Harvey](https://appcenter.elementary.io/com.github.danrabbit.harvey/) application, since this is the only app that I know has this implemented. I also tried a random assortment of titles with and without screenshots without any problems/crashes, though.