### PR TITLE
ODRSProvider: Result as return value, set out parameters only when succeeds

### DIFF
--- a/src/Core/ODRSProvider.vala
+++ b/src/Core/ODRSProvider.vala
@@ -6,7 +6,7 @@
 public class AppCenter.ODRSProvider : Object {
     private const string REVIEW_SERVER = "https://odrs.gnome.org/1.0/reviews/api";
 
-    public static async void fetch_ratings_for_app (string app_id, out int64 avg, out uint n_ratings) {
+    public static async bool fetch_ratings_for_app (string app_id, out int64 avg, out uint n_ratings) {
         avg = -1;
         n_ratings = 0;
 
@@ -15,7 +15,7 @@ public class AppCenter.ODRSProvider : Object {
             user_hash = get_user_hash ();
         } catch (Error e) {
             critical (e.message);
-            return;
+            return false;
         }
 
         var distro = Environment.get_os_info ("NAME");
@@ -61,14 +61,13 @@ public class AppCenter.ODRSProvider : Object {
             bytes = yield session.send_and_read_async (message, GLib.Priority.DEFAULT, null);
         } catch (Error e) {
             critical (e.message);
-            avg = -1;
-            return;
+            return false;
         }
 
         var output = (string) bytes.get_data ();
         if (output == null) {
             critical ("no ODRS output");
-            return;
+            return false;
         }
 
         var parser = new Json.Parser ();
@@ -76,41 +75,43 @@ public class AppCenter.ODRSProvider : Object {
             parser.load_from_data (output);
         } catch (Error e) {
             critical ("ODRS: %s", e.message);
-            return;
+            return false;
         }
 
         var root = parser.get_root ();
         if (root == null) {
             critical ("no ODRS root");
-            return;
+            return false;
         }
 
         if (root.get_node_type () != ARRAY) {
             critical ("no ODRS array");
-            return;
+            return false;
         }
 
         int64 sum_rating = 0;
         var reviews = root.get_array ();
 
-        n_ratings = reviews.get_length ();
+        uint num_ratings = reviews.get_length ();
         for (int i = 0; i < reviews.get_length (); i++) {
             var element = reviews.get_element (i);
 
             var object = element.get_object ();
             if (object == null || !object.has_member ("rating")) {
-                n_ratings = n_ratings - 1;
+                num_ratings = num_ratings - 1;
                 continue;
             }
 
             sum_rating += object.get_int_member ("rating");
         }
 
-        if (n_ratings <= 0) {
-            return;
+        if (num_ratings <= 0) {
+            return false;
         }
 
+        n_ratings = num_ratings;
         avg = sum_rating / n_ratings;
+        return true;
     }
 
    /*

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -285,8 +285,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
                 int64 avg;
                 uint n_ratings;
 
-                bool ret = ODRSProvider.fetch_ratings_for_app.end (res, out avg, out n_ratings);
-                if (!ret) {
+                if (!ODRSProvider.fetch_ratings_for_app.end (res, out avg, out n_ratings)) {
                     return;
                 }
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -282,11 +282,11 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
 
         if (!package.is_runtime_updates) {
             ODRSProvider.fetch_ratings_for_app.begin (package_component.id, (obj, res) => {
-                int64 avg = -1;
-                uint n_ratings = 0;
+                int64 avg;
+                uint n_ratings;
 
-                ODRSProvider.fetch_ratings_for_app.end (res, out avg, out n_ratings);
-                if (n_ratings == 0 || avg == -1) {
+                bool ret = ODRSProvider.fetch_ratings_for_app.end (res, out avg, out n_ratings);
+                if (!ret) {
                     return;
                 }
 


### PR DESCRIPTION
- out variables does not need to be initialized explicitly in the calling side
- Use return value instead of out parameters to check if the method succeeds
- Make sure to set values to the out parameters only when the method succeeds
