### PR TITLE
Filter screenshots by style and environment (round 2)

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -496,7 +496,69 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             }
         }
 
-        screenshots = package_component.get_screenshots_all ();
+        bool has_matching_environment = false;
+        bool has_matching_style = false;
+        var desktop_environment = Environment.get_variable ("XDG_SESSION_DESKTOP");
+        var prefer_dark_style = Gtk.Settings.get_default ().gtk_application_prefer_dark_theme;
+        var desktop_style = prefer_dark_style
+            ? AppStream.ColorSchemeKind.DARK.to_string ()
+            : AppStream.ColorSchemeKind.LIGHT.to_string ();
+
+            package_component.sort_screenshots (desktop_environment,
+                desktop_style.to_string (),
+                false);
+
+                var all_screenshots = package_component.get_screenshots_all ();
+
+                // This first pass is to gather if we have matching style and matching
+                // desktop environments, this is useful if we need to fall back to any
+                // screnshot if none of the conditions are fullfiled
+                all_screenshots.foreach ((screenshot) => {
+                    var environment_id = screenshot.get_environment ();
+                    if (environment_id != null) {
+                        var environment_split = environment_id.split (":", 2);
+                        var screenshot_environment = environment_split[0];
+                        var screenshot_style = environment_split[1]
+                        ?? AppStream.ColorSchemeKind.LIGHT.to_string ();
+
+                        if (screenshot_environment == desktop_environment) {
+                            has_matching_environment = true;
+                        }
+
+                        if (screenshot_style == desktop_style) {
+                            has_matching_style = true;
+                        }
+                    }
+                });
+
+        screenshots = new GenericArray<AppStream.Screenshot> ();
+
+        all_screenshots.foreach ((screenshot) => {
+            var environment_id = screenshot.get_environment ();
+            if (environment_id == null) {
+                screenshots.add (screenshot);
+                return;
+            }
+
+            var environment_split = environment_id.split (":", 2);
+            var screenshot_environment = environment_split[0];
+            var screenshot_style = environment_split[1]
+                ?? AppStream.ColorSchemeKind.LIGHT.to_string ();
+
+            var same_environment = screenshot_environment == desktop_environment;
+            var same_style = screenshot_style == desktop_style;
+
+            if (same_environment && same_style) {
+                screenshots.add (screenshot);
+            } else if (same_environment && !same_style && !has_matching_style) {
+                screenshots.add (screenshot);
+            } else if (!same_environment && same_style && !has_matching_environment) {
+                screenshots.add (screenshot);
+            } else if (!has_matching_environment && !has_matching_style) {
+                screenshots.add (screenshot);
+                return;
+            }
+        });
 
         if (screenshots.length > 0) {
             screenshot_carousel = new Adw.Carousel () {
@@ -942,22 +1004,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             var scale = get_scale_factor ();
             var min_screenshot_width = MAX_WIDTH * scale;
 
-            var prefer_dark_theme = Gtk.Settings.get_default ().gtk_application_prefer_dark_theme;
             screenshots.foreach ((screenshot) => {
-                var environment_id = screenshot.get_environment ();
-                if (environment_id != null) {
-                    var environment_split = environment_id.split (":", 2);
-                    if (prefer_dark_theme && environment_split.length != 2) {
-                        return;
-                    }
-
-                    var color_scheme = AppStream.ColorSchemeKind.from_string (environment_split[1]);
-                    if ((prefer_dark_theme && color_scheme != AppStream.ColorSchemeKind.DARK) ||
-                        (!prefer_dark_theme && color_scheme == AppStream.ColorSchemeKind.DARK)) {
-                        return;
-                    }
-                }
-
                 AppStream.Image? best_image = null;
                 screenshot.get_images ().foreach ((image) => {
                     // Image is better than no image


### PR DESCRIPTION
## Short summary

This aims for a second round to complete the work to complete #2210 

This uses `XDG_SESSION_DESKTOP` and use either LIGHT or DARK `ColorSchemeKind` according to `gtk_application_prefer_dark_theme`.

Then it gets the screenshot environment metadata (described here: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-screenshots) to filter screenshots that match according to priority of environment first, color scheme second.

This triggers every time you open the AppView, so you should be able to exit the Appview, then change the color scheme then go back and see changes.

The environment IDs that currently exist in AppStream can be found here: https://github.com/ximion/appstream/blob/main/data/desktop-style-ids.txt

Notice that dark style specific the `:dark` suffix, whereas light scheme simply does not. So I assign `ColorSchemeKind.LIGHT` instead of `ColorSchemeKind.UNKNOWN`

What I did was to get all screenshot in a temporary list and make two passes on the list:

* The first one is to see if there are screenshots that fulfill either the desktop environment or the desktop color scheme. This is to keep some boolean to ask about this on the second pass.
* The second pass asks questions around adding to the screenshot list class member if it passes the following criteria:
    * If the environment and style match, simply add them
    * If the environment does NOT match, but the style does AND there are no known screenshots that match style
    * If the environment does match, but the style does NOT, and there are no know screenshots that match the environment.
    * IF neither the environment nor the style match, and there are no screenshots that match neither the desktop environment nor the style
    * Null environments are automatically added, since it's impossible to assume if they fulfil the criteria or not.

The reason this is done this way is that the idea that any screenshot available is better than no screenshot. But of course we do want to have precedence on the matching desktop environment and the style, so we can technically get rid of screenshots that do not match if we _know that there are existing matching ones in the list_, hence the two passes.

I'm not sure if there is a better way to do this though, let me know if the PR makes sense or if it needs a better approach to the screenshots.

By the way I removed the filtering from the screenshots `foreach` loop and put everything in the constructor, so when it gets to that `foreach` loop everythig is already filtered out in `screenshots`. This should avoid clutter in the `foreach` loop and separates concerns.

## Tests

Oddly enough, it's a bit difficult to test this, since there are not that many applications that use the environment tag. But doing a GitHub search, I could find some:

---

### [Harvey](https://appcenter.elementary.io/com.github.danrabbit.harvey/)
Has the `pantheon` and `pantheon:dark` environment tags. It should match properly between light and dark setups.

### [Taxi](https://appcenter.elementary.io/com.github.alecaddd.taxi/)
Has only one `pantheon` environment tag. It should show that one regardless of desktop color scheme.

### [Nicotine+](https://flathub.org/apps/org.nicotine_plus.Nicotine)
Nicotine+ has `gnome` and `gnome:Dark` screenshots. It will never match the pantheon environment, but should default to style and work with light/dark schemes.

### [Ruffle](https://flathub.org/apps/rs.ruffle.Rufflee)
Similar to Nicotine+, it has `gnome` and `gnome:dark` screenshots. There is only one `gnome` screenshot, so in light color scheme, it should show only one screenshot.

### [Synfig studio](https://flathub.org/apps/org.synfig.SynfigStudio)
This is the reverse of Ruffle, only one `gnome:dark` screenshot.

### [Euterpe](https://flathub.org/apps/com.doycho.euterpe.gtk)
Has only `gnome:dark` screenshots. This means that it should always show the dark screenshots regardless of color scheme style.

---

These are the most representative applications that I could find, if you can find more, the better to test.