### PR TITLE
Rewording End of life warning box with a simpler description (#2244)

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -818,8 +818,8 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
         switch (package.runtime_status) {
             case RuntimeStatus.END_OF_LIFE:
                 runtime_warning = new ContentType (
-                    _("End of Life"),
-                    _("May not work as expected or receive security updates"),
+                    _("Outdated"),
+                    _("May not receive security updates"),
                     "flatpak-eol-symbolic"
                 );
                 break;

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -819,7 +819,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             case RuntimeStatus.END_OF_LIFE:
                 runtime_warning = new ContentType (
                     _("Outdated"),
-                    _("May not receive security updates"),
+                    _("May not work as expected or receive security updates"),
                     "flatpak-eol-symbolic"
                 );
                 break;


### PR DESCRIPTION
### Short Summary

This issue relates to a redaction problem on what end-of-life means.
Particularly expressed in #2244

In the Flatpak context, it means that the app is currently using an end-of-life runtime, which itself is problematic and the app should update it. But currently the wording of the message seems to indicate that the developer has set an end-of-life treatment to the product, which is not the intention of the message.

So the wording was changed to simply indicate that the issue is "outdated" and it may not receive important security updates (the main consequence not having an up-to-date runtime)

### Tests

I tested these changes in the following apps:
* Atoms
* Veusz

Atoms and Veusz have an end-of-life runtime. They now show the reworded text:

> **Outdated**
> _May not work as expected or receive security updates_

This is similar to the MAJOR_OUTDATED warning box, but instead of mentioning features, it mentions security updates, which is, as afar as I understand, the main drawback of having and EOL runtime.