### PR TITLE
 Made issue_box widget a grid (elementary#2224)

### DIFF
--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -45,6 +45,7 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
         var description_label = new Gtk.Label (format_release_description (release.get_description ())) {
             selectable = true,
             use_markup = true,
+            max_width_chars = 55,
             wrap = true,
             xalign = 0
         };
@@ -69,7 +70,8 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
 
         if (issues.length > 0) {
             var issue_header = new Gtk.Label (_("Fixed Issues")) {
-                halign = Gtk.Align.START
+                halign = Gtk.Align.START,
+                margin_top = 9
             };
             issue_header.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
@@ -78,10 +80,11 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
 
         foreach (unowned AppStream.Issue issue in issues) {
             var issue_image = new Gtk.Image.from_icon_name ("bug-symbolic") {
-                valign = Gtk.Align.START
+                valign = Gtk.Align.BASELINE_CENTER
             };
 
             var issue_label = new Gtk.Label (issue.get_id ()) {
+                max_width_chars = 35,
                 wrap = true,
                 xalign = 0
             };
@@ -90,9 +93,9 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
             issue_linkbutton.get_child ().destroy ();
             issue_linkbutton.child = issue_label;
 
-            var issue_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 3);
-            issue_box.append (issue_image);
-            issue_box.append (issue_linkbutton);
+            var issue_box = new Gtk.Grid ();
+            issue_box.attach (issue_image, 0, 0);
+            issue_box.attach (issue_linkbutton, 1, 0);
 
             append (issue_box);
         }


### PR DESCRIPTION
## Short summary

Aims to fix #2224

The main issue was that the Issue box `LinkedButton` Label widget broke the natural sizing within the box when `wrap` was set to true. I'm not sure why this is the case, though. 

I could have removed the wrapping, but it would let issues too long and the boxes looked too odd. However, I managed to fix this by changing the `issue_boxes` GTK Widget to a Grid. This does detect and respect the natural size height changes when enabling wrap within a `LinkedButton` Label. 

This PR also contains three small additions:

* Changed the alignment of the cute bug icon so it centers better with the corresponding `LinkedButton` label (set `valign` to `Gtk.Align.BASELINE_CENTER`).
* Added a `margin_top` value on the "Fixed Issues" header to separate better the issues section from the rest.
* Explicitly set wrapping values via `max_width_chars` to the `LinkedButton` Label and the description label to avoid having too long descriptions and issues that made all the boxes too long. 
    * This is probably the part that might not go well with the whole design of the page? Please, let me know if these changes make sense, or if only enable wrapping should be enabled but not set any wrap max length. I did this i particular for the videos app that ha s particularly long one line description, and it looked odd in my view.

## Tests

Here are the applications that I tested with this change:

### [Calendar](https://appcenter.elementary.io/io.elementary.calendar/) 

#### Before: 

![Calendar Before](https://github.com/user-attachments/assets/2a2b891c-cee5-49a9-b20d-e4321aefae56)

#### After:
 
![Calendar After](https://github.com/user-attachments/assets/c0340f7a-7221-4340-a784-b0d5dbe51e92)

### [Mail](https://appcenter.elementary.io/io.elementary.calendar/)

##### Before: 

![Mail Before](https://github.com/user-attachments/assets/e366916c-39cc-4133-8990-d3365bdf5333)

#### After:
 
![Mail After](https://github.com/user-attachments/assets/508033a3-2226-4621-a92d-b70035a546e1)

#### [Screenshot](https://appcenter.elementary.io/io.elementary.screenshot/)

##### Before: 

![Screenshot Before](https://github.com/user-attachments/assets/bf2cb617-544a-461a-8185-c6d985a58bc4)

#### After:
 
![Screenshot After](https://github.com/user-attachments/assets/a33f537f-73db-48fc-9f2f-21480078b241)
