### PR TITLE
Parse all branding colors from appstream (elementary#2140)

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -755,13 +755,13 @@ public class AppCenterCore.Package : Object {
             var branding = component.get_branding ();
             if (branding != null) {
                 var gtk_settings = Gtk.Settings.get_default ();
-                if (gtk_settings.gtk_application_prefer_dark_theme){
+                if (gtk_settings.gtk_application_prefer_dark_theme) {
                     color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.DARK);
                 } else {
                     color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.LIGHT);
                 }
 
-                if (color_primary == null){
+                if (color_primary == null) {
                     color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.UNKNOWN);
                 }
             }

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -754,7 +754,16 @@ public class AppCenterCore.Package : Object {
         } else {
             var branding = component.get_branding ();
             if (branding != null) {
-                color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.UNKNOWN);
+                var gtk_settings = Gtk.Settings.get_default ();
+                if (gtk_settings.gtk_application_prefer_dark_theme){
+                    color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.DARK);
+                } else {
+                    color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.LIGHT);
+                }
+
+                if (color_primary == null){
+                    color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.UNKNOWN);
+                }
             }
 
             if (color_primary == null) {

--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -390,7 +390,10 @@ public class AppCenterCore.Package : Object {
 
     public string? description = null;
     private string? summary = null;
-    private string? color_primary = null;
+    private string? color_primary_light = null;
+    private string? color_primary_dark = null;
+    private string? color_primary_unknown = null;
+    private string? color_primary_fallback = null;
     private string? color_primary_text = null;
     private string? payments_key = null;
     private string? suggested_amount = null;
@@ -418,7 +421,10 @@ public class AppCenterCore.Package : Object {
         name = null;
         description = null;
         summary = null;
-        color_primary = null;
+        color_primary_light = null;
+        color_primary_dark = null;
+        color_primary_unknown = null;
+        color_primary_fallback = null;
         color_primary_text = null;
         payments_key = null;
         suggested_amount = null;
@@ -749,28 +755,44 @@ public class AppCenterCore.Package : Object {
     }
 
     public string? get_color_primary () {
-        if (color_primary != null) {
-            return color_primary;
+        cache_primary_colors ();
+
+        string? color_primary = null;
+        var gtk_settings = Gtk.Settings.get_default ();
+        if (color_primary_light != null && !gtk_settings.gtk_application_prefer_dark_theme) {
+            color_primary = color_primary_light;
+        } else if (color_primary_dark != null && gtk_settings.gtk_application_prefer_dark_theme) {
+            color_primary = color_primary_dark;
+        } else if (color_primary_unknown != null) {
+            color_primary = color_primary_unknown;
         } else {
-            var branding = component.get_branding ();
-            if (branding != null) {
-                var gtk_settings = Gtk.Settings.get_default ();
-                if (gtk_settings.gtk_application_prefer_dark_theme) {
-                    color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.DARK);
-                } else {
-                    color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.LIGHT);
-                }
+            color_primary = color_primary_fallback;
+        }
 
-                if (color_primary == null) {
-                    color_primary = branding.get_color (AppStream.ColorKind.PRIMARY, AppStream.ColorSchemeKind.UNKNOWN);
-                }
+        return color_primary;
+    }
+
+    private void cache_primary_colors () {
+        var branding = component.get_branding ();
+        if (branding != null) {
+            if (color_primary_dark == null) {
+                color_primary_dark = branding.get_color (AppStream.ColorKind.PRIMARY,
+                    AppStream.ColorSchemeKind.DARK);
             }
 
-            if (color_primary == null) {
-                color_primary = component.get_custom_value ("x-appcenter-color-primary");
+            if (color_primary_light == null) {
+                color_primary_light = branding.get_color (AppStream.ColorKind.PRIMARY,
+                    AppStream.ColorSchemeKind.LIGHT);
             }
 
-            return color_primary;
+            if (color_primary_unknown == null) {
+                color_primary_unknown = branding.get_color (AppStream.ColorKind.PRIMARY,
+                    AppStream.ColorSchemeKind.UNKNOWN);
+            }
+        }
+
+        if (color_primary_fallback == null) {
+            color_primary_fallback = component.get_custom_value ("x-appcenter-color-primary");
         }
     }
 


### PR DESCRIPTION
### Short summary
Aims to fix #2140 

This will parse all the branding possibilities of the metadata info according to the freedesktop docs [here](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-branding).

The branding tag has a must-have color tag with `primary_color` attribute (always set its value to `primary`), with an optional `scheme_preference` attribute which shows a preference for a particular color scheme (withe light or dark) and this should take precedence.

But, as the issue says, there can be multiple setups here, and this PR aims to account for all of these in the following order:

* If the color tag has a `scheme_preference`, either set to light or dark, it should be taken as precedent, according to the desktop current color scheme (via `gtk_application_prefer_dark_theme`).
* If not, look for the color tag that has no `scheme_preference` (i.e. unknown). This was the original call.
* If the last call returns null, use the local color scheme setting.

### Tests

Apps that I tested with this change:

* [Reco](https://appcenter.elementary.io/com.github.ryonakano.reco/): Has all color branding setups (light, dark and without `scheme_preference` attribute). Different colors per tag.
* [KonbuCase](https://appcenter.elementary.io/com.github.ryonakano.konbucase/): Only has light and dark branding tags. Different colors per tag.
* [Larawan](https://appcenter.elementary.io/io.github.xchan14.larawan/): I _believe_ it has no branding tag of any kind.
* [Mail](https://appcenter.elementary.io/io.elementary.mail/): Has all tags, but all with the same color.

I couldn't find an application that had only the no `scheme_preference` attribute, but it was the default original call, so it should cover that case as well.