### PR TITLE
SearchView: clamp results

### DIFF
--- a/data/styles/Index.scss
+++ b/data/styles/Index.scss
@@ -8,4 +8,4 @@
 @import 'MainWindow.scss';
 @import 'ProgressButton.scss';
 @import 'ReleaseRow.scss';
-@import 'SearchListItem.scss';
+@import 'SearchPage.scss';

--- a/data/styles/SearchListItem.scss
+++ b/data/styles/SearchListItem.scss
@@ -1,4 +1,0 @@
-search-list-item {
-    border-spacing: 1em 0;
-    margin: 0.5em 1em;
-}

--- a/data/styles/SearchPage.scss
+++ b/data/styles/SearchPage.scss
@@ -1,0 +1,8 @@
+navigation-view-page.search stack.large row {
+    border-radius: 0.25em;
+}
+
+search-list-item {
+    border-spacing: 1em 0;
+    margin: 0.5em 1em;
+}

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -56,7 +56,9 @@ public class AppCenter.SearchView : Adw.NavigationPage {
         search_entry.set_key_capture_widget (this);
 
         var search_clamp = new Adw.Clamp () {
-            child = search_entry
+            child = search_entry,
+            maximum_size = 800,
+            tightening_threshold = 800
         };
 
         var headerbar = new Gtk.HeaderBar () {
@@ -80,9 +82,15 @@ public class AppCenter.SearchView : Adw.NavigationPage {
         stack.add_child (alert_view);
         stack.add_child (list_view);
 
-        var scrolled = new Gtk.ScrolledWindow () {
+        var clamp = new Adw.Clamp () {
             child = stack,
-            hscrollbar_policy = Gtk.PolicyType.NEVER
+            maximum_size = 800,
+            tightening_threshold = 800
+        };
+
+        var scrolled = new Gtk.ScrolledWindow () {
+            child = clamp,
+            hscrollbar_policy = NEVER
         };
 
         var toolbarview = new Adw.ToolbarView () {
@@ -91,6 +99,7 @@ public class AppCenter.SearchView : Adw.NavigationPage {
         toolbarview.add_top_bar (headerbar);
 
         add_css_class (Granite.STYLE_CLASS_VIEW);
+        add_css_class ("search");
         child = toolbarview;
         /// TRANSLATORS: the name of the Search view
         title = C_("view", "Search");


### PR DESCRIPTION
![Screenshot from 2025-03-04 17 37 36](https://github.com/user-attachments/assets/39d9b9f9-1e33-49c3-b5f3-6752985c742f)

clamp results width, otherwise things get pretty silly with, for example a maximized window on a 30" monitor