### PR TITLE
Do not try to autostart the removed appcenter-daemon

### DIFF
--- a/debian/appcenter.links
+++ b/debian/appcenter.links
@@ -1,1 +1,0 @@
-usr/share/applications/io.elementary.appcenter-daemon.desktop etc/xdg/autostart/io.elementary.appcenter-daemon.desktop


### PR DESCRIPTION
This PR prevents creating the dead symlink to `/usr/share/applications/io.elementary.appcenter-daemon.desktop` at `/etc/xdg/autostart/io.elementary.appcenter-daemon.desktop` which causes the following warnings on journal:

```
user@elementary:~$ journalctl -b | grep io.elementary.appcenter-daemon
Jan 02 03:32:02 elementary systemd-xdg-autostart-generator[1048]: /etc/xdg/autostart/io.elementary.appcenter-daemon.desktop: stat() failed, ignoring: No such file or directory
Jan 02 03:32:19 elementary systemd-xdg-autostart-generator[1372]: /etc/xdg/autostart/io.elementary.appcenter-daemon.desktop: stat() failed, ignoring: No such file or directory
Jan 02 03:32:19 elementary gnome-session[1666]: gnome-session-binary[1666]: WARNING: Desktop file /etc/xdg/autostart/io.elementary.appcenter-daemon.desktop for application io.elementary.appcenter-daemon.desktop could not be parsed or references a missing TryExec binary
Jan 02 03:32:19 elementary gnome-session-binary[1666]: WARNING: Desktop file /etc/xdg/autostart/io.elementary.appcenter-daemon.desktop for application io.elementary.appcenter-daemon.desktop could not be parsed or references a missing TryExec binary
Jan 02 03:32:35 elementary systemd-xdg-autostart-generator[3113]: /etc/xdg/autostart/io.elementary.appcenter-daemon.desktop: stat() failed, ignoring: No such file or directory
Jan 02 03:32:37 elementary gnome-session[3591]: gnome-session-binary[3591]: WARNING: Desktop file /etc/xdg/autostart/io.elementary.appcenter-daemon.desktop for application io.elementary.appcenter-daemon.desktop could not be parsed or references a missing TryExec binary
Jan 02 03:32:37 elementary gnome-session-binary[3591]: WARNING: Desktop file /etc/xdg/autostart/io.elementary.appcenter-daemon.desktop for application io.elementary.appcenter-daemon.desktop could not be parsed or references a missing TryExec binary
user@elementary:~$ 
```