### PR TITLE
AppIcon: reload on metadata remote preprocessed

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -51,6 +51,7 @@ public class AppCenterCore.FlatpakPackage : Package {
 public class AppCenterCore.FlatpakBackend : Object {
     public signal void operation_finished (Package package, Package.State operation, Error? error);
     public signal void cache_flush_needed ();
+    public signal void on_metadata_remote_preprocessed (string remote_title);
 
     // Based on https://github.com/flatpak/flatpak/blob/417e3949c0ecc314e69311e3ee8248320d3e3d52/common/flatpak-run-private.h
     private const string FLATPAK_METADATA_GROUP_APPLICATION = "Application";
@@ -1135,6 +1136,8 @@ public class AppCenterCore.FlatpakBackend : Object {
             } else {
                 continue;
             }
+
+            on_metadata_remote_preprocessed (remote.get_title ());
         }
     }
 

--- a/src/Widgets/AppIcon.vala
+++ b/src/Widgets/AppIcon.vala
@@ -5,29 +5,9 @@
 
 public class AppCenter.AppIcon : Adw.Bin {
     public int pixel_size { get; construct; }
+    public AppCenterCore.Package package { get; set; }
     public Icon badge_icon { get; set; }
     public Icon icon { get; set; }
-
-    public AppCenterCore.Package package {
-        set {
-            var plugin_host_package = get_plugin_host_package (value.component);
-            if (plugin_host_package != null) {
-                icon = plugin_host_package.get_icon (pixel_size, scale_factor);
-                badge_icon = value.get_icon (pixel_size / 2, scale_factor);
-
-                return;
-            }
-
-            icon = value.get_icon (pixel_size, scale_factor);
-
-            if (value.is_runtime_updates) {
-                badge_icon = new ThemedIcon ("system-software-update");
-                return;
-            }
-
-            badge_icon = null;
-        }
-    }
 
     public AppIcon (int pixel_size) {
         Object (pixel_size: pixel_size);
@@ -54,6 +34,33 @@ public class AppCenter.AppIcon : Adw.Bin {
 
         bind_property ("icon", image, "gicon");
         bind_property ("badge-icon", badge_image, "gicon");
+
+        notify["package"].connect (fetch_icon);
+
+        AppCenterCore.FlatpakBackend.get_default ().on_metadata_remote_preprocessed.connect ((remote_title) => {
+            if (package != null && package.origin_description == remote_title) {
+                fetch_icon ();
+            }
+        });
+    }
+
+    private void fetch_icon () {
+        var plugin_host_package = get_plugin_host_package (package.component);
+        if (plugin_host_package != null) {
+            icon = plugin_host_package.get_icon (pixel_size, scale_factor);
+            badge_icon = package.get_icon (pixel_size / 2, scale_factor);
+
+            return;
+        }
+
+        icon = package.get_icon (pixel_size, scale_factor);
+
+        if (package.is_runtime_updates) {
+            badge_icon = new ThemedIcon ("system-software-update");
+            return;
+        }
+
+        badge_icon = null;
     }
 
     private AppCenterCore.Package? get_plugin_host_package (AppStream.Component component) {


### PR DESCRIPTION
Does the least from #2238 to fix #2209

Doesn't include any of the fancier stuff like making fallback images look nice or fading between them