### PR TITLE
ReleaseRow: fix overflow, improve styles

### DIFF
--- a/data/styles/AppInfoView.scss
+++ b/data/styles/AppInfoView.scss
@@ -101,7 +101,6 @@ appinfoview {
         background: #{'@selected_bg_color'};
         border-radius: rem(6px);
         margin: rem(6px) rem(12px) rem(12px) rem(12px);
-        padding: rem(12px);
     }
 
     linklistbox {

--- a/data/styles/Index.scss
+++ b/data/styles/Index.scss
@@ -7,3 +7,4 @@
 @import 'HomePage.scss';
 @import 'MainWindow.scss';
 @import 'ProgressButton.scss';
+@import 'ReleaseRow.scss';

--- a/data/styles/ReleaseRow.scss
+++ b/data/styles/ReleaseRow.scss
@@ -1,0 +1,8 @@
+release {
+    border-spacing: rem(6px);
+    padding: 1em;
+
+    box.header {
+        border-spacing: rem(6px);
+    }
+}

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -918,6 +918,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
                     foreach (unowned var release in releases) {
                         var release_row = new Widgets.ReleaseRow (release);
+                        release_row.add_css_class (Granite.STYLE_CLASS_CARD);
                         release_row.get_style_context ().add_provider (accent_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
                         release_carousel.append (release_row);

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -143,17 +143,21 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
             modal = true;
 
             var releases_title = new Gtk.Label (title) {
+                margin_end = 12,
+                margin_start = 12,
                 selectable = true,
                 width_chars = 20,
                 wrap = true
             };
             releases_title.add_css_class ("primary");
 
-            var release_row = new AppCenter.Widgets.ReleaseRow (package.get_newest_release ());
+            var release_row = new AppCenter.Widgets.ReleaseRow (package.get_newest_release ()) {
+                vexpand = true
+            };
+            release_row.add_css_class (Granite.STYLE_CLASS_FRAME);
+            release_row.add_css_class (Granite.STYLE_CLASS_VIEW);
 
             var releases_dialog_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
-                margin_end = 12,
-                margin_start = 12,
                 vexpand = true
             };
             releases_dialog_box.append (releases_title);

--- a/src/Widgets/ReleaseRow.vala
+++ b/src/Widgets/ReleaseRow.vala
@@ -37,7 +37,7 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
         header_label.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var date_label = new Gtk.Label (format_date (release.get_timestamp ())) {
-            halign = Gtk.Align.START,
+            halign = END,
             hexpand = true
         };
         date_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
@@ -49,32 +49,21 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
             wrap = true,
             xalign = 0
         };
-        description_label.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
-        var grid = new Gtk.Grid () {
-            column_spacing = 6,
-            row_spacing = 6,
-            margin_bottom = 6
-        };
-        grid.attach (header_icon, 0, 0);
-        grid.attach (header_label, 1, 0);
-        grid.attach (date_label, 2, 0);
-        grid.attach (description_label, 0, 1, 3);
+        var header_box = new Gtk.Box (HORIZONTAL, 0);
+        header_box.add_css_class ("header");
+        header_box.append (header_icon);
+        header_box.append (header_label);
+        header_box.append (date_label);
 
-        orientation = Gtk.Orientation.VERTICAL;
-        spacing = 6;
-
-        append (grid);
+        orientation = VERTICAL;
+        append (header_box);
+        append (description_label);
 
         var issues = release.get_issues ();
 
         if (issues.length > 0) {
-            var issue_header = new Gtk.Label (_("Fixed Issues")) {
-                halign = Gtk.Align.START,
-                margin_top = 9
-            };
-            issue_header.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
-
+            var issue_header = new Granite.HeaderLabel (_("Fixed Issues"));
             append (issue_header);
         }
 
@@ -90,12 +79,11 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
             };
 
             var issue_linkbutton = new Gtk.LinkButton (issue.get_url ());
-            issue_linkbutton.get_child ().destroy ();
             issue_linkbutton.child = issue_label;
 
-            var issue_box = new Gtk.Grid ();
-            issue_box.attach (issue_image, 0, 0);
-            issue_box.attach (issue_linkbutton, 1, 0);
+            var issue_box = new Gtk.Box (HORIZONTAL, 0);
+            issue_box.append (issue_image);
+            issue_box.append (issue_linkbutton);
 
             append (issue_box);
         }


### PR DESCRIPTION
Fixes #2233 
Closes #2234

* Switch to boxes instead of adding an extra grid
* Do spacing and margins in CSS so they scale with text size
* Add card style class to make release notes easier to see borders of with light accent colors

![Screenshot from 2025-02-20 10 21 35](https://github.com/user-attachments/assets/858b185f-f235-4560-ac8d-a4e4d9894246)
![Screenshot from 2025-02-20 10 21 17](https://github.com/user-attachments/assets/71104b58-a833-4de9-82a6-e58c88684841)
