### PR TITLE
get_installed_applications: mark installed on main thread

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -514,12 +514,16 @@ public class AppCenterCore.FlatpakBackend : Object {
         job.results_ready ();
     }
 
-    public async Gee.Collection<Package> get_installed_applications (Cancellable? cancellable = null) {
+    private async void get_installed_applications (Cancellable? cancellable = null) {
         var job_args = new GetInstalledPackagesArgs ();
         job_args.cancellable = cancellable;
 
         var job = yield launch_job (Job.Type.GET_INSTALLED_PACKAGES, job_args);
-        return (Gee.Collection<Package>)job.result.get_object ();
+        var installed_applications = (Gee.Collection<Package>) job.result.get_object ();
+
+        foreach (var package in installed_applications) {
+            package.mark_installed ();
+        }
     }
 
     private Gee.Collection<Package> get_installed_apps_from_refs (bool system, GLib.GenericArray<weak Flatpak.InstalledRef> installed_refs, Cancellable? cancellable) {
@@ -535,8 +539,6 @@ public class AppCenterCore.FlatpakBackend : Object {
             var bundle_id = generate_package_list_key (system, installed_ref.origin, installed_ref.format_ref ());
             var package = package_list[bundle_id];
             if (package != null) {
-                package.mark_installed ();
-                package.update_state ();
                 installed_apps.add (package);
             }
         }


### PR DESCRIPTION
marking installed results in an update state call which in turn results in
1. a notify signal for state to which a bunch of ui components are connected which leads to incosistencies and crashes with gtk not being threadsafe
2. since the list models pr an items_changed in the list models to which a bunch of other stuff is connected with the same problems as 1

I think in general we should be much more careful with doing things like that in the worker thread (e.g. #2306 comes to mind) since I could imagine a good portion of crashes currently are due to us calling methods or emitting signals from the worker thread or not being aware they are emitted from the worker thread.

Fixes a crash that sometimes occurs when trying to start appcenter silently and probably a bunch of incosistencies when appcenter is open while we fetch installed apps (e.g. on refresh)