### PR TITLE
Homepage: label updates button for screen reader

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -131,7 +131,8 @@ public class AppCenter.Homepage : Adw.NavigationPage {
         search_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
 
         var updates_button = new Gtk.Button.from_icon_name ("software-update-available") {
-            action_name = "app.show-updates"
+            action_name = "app.show-updates",
+            tooltip_text = C_("view", "Updates & installed apps")
         };
         updates_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
 
@@ -147,8 +148,7 @@ public class AppCenter.Homepage : Adw.NavigationPage {
         };
 
         var updates_overlay = new Gtk.Overlay () {
-            child = updates_button,
-            tooltip_text = C_("view", "Updates & installed apps")
+            child = updates_button
         };
         updates_overlay.add_overlay (updates_badge_revealer);
 


### PR DESCRIPTION
Fixes missing screen reader label for the updates button

Tooltip was added to the overlay in GTK3 because the badge would prevent the button from receiving mouse over events. in GTK4 we set `can_target = false` so the tooltip works as expected when being set on the button.