### PR TITLE
Added a Gtk.ScrollingWindow to the Release notes dialog (issue #2033)

### DIFF
--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -144,8 +144,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
 
             var releases_title = new Gtk.Label (title) {
                 selectable = true,
-                width_chars = 20,
-                wrap = true
+                halign = Gtk.Align.CENTER
             };
             releases_title.add_css_class ("primary");
 
@@ -156,10 +155,16 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
                 margin_start = 12,
                 vexpand = true
             };
-            releases_dialog_box.append (releases_title);
             releases_dialog_box.append (release_row);
 
-            get_content_area ().append (releases_dialog_box);
+            var release_scrolled_window = new Gtk.ScrolledWindow () {
+                child = releases_dialog_box,
+                width_request = 400,
+                height_request = 320,
+                valign = Gtk.Align.FILL
+            };
+            get_content_area ().append (releases_title);
+            get_content_area ().append (release_scrolled_window);
 
             add_button (_("Close"), Gtk.ResponseType.CLOSE);
 

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -146,29 +146,32 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
                 margin_end = 12,
                 margin_start = 12,
                 selectable = true,
-                halign = Gtk.Align.CENTER
+                width_chars = 20,
+                wrap = true
             };
             releases_title.add_css_class ("primary");
 
             var release_row = new AppCenter.Widgets.ReleaseRow (package.get_newest_release ()) {
                 vexpand = true
             };
-            release_row.add_css_class (Granite.STYLE_CLASS_FRAME);
-            release_row.add_css_class (Granite.STYLE_CLASS_VIEW);
+
+            var release_scrolled_window = new Gtk.ScrolledWindow () {
+                child = release_row,
+                propagate_natural_height = true,
+                propagate_natural_width = true,
+                max_content_width = 400,
+                max_content_height = 500,
+            };
+            release_scrolled_window.add_css_class (Granite.STYLE_CLASS_FRAME);
+            release_scrolled_window.add_css_class (Granite.STYLE_CLASS_VIEW);
 
             var releases_dialog_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
                 vexpand = true
             };
-            releases_dialog_box.append (release_row);
+            releases_dialog_box.append (releases_title);
+            releases_dialog_box.append (release_scrolled_window);
 
-            var release_scrolled_window = new Gtk.ScrolledWindow () {
-                child = releases_dialog_box,
-                width_request = 400,
-                height_request = 320,
-                valign = Gtk.Align.FILL
-            };
-            get_content_area ().append (releases_title);
-            get_content_area ().append (release_scrolled_window);
+            get_content_area ().append (releases_dialog_box);
 
             add_button (_("Close"), Gtk.ResponseType.CLOSE);
 


### PR DESCRIPTION
## Short summary 

This aims to fix #2033 

Added a `Gtk.ScrolledWindow` inside the release notes window. This has a fixed size that will show a scrollbar if the notes go beyond the expected size and avoid extra large release notes windows.

## Tests

I managed to reproduce this on the [Colorful](https://flathub.org/apps/pl.suve.colorful) app

#### Before: 
![Colorful Before](https://github.com/user-attachments/assets/28b68179-7a53-4323-a3f3-6ac119643d9a)

#### After:
![Colorful After](https://github.com/user-attachments/assets/864cfbea-801f-4005-82e1-9405627dccf2)


I tested other apps with different release notes layouts, and they worked ok, although none of them had the extremely long window height that Colorful had.

## Other notes

The `Gtk.ScrolledWindow` has a bit hardcoded part on `width_request` and `height_request` set `400x320`. Not sure if this could be a good solution, given my not broad knowledge on GTK4. If anyone has a better idea here, please, let me know to amend this PR.