### PR TITLE
Various fixes in AppListUpdateView

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -225,6 +225,7 @@ public class AppCenter.App : Gtk.Application {
 
         if (show_updates) {
             ((MainWindow) active_window).go_to_installed ();
+            show_updates = false;
         }
 
         active_window.present ();

--- a/src/Core/UpdateManager.vala
+++ b/src/Core/UpdateManager.vala
@@ -227,6 +227,7 @@ public class AppCenterCore.UpdateManager : Object {
     }
 
     public async void update_cache (bool force = false) {
+        updates_liststore.remove_all ();
         cancellable.reset ();
 
         if (Utils.is_running_in_demo_mode () || Utils.is_running_in_guest_session ()) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -145,6 +145,14 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         backend.notify["job-type"].connect (update_overlaybar_label);
 
         overlaybar.label = backend.job_type.to_string ();
+
+        if (installed_view == null) {
+            installed_view = new Views.AppListUpdateView ();
+
+            installed_view.show_app.connect ((package) => {
+                show_package (package);
+            });
+        }
     }
 
     public override bool close_request () {
@@ -192,14 +200,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     }
 
     public void go_to_installed () {
-        if (installed_view == null) {
-            installed_view = new Views.AppListUpdateView ();
-
-            installed_view.show_app.connect ((package) => {
-                show_package (package);
-            });
-        }
-
         if (installed_view.parent != null) {
             navigation_view.pop_to_page (installed_view);
         } else {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -142,6 +142,7 @@ namespace AppCenter.Views {
 
             AppCenter.App.refresh_action.activate.connect (() => {
                 installed_liststore.remove_all ();
+                list_box.set_placeholder (loading_view);
 
                 refresh_menuitem.sensitive = false;
                 header_revealer.reveal_child = false;
@@ -232,7 +233,9 @@ namespace AppCenter.Views {
                     refresh_menuitem.sensitive = false;
                     header_revealer.reveal_child = false;
                     updated_revealer.reveal_child = false;
+                    list_box.set_placeholder (loading_view);
                 } else {
+                    list_box.set_placeholder (null);
                     refresh_menuitem.sensitive = true;
                     on_updates_changed ();
                 }

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -141,7 +141,6 @@ namespace AppCenter.Views {
             });
 
             AppCenter.App.refresh_action.activate.connect (() => {
-                update_manager.updates_liststore.remove_all ();
                 installed_liststore.remove_all ();
 
                 refresh_menuitem.sensitive = false;
@@ -378,11 +377,9 @@ namespace AppCenter.Views {
         }
 
         public void clear () {
-            var update_manager = AppCenterCore.UpdateManager.get_default ();
             // Free widgets with all their connected signals https://github.com/elementary/appcenter/pull/846
             list_box.remove_all ();
             installed_flowbox.remove_all ();
-            update_manager.updates_liststore.remove_all ();
         }
     }
 }

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -135,6 +135,9 @@ namespace AppCenter.Views {
                 child = refresh_accellabel
             };
             refresh_menuitem.add_css_class (Granite.STYLE_CLASS_MENUITEM);
+            refresh_menuitem.clicked.connect (() => {
+                refresh_menuitem.set_sensitive (false);
+            });
 
             var menu_popover_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
             menu_popover_box.append (automatic_updates_button);
@@ -218,6 +221,7 @@ namespace AppCenter.Views {
 
             flatpak_backend.notify ["working"].connect (() => {
                 if (flatpak_backend.working) {
+                    refresh_menuitem.set_sensitive (false);
                     updated_revealer.reveal_child = false;
                     list_box.vexpand = false;
                     
@@ -233,6 +237,7 @@ namespace AppCenter.Views {
                             break;
                     }
                 } else {
+                    refresh_menuitem.set_sensitive (true);
                     list_box.set_placeholder (null);
                 }
             });

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -302,13 +302,14 @@ namespace AppCenter.Views {
                 unowned var flatpak_backend = AppCenterCore.FlatpakBackend.get_default ();
                 var installed_apps = yield flatpak_backend.get_installed_applications (refresh_cancellable);
                 installed_header.visible = !installed_apps.is_empty;
-                list_box.vexpand = installed_apps.is_empty;
 
                 foreach (var package in installed_apps) {
                     if (package.state != UPDATE_AVAILABLE && package.kind != ADDON && package.kind != FONT) {
                         installed_liststore.insert_sorted (package, compare_installed_func);
                     }
                 }
+
+                list_box.vexpand = installed_liststore.n_items <= 0;
             }
 
             refresh_cancellable = null;

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -229,21 +229,8 @@ namespace AppCenter.Views {
                     refresh_menuitem.set_sensitive (false);
                     header_revealer.reveal_child = false;
                     updated_revealer.reveal_child = false;
-
-                    switch (flatpak_backend.job_type) {
-                        case GET_PREPARED_PACKAGES:
-                        case GET_UPDATES:
-                        case REFRESH_CACHE:
-                        case UPDATE_PACKAGE:
-                            list_box.set_placeholder (loading_view);
-                            break;
-                        default:
-                            list_box.set_placeholder (null);
-                            break;
-                    }
                 } else {
                     refresh_menuitem.set_sensitive (true);
-                    list_box.set_placeholder (null);
                     on_updates_changed ();
                 }
             });

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -132,15 +132,19 @@ namespace AppCenter.Views {
             );
 
             var refresh_menuitem = new Gtk.Button () {
-                action_name = "app.refresh",
-                child = refresh_accellabel
+                child = refresh_accellabel,
+                sensitive = false
             };
             refresh_menuitem.add_css_class (Granite.STYLE_CLASS_MENUITEM);
             refresh_menuitem.clicked.connect (() => {
-                refresh_menuitem.set_sensitive (false);
+                activate_action ("app.refresh", null);
+            });
+
+            AppCenter.App.refresh_action.activate.connect (() => {
                 update_manager.updates_liststore.remove_all ();
                 installed_liststore.remove_all ();
-                
+
+                refresh_menuitem.sensitive = false;
                 header_revealer.reveal_child = false;
                 updated_revealer.reveal_child = false;
                 installed_header.visible = false;
@@ -226,14 +230,15 @@ namespace AppCenter.Views {
 
             flatpak_backend.notify ["working"].connect (() => {
                 if (flatpak_backend.working) {
-                    refresh_menuitem.set_sensitive (false);
+                    refresh_menuitem.sensitive = false;
                     header_revealer.reveal_child = false;
                     updated_revealer.reveal_child = false;
                 } else {
-                    refresh_menuitem.set_sensitive (true);
+                    refresh_menuitem.sensitive = true;
                     on_updates_changed ();
                 }
             });
+
 
             automatic_updates_button.notify["active"].connect (() => {
                 if (automatic_updates_button.active) {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -219,7 +219,8 @@ namespace AppCenter.Views {
             flatpak_backend.notify ["working"].connect (() => {
                 if (flatpak_backend.working) {
                     updated_revealer.reveal_child = false;
-
+                    list_box.vexpand = false;
+                    
                     switch (flatpak_backend.job_type) {
                         case GET_PREPARED_PACKAGES:
                         case GET_UPDATES:

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -122,7 +122,9 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
                     release_button_revealer.reveal_child = true;
                 }
             } else {
-                release_button_revealer.reveal_child = true;
+                if (newest.get_description () != null) {
+                    release_button_revealer.reveal_child = true;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

This PR make several fixes around the `AppListUpdateView`, and the general Update packages behavior, namely:

1. Fixes #2215 _AppCenter still reserves space for system updates_
![Bug 2215](https://github.com/user-attachments/assets/ff263b2c-badb-47e0-a0e8-faa694ef2a68)

    * The problem was related to the `vexpand` property of the `list_box`. When set to `true`
 it would try to take as much space as possible. It's now set to `false` once the installed panel is visible with any available installed packages.

2. Fixes various issues around not showing properly the updates label.
    * Those are the _"Everything is up-to-date."_ and _"Updates available"_ labels on the top. They should now show/hide properly according to the update behavior.

4. Disable the "Check for updates" menu button (set sensitive to `false`) when clicking on it, and enable it when the Flatpak backend stops again. This is to stop the user for clicking multiple times (when the button is enabled for brief moments in the check for updates process), which would create duplicate items in the updates view. This fix should also disable it if you are updating any package in the updates list box.
![Check for updates menu button bug](https://github.com/user-attachments/assets/74b1aafc-8ef9-4f49-8fb1-79c50ff3eedc)

5. Fixes a bug where if you clicked on an application to update that had no description available (and thus no release notes button) and then cancel it immediately, it would show the release notes button.

https://github.com/user-attachments/assets/7d8e7593-21c0-49b4-8bd3-4460c04a3b31

6. Fixes issue #529 that the application would get "stuck" in the `AppListUpdateView` page and would not open to the main menu until terminated. This also fixes a problem where the view would not show the installed apps if you let the backend check for updates without changing to the updates view until the backend finished.

## Tests

Here is a video of the whole flow with all the fixes applied:

https://github.com/user-attachments/assets/22efbfa5-442f-4927-8c39-b8adb255f3a0

## Comments

I know this is might be a moderate (maybe big?) PR, and I may be doing things wrong here on some places, especially since I don't know the whole picture. I hope it's still good work though to at least keep working on it, or maybe getting closer to something good.

Also, if you'd rather have this split into multiple PRs, or maybe it's not good enough, let me know so I can make it more streamlined or make the necessary changes for everyone.

Thanks a lot,