### PR TITLE
Preprocess metadata cache if non-existing (issue #2246)

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -241,6 +241,29 @@ public class AppCenterCore.FlatpakBackend : Object {
             "system"
         );
 
+        GLib.GenericArray<weak Flatpak.Remote> remotes = null;
+        var user_file = File.new_for_path (user_metadata_path);
+        if (user_installation != null && !user_file.query_exists ()) {
+            try {
+                user_installation.drop_caches ();
+                remotes = user_installation.list_remotes ();
+                preprocess_metadata (false, remotes, null);
+            } catch (Error e) {
+                critical ("Error getting user flatpak remotes: %s", e.message);
+            }
+        }
+
+        var system_file = File.new_for_path (system_metadata_path);
+        if (system_installation != null && !system_file.query_exists ()) {
+            try {
+                system_installation.drop_caches ();
+                remotes = system_installation.list_remotes ();
+                preprocess_metadata (true, remotes, null);
+            } catch (Error e) {
+                warning ("Error getting system flatpak remotes: %s", e.message);
+            }
+        }
+
         reload_appstream_pool ();
     }
 


### PR DESCRIPTION
## Short summary

This aims to fix #2246 

Forcefully deleting the cache will create an odd situation where the app loads the main banner and disappears after a few seconds (probably when the caches have been loaded in the worker thread), leaving the main window in an odd incomplete state.

This change looks up in the `FlatpakBackend.vala` constructor for the user and system cache metadata folders and will recreate them (via `preprocess_metadata`) if they are not found.

This will incur in a load time penalty. I believe this is not much of a big deal since this only happen if you explicitly delete the cache folders, which should be a rare occurrence in general.

## Tests

Same procedure as set in the bug:

* Kill App Center
* Remove in `~/.cache` the folders `io.elementary.appcenter`, `flatpak` and `appstream` (you can also simply delete the `~/.cache` folder itself.
* Open App Center

This fix should show the banner and recently updated icons without issue.

## Additional info

I believe this is probably the least expensive and more complete solution. There might be a case for just letting the main banner stand and do nothing... but I'm not sure about that. You'd expect all the times to have a fully loaded presentation in the main window, no matter if it's the first time or if you have cleaned your cache.