### PR TITLE
Create ReleasesDialog.vala and redesign

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -13,6 +13,7 @@ src/Core/Stripe.vala
 src/Core/UpdateManager.vala
 src/Dialogs/InstallFailDialog.vala
 src/Dialogs/RepairFailDialog.vala
+src/Dialogs/ReleasesDialog.vala
 src/Dialogs/StripeDialog.vala
 src/Dialogs/UninstallConfirmDialog.vala
 src/Dialogs/UninstallFailDialog.vala

--- a/src/Dialogs/ReleasesDialog.vala
+++ b/src/Dialogs/ReleasesDialog.vala
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2025 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+public class AppCenter.ReleasesDialog : Granite.Dialog {
+    public AppCenterCore.Package package { get; construct; }
+
+    public ReleasesDialog (AppCenterCore.Package package) {
+        Object (package: package);
+    }
+
+    construct {
+        title = _("What's new in %s").printf (package.name);
+        modal = true;
+
+        var releases_title = new Gtk.Label (title) {
+            margin_end = 12,
+            margin_start = 12,
+            selectable = true,
+            width_chars = 20,
+            wrap = true
+        };
+        releases_title.add_css_class ("primary");
+
+        var release_row = new AppCenter.Widgets.ReleaseRow (package.get_newest_release ()) {
+            vexpand = true
+        };
+
+        var release_scrolled_window = new Gtk.ScrolledWindow () {
+            child = release_row,
+            propagate_natural_height = true,
+            propagate_natural_width = true,
+            max_content_width = 400,
+            max_content_height = 500,
+        };
+        release_scrolled_window.add_css_class (Granite.STYLE_CLASS_FRAME);
+        release_scrolled_window.add_css_class (Granite.STYLE_CLASS_VIEW);
+
+        var releases_dialog_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
+            vexpand = true
+        };
+        releases_dialog_box.append (releases_title);
+        releases_dialog_box.append (release_scrolled_window);
+
+        get_content_area ().append (releases_dialog_box);
+
+        add_button (_("Close"), Gtk.ResponseType.CLOSE);
+
+        response.connect (() => {
+            close ();
+        });
+    }
+}

--- a/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
+++ b/src/Widgets/AppContainers/InstalledPackageRowGrid.vala
@@ -84,7 +84,7 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         append (grid);
 
         release_button.clicked.connect (() => {
-            var releases_dialog = new ReleaseDialog (package) {
+            var releases_dialog = new ReleasesDialog (package) {
                 transient_for = ((Gtk.Application) Application.get_default ()).active_window
             };
             releases_dialog.present ();
@@ -129,55 +129,5 @@ public class AppCenter.Widgets.InstalledPackageRowGrid : AbstractPackageRowGrid 
         }
 
         changed ();
-    }
-
-    private class ReleaseDialog : Granite.Dialog {
-        public AppCenterCore.Package package { get; construct; }
-
-        public ReleaseDialog (AppCenterCore.Package package) {
-            Object (package: package);
-        }
-
-        construct {
-            title = _("What's new in %s").printf (package.name);
-            modal = true;
-
-            var releases_title = new Gtk.Label (title) {
-                margin_end = 12,
-                margin_start = 12,
-                selectable = true,
-                width_chars = 20,
-                wrap = true
-            };
-            releases_title.add_css_class ("primary");
-
-            var release_row = new AppCenter.Widgets.ReleaseRow (package.get_newest_release ()) {
-                vexpand = true
-            };
-
-            var release_scrolled_window = new Gtk.ScrolledWindow () {
-                child = release_row,
-                propagate_natural_height = true,
-                propagate_natural_width = true,
-                max_content_width = 400,
-                max_content_height = 500,
-            };
-            release_scrolled_window.add_css_class (Granite.STYLE_CLASS_FRAME);
-            release_scrolled_window.add_css_class (Granite.STYLE_CLASS_VIEW);
-
-            var releases_dialog_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
-                vexpand = true
-            };
-            releases_dialog_box.append (releases_title);
-            releases_dialog_box.append (release_scrolled_window);
-
-            get_content_area ().append (releases_dialog_box);
-
-            add_button (_("Close"), Gtk.ResponseType.CLOSE);
-
-            response.connect (() => {
-                close ();
-            });
-        }
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ appcenter_files = files(
     'Core/Stripe.vala',
     'Core/UpdateManager.vala',
     'Dialogs/InstallFailDialog.vala',
+    'Dialogs' / 'ReleasesDialog.vala',
     'Dialogs/RepairFailDialog.vala',
     'Dialogs/StripeDialog.vala',
     'Dialogs/UninstallConfirmDialog.vala',


### PR DESCRIPTION
Use a list of cards for releases in the release dialog and make it its own class. I eventually want to use it in AppInfoView as well

## AFTER
<img width="454" height="554" alt="Screenshot from 2025-08-30 15 13 58" src="https://github.com/user-attachments/assets/c4b02867-c8f7-4f59-9433-4b79fa055b41" />

## BEFORE
<img width="479" height="555" alt="Screenshot from 2025-08-30 15 18 48" src="https://github.com/user-attachments/assets/14f34887-982f-46a5-b538-dddc006c88f8" />
