### PR TITLE
Put the release notes description label inside a Gtk.Grid

### DIFF
--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -69,7 +69,7 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
             use_markup = true,
             max_width_chars = 55,
             wrap = true,
-            xalign = 0,
+            xalign = 0
         };
         description_label.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 

--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -33,12 +33,6 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
         spacing = 6;
         margin_bottom = 6;
 
-        create_header ();
-        create_description ();
-        create_issues ();
-    }
-
-    private void create_header () {
         var header_icon = new Gtk.Image.from_icon_name ("tag-symbolic");
         var header_label = new Gtk.Label (format_version (release.get_version ())) {
             use_markup = true
@@ -59,11 +53,8 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
         header_grid.attach (header_icon, 0, 0);
         header_grid.attach (header_label, 1, 0);
         header_grid.attach (date_label, 2, 0);
-
         append (header_grid);
-    }
 
-    private void create_description () {
         var description_label = new Gtk.Label (format_release_description (release.get_description ())) {
             selectable = true,
             use_markup = true,
@@ -79,11 +70,8 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
             margin_bottom = 6
         };
         description_grid.attach (description_label, 0, 0);
-
         append (description_grid);
-    }
 
-    private void create_issues () {
         var issues = release.get_issues ();
         if (issues.length > 0) {
             var issue_header = new Gtk.Label (_("Fixed Issues")) {

--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -29,8 +29,17 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
     }
 
     construct {
-        var header_icon = new Gtk.Image.from_icon_name ("tag-symbolic");
+        orientation = Gtk.Orientation.VERTICAL;
+        spacing = 6;
+        margin_bottom = 6;
 
+        create_header ();
+        create_description ();
+        create_issues ();
+    }
+
+    private void create_header () {
+        var header_icon = new Gtk.Image.from_icon_name ("tag-symbolic");
         var header_label = new Gtk.Label (format_version (release.get_version ())) {
             use_markup = true
         };
@@ -42,32 +51,40 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
         };
         date_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
 
+        var header_grid = new Gtk.Grid () {
+            column_spacing = 6,
+            row_spacing = 6,
+            margin_bottom = 6
+        };
+        header_grid.attach (header_icon, 0, 0);
+        header_grid.attach (header_label, 1, 0);
+        header_grid.attach (date_label, 2, 0);
+
+        append (header_grid);
+    }
+
+    private void create_description () {
         var description_label = new Gtk.Label (format_release_description (release.get_description ())) {
             selectable = true,
             use_markup = true,
             max_width_chars = 55,
             wrap = true,
-            xalign = 0
+            xalign = 0,
         };
         description_label.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
-        var grid = new Gtk.Grid () {
+        var description_grid = new Gtk.Grid () {
             column_spacing = 6,
             row_spacing = 6,
             margin_bottom = 6
         };
-        grid.attach (header_icon, 0, 0);
-        grid.attach (header_label, 1, 0);
-        grid.attach (date_label, 2, 0);
-        grid.attach (description_label, 0, 1, 3);
+        description_grid.attach (description_label, 0, 0);
 
-        orientation = Gtk.Orientation.VERTICAL;
-        spacing = 6;
+        append (description_grid);
+    }
 
-        append (grid);
-
+    private void create_issues () {
         var issues = release.get_issues ();
-
         if (issues.length > 0) {
             var issue_header = new Gtk.Label (_("Fixed Issues")) {
                 halign = Gtk.Align.START,


### PR DESCRIPTION
## Short summary 

This fixes #2233 

This is the same issue that we had for issues, but now for the description label itself. It seems that in a `Gtk.Box` with wrapped labels will not do its height correctly, if there are grids abound.

Putting the label inside a `Gtk.Grid` will make it also respect the natural height and will fix another set of problems found in other description labels.

~~Another change in this PR was a small refactor to compartmentalize each widget creation in its own method. This is just for organization and refactoring purposes only.~~ 
_Edit: Having methods within the constructor is not preferred, so this was set back to how it was before._

## Tests

Here are tests made on the notified app issues:

### [Nimbus](https://appcenter.elementary.io/com.github.danrabbit.nimbus/) 
#### Before: 
![Nimbus Before](https://github.com/user-attachments/assets/3f6627b7-2c78-4248-80f6-ab450874039c)
#### After:
![Nimbus After](https://github.com/user-attachments/assets/ee9e7de6-981c-47af-8eb4-2c9d2eb477d2)

### [Journaler](https://appcenter.elementary.io/com.github.phase1geo.journaler/) 
#### Before: 
![Journaler Before](https://github.com/user-attachments/assets/a84f0fa3-0692-4561-8839-a2617239da99)
#### After:
![Journaler After](https://github.com/user-attachments/assets/30000b1a-35ea-4e3a-9066-b7175cafb376)

### [Reco](https://appcenter.elementary.io/com.github.ryonakano.reco/) 
#### Before: 
![Reco Before](https://github.com/user-attachments/assets/011e7de8-8813-4572-8e55-b1f6b0a3c106)
#### After:
![Reco After](https://github.com/user-attachments/assets/cebe8a8d-2ff4-41fa-a9ea-97b631f89ae2)
