### PR TITLE
Styles: remove placeholder app icon dim

### DIFF
--- a/data/styles/HomePage.scss
+++ b/data/styles/HomePage.scss
@@ -75,7 +75,3 @@ homepage {
         }
     }
 }
-
-.icon-dim {
-    filter: blur(0.75px) saturate(20%);
-}

--- a/src/Widgets/AppIcon.vala
+++ b/src/Widgets/AppIcon.vala
@@ -21,7 +21,6 @@ public class AppCenter.AppIcon : Adw.Bin {
             pixel_size = pixel_size,
             gicon = new ThemedIcon ("application-default-icon"),
         };
-        image_default_icon.add_css_class ("icon-dim");
 
         image = new Gtk.Image () {
             pixel_size = pixel_size


### PR DESCRIPTION
We should be consistent here. If there needs to be design changes to the default icon we should do that in the icon set and not as a (expensive) CSS filter.

See also: https://github.com/elementary/icons/pull/1380