### PR TITLE
Memory leak: Application views + screenshots never release memory to the system

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -14,6 +14,9 @@
 * with this program. If not, see http://www.gnu.org/licenses/.
 */
 
+[CCode (cheader_filename = "malloc.h")]
+extern int malloc_trim (size_t pad);
+
 public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     public const string ACTION_PREFIX = "win.";
     public const string ACTION_SHOW_PACKAGE = "show-package";
@@ -156,7 +159,10 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
         // We have to wrap in Idle otherwise we crash because libportal hasn't unexported us yet.
         ((AppCenter.App) application).request_background.begin (() =>
-            Idle.add_once (() => destroy ())
+            Idle.add_once (() => {
+                destroy ();
+                Idle.add_once (() => malloc_trim (0));
+            })
         );
 
         return true;

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -45,6 +45,12 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
     private Gtk.Revealer oars_flowbox_revealer;
     private Gtk.Revealer uninstall_button_revealer;
 
+    private Gtk.Revealer title_revealer;
+    private Gtk.Box header;
+    private Gtk.ScrolledWindow scrolled;
+    private Gtk.Revealer screenshot_arrow_revealer_p;
+    private Gtk.Revealer screenshot_arrow_revealer_n;
+
     private bool is_runtime_warning_shown = false;
     private bool permissions_shown = false;
 
@@ -75,7 +81,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
         title_widget.append (title_label);
         title_widget.add_css_class (Granite.STYLE_CLASS_TITLE_LABEL);
 
-        var title_revealer = new Gtk.Revealer () {
+        title_revealer = new Gtk.Revealer () {
             child = title_widget,
             transition_type = CROSSFADE
         };
@@ -192,7 +198,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
             maximum_size = MAX_WIDTH
         };
 
-        var header = new Gtk.Box (HORIZONTAL, 0) {
+        header = new Gtk.Box (HORIZONTAL, 0) {
             hexpand = true
         };
         header.append (header_clamp);
@@ -555,14 +561,14 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
                 }
             });
 
-            var screenshot_arrow_revealer_p = new Gtk.Revealer () {
+            screenshot_arrow_revealer_p = new Gtk.Revealer () {
                 child = screenshot_previous,
                 halign = Gtk.Align.START,
                 valign = Gtk.Align.CENTER,
                 transition_type = Gtk.RevealerTransitionType.CROSSFADE
             };
 
-            var screenshot_arrow_revealer_n = new Gtk.Revealer () {
+            screenshot_arrow_revealer_n = new Gtk.Revealer () {
                 child = screenshot_next,
                 halign = Gtk.Align.END,
                 valign = Gtk.Align.CENTER,
@@ -673,7 +679,7 @@ public class AppCenter.Views.AppInfoView : Adw.NavigationPage {
         box.append (body_clamp);
         box.append (new AuthorView (package, MAX_WIDTH));
 
-        var scrolled = new Gtk.ScrolledWindow () {
+        scrolled = new Gtk.ScrolledWindow () {
             child = box,
             hscrollbar_policy = Gtk.PolicyType.NEVER,
             hexpand = true,

--- a/src/Widgets/Screenshot.vala
+++ b/src/Widgets/Screenshot.vala
@@ -14,6 +14,7 @@ public class AppCenter.Screenshot : Granite.Bin {
 
     private static Gee.HashMap<string, Gtk.CssProvider>? providers;
     private Gtk.Picture picture;
+    private string? accent_color;
 
     class construct {
         set_css_name ("screenshot");
@@ -40,14 +41,18 @@ public class AppCenter.Screenshot : Granite.Bin {
         add_css_class (Granite.CssClass.CARD);
 
         bind_property ("caption", label, "label");
+
+        // Only capture `this` here: capturing a local would make Vala use
+        // g_signal_connect_data (), which refs us into the process-lifetime
+        // Granite.Settings singleton and leaks every screenshot ever shown
+        Granite.Settings.get_default ().notify["prefers-color-scheme"].connect (() => {
+            set_accent_color (accent_color);
+        });
     }
 
     public void set_branding (AppCenterCore.Package package) {
-        set_accent_color (package.get_color_primary ());
-
-        Granite.Settings.get_default ().notify["prefers-color-scheme"].connect (() => {
-            set_accent_color (package.get_color_primary ());
-        });
+        accent_color = package.get_color_primary ();
+        set_accent_color (accent_color);
     }
 
     private void set_accent_color (string? color) {


### PR DESCRIPTION
Every AppInfoView (and all of its screenshots) stayed alive after being popped from the navigation view, so browsing leaked hundreds of MB that were never reclaimed. (I initially thought this was just a screenshot issue.)

Now AppInfoView is free'd within the app memory pool when navigating away, and closing the window releases all free'd memory to the system.

**Before:** Browing apps brought memory usage to 1.4GiB, not free'd on close.
**After:** Browsing apps brought memory usage to ~800MiB, free'd to ~500MiB on close.