### PR TITLE
AppInfoView: show when a game supports controllers

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -272,6 +272,22 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             maximum_size = MAX_WIDTH
         };
 
+        var supports_flowbox = new Gtk.FlowBox () {
+            column_spacing = 24,
+            row_spacing = 24,
+            selection_mode = NONE
+        };
+        supports_flowbox.add_css_class ("content-warning-box");
+
+        var supports_flowbox_revealer = new Gtk.Revealer () {
+            child = supports_flowbox
+        };
+
+        var supports_clamp = new Adw.Clamp () {
+            child = supports_flowbox_revealer,
+            maximum_size = MAX_WIDTH
+        };
+
         if (!package.is_runtime_updates) {
 #if CURATED
             if (package.is_native) {
@@ -470,6 +486,43 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
                 oars_flowbox.append (social_info);
             }
+        }
+
+        var supports = package_component.get_supports ();
+        for (int i = 0; i < supports.length; i++) {
+            var relation = supports[i];
+
+            string title, description, icon_name;
+
+            switch (relation.get_value_control_kind ()) {
+                // An input method for users to control software
+                case GAMEPAD:
+                    switch (relation.get_kind ()) {
+                        case REQUIRES:
+                            title = _("Requires a Controller");
+                        case RECOMMENDS:
+                            title = _("Recommends a Controller");
+                        case SUPPORTS:
+                        default:
+                            title = _("Play With a Controller");
+                    }
+
+                    description = _("Such as a PlayStation, Xbox, or 8BitDo controller.");
+                    icon_name = "input-gaming-symbolic";
+                    break;
+
+                default:
+                    // unhandled
+                    debug (relation.get_value_control_kind ().to_string ());
+                    debug (relation.get_kind ().to_string ());
+                    continue;
+            }
+
+            supports_flowbox.append (new ContentType (
+                title,
+                description,
+                icon_name
+            ));
         }
 
         bool has_matching_environment = false;
@@ -692,6 +745,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             box.append (screenshot_stack);
         }
 
+        box.append (supports_clamp);
         box.append (body_clamp);
         box.append (release_carousel);
         box.append (links_clamp);
@@ -723,6 +777,10 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
         if (oars_flowbox.get_first_child () != null) {
             oars_flowbox_revealer.reveal_child = true;
+        }
+
+        if (supports_flowbox.get_first_child () != null) {
+            supports_flowbox_revealer.reveal_child = true;
         }
 
         origin_dropdown.notify["selected-item"].connect (() => {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -512,9 +512,11 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
                     break;
 
                 default:
-                    // unhandled
-                    debug (relation.get_value_control_kind ().to_string ());
-                    debug (relation.get_kind ().to_string ());
+                    debug (
+                        "Unhandled control kind %s %s",
+                        relation.get_kind ().to_string (),
+                        relation.get_value_control_kind ().to_string ()
+                    );
                     continue;
             }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -497,18 +497,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             switch (relation.get_value_control_kind ()) {
                 // An input method for users to control software
                 case GAMEPAD:
-                    switch (relation.get_kind ()) {
-                        case REQUIRES:
-                            title = _("Requires a Controller");
-                        case RECOMMENDS:
-                            title = _("Recommends a Controller");
-                        case SUPPORTS:
-                        default:
-                            title = _("Play With a Controller");
-                    }
-
-                    description = _("Such as a PlayStation, Xbox, or 8BitDo controller.");
-                    icon_name = "input-gaming-symbolic";
+                    get_gamepad_info_for_kind (relation.get_kind (), out icon_name, out title, out description);
                     break;
 
                 default:
@@ -1123,6 +1112,23 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
         var title = (Gtk.Label) list_item.child;
         title.label = package.origin_description;
+    }
+
+    private void get_gamepad_info_for_kind (AppStream.RelationKind kind, out string icon_name, out string title, out string description) {
+        switch (kind) {
+            case REQUIRES:
+                title = _("Requires a Controller");
+                break;
+            case RECOMMENDS:
+                title = _("Recommends a Controller");
+                break;
+            default:
+                title = _("Play With a Controller");
+                break;
+        }
+
+        description = _("Such as a PlayStation, Xbox, or 8BitDo controller.");
+        icon_name = "input-gaming-symbolic";
     }
 
     private class ArrowButton : Gtk.Button {


### PR DESCRIPTION
Initial support for listing things an app supports, starting with controllers. Eventually this will also include things like mobile support, etc. I made this a separate list from content warnings because I think it's less important and doesn't need to be "above the fold" like content warnings do

![Screenshot from 2025-05-14 13 15 56](https://github.com/user-attachments/assets/a9f84747-1a0f-42af-ba18-980af528a983)
