### PR TITLE
UpdatesView is a dialog

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -76,6 +76,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             modal = true,
             transient_for = this
         };
+        installed_view.navigate.connect ((uid) => activate_action_variant (MainWindow.ACTION_PREFIX + MainWindow.ACTION_SHOW_PACKAGE, uid));
 
         navigation_view = new Adw.NavigationView ();
         navigation_view.add (homepage);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -25,7 +25,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     // Launchable package set when installed
     private AppCenterCore.Package? last_installed_package;
 
-    private Views.AppListUpdateView installed_view;
+    private UpdatesDialog installed_view;
 
     public MainWindow (Gtk.Application app) {
         Object (application: app);
@@ -72,7 +72,10 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
 
         var homepage = new Homepage ();
 
-        installed_view = new Views.AppListUpdateView ();
+        installed_view = new UpdatesDialog () {
+            modal = true,
+            transient_for = this
+        };
 
         navigation_view = new Adw.NavigationView ();
         navigation_view.add (homepage);
@@ -196,11 +199,7 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     }
 
     public void go_to_installed () {
-        if (installed_view.parent != null) {
-            navigation_view.pop_to_page (installed_view);
-        } else {
-            navigation_view.push (installed_view);
-        }
+        installed_view.present ();
     }
 
     public void search (string term = "", bool mimetype = false) {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -66,7 +66,6 @@ public class AppCenter.UpdatesDialog : Gtk.ApplicationWindow {
         updatable_header.append (update_all_button);
 
         list_box = new Gtk.ListBox () {
-            activate_on_single_click = true,
             hexpand = true,
         };
         list_box.bind_model (flatpak_backend.updatable_packages, create_row_from_package);
@@ -82,7 +81,6 @@ public class AppCenter.UpdatesDialog : Gtk.ApplicationWindow {
         };
 
         var in_progress_list = new Gtk.ListBox () {
-            activate_on_single_click = true,
             hexpand = true,
         };
         in_progress_list.bind_model (flatpak_backend.working_packages, create_row_from_package);
@@ -103,6 +101,7 @@ public class AppCenter.UpdatesDialog : Gtk.ApplicationWindow {
         );
 
         installed_flowbox = new Gtk.FlowBox () {
+            activate_on_single_click = false,
             column_spacing = 24,
             max_children_per_line = 5,
             row_spacing = 12

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -8,7 +8,7 @@
 
 /** AppList for the Updates View. Sorts update_available first and shows headers.
  * Does not show Uninstall Button **/
-public class AppCenter.Views.AppListUpdateView : Adw.NavigationPage {
+public class AppCenter.UpdatesDialog : Gtk.Window {
     private Gtk.FlowBox installed_flowbox;
     private Gtk.ListBox list_box;
     private Granite.HeaderLabel installed_header;
@@ -117,7 +117,7 @@ public class AppCenter.Views.AppListUpdateView : Adw.NavigationPage {
 
         var clamp = new Adw.Clamp () {
             child = box,
-            maximum_size = AppInfoView.MAX_WIDTH,
+            maximum_size = Views.AppInfoView.MAX_WIDTH,
         };
 
         var scrolled = new Gtk.ScrolledWindow () {
@@ -154,7 +154,7 @@ public class AppCenter.Views.AppListUpdateView : Adw.NavigationPage {
         menu_popover.add_css_class (Granite.STYLE_CLASS_MENU);
 
         var menu_button = new Gtk.MenuButton () {
-            icon_name = "open-menu",
+            icon_name = "open-menu-symbolic",
             popover = menu_popover,
             primary = true,
             tooltip_markup = ("%s\n" + Granite.TOOLTIP_SECONDARY_TEXT_MARKUP).printf (
@@ -162,21 +162,11 @@ public class AppCenter.Views.AppListUpdateView : Adw.NavigationPage {
                 "F10"
             )
         };
-        menu_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
-
-        var search_button = new Gtk.Button.from_icon_name ("edit-find") {
-            action_name = "win.search",
-            /// TRANSLATORS: the action of searching
-            tooltip_text = C_("action", "Search")
-        };
-        search_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
 
         var headerbar = new Gtk.HeaderBar () {
             title_widget = new Gtk.Grid () { visible = false }
         };
-        headerbar.pack_start (new BackButton ());
         headerbar.pack_end (menu_button);
-        headerbar.pack_end (search_button);
 
         var toolbarview = new Adw.ToolbarView () {
             content = scrolled
@@ -184,9 +174,15 @@ public class AppCenter.Views.AppListUpdateView : Adw.NavigationPage {
         toolbarview.add_top_bar (headerbar);
         toolbarview.add_css_class (Granite.STYLE_CLASS_VIEW);
 
+        titlebar = new Gtk.Grid () { visible = false };
         child = toolbarview;
+        hide_on_close = true;
         /// TRANSLATORS: the name of the Installed Apps view
         title = C_("view", "Installed");
+        default_height = 600;
+        default_width = 400;
+        height_request = 400;
+        add_css_class ("dialog");
 
         list_box.row_activated.connect ((row) => {
             if (row.get_child () is Widgets.InstalledPackageRowGrid) {

--- a/src/Views/AppListUpdateView.vala
+++ b/src/Views/AppListUpdateView.vala
@@ -8,7 +8,9 @@
 
 /** AppList for the Updates View. Sorts update_available first and shows headers.
  * Does not show Uninstall Button **/
-public class AppCenter.UpdatesDialog : Gtk.Window {
+public class AppCenter.UpdatesDialog : Gtk.ApplicationWindow {
+    public signal void navigate (string uid);
+
     private Gtk.FlowBox installed_flowbox;
     private Gtk.ListBox list_box;
     private Granite.HeaderLabel installed_header;
@@ -17,6 +19,8 @@ public class AppCenter.UpdatesDialog : Gtk.Window {
     private uint updated_label_timeout_id = 0;
 
     construct {
+        application = (Gtk.Application) GLib.Application.get_default ();
+
         var update_manager = AppCenterCore.UpdateManager.get_default ();
         unowned var flatpak_backend = AppCenterCore.FlatpakBackend.get_default ();
 
@@ -187,14 +191,16 @@ public class AppCenter.UpdatesDialog : Gtk.Window {
         list_box.row_activated.connect ((row) => {
             if (row.get_child () is Widgets.InstalledPackageRowGrid) {
                 var package = ((Widgets.InstalledPackageRowGrid) row.get_child ()).package;
-                activate_action_variant (MainWindow.ACTION_PREFIX + MainWindow.ACTION_SHOW_PACKAGE, package.uid);
+                navigate (package.uid);
+                close ();
             }
         });
 
         installed_flowbox.child_activated.connect ((child) => {
             if (child.get_child () is Widgets.InstalledPackageRowGrid) {
                 var package = ((Widgets.InstalledPackageRowGrid) child.get_child ()).package;
-                activate_action_variant (MainWindow.ACTION_PREFIX + MainWindow.ACTION_SHOW_PACKAGE, package.uid);
+                navigate (package.uid);
+                close ();
             }
         });
 


### PR DESCRIPTION
<img width="1096" height="835" alt="Screenshot from 2026-08-10 11 17 05" src="https://github.com/user-attachments/assets/24fc9ecb-b108-4717-9e6d-a0ef3aceb23e" />


* Updates and installed is a dialog
* Double click activate because it takes you away from this window

Todo:
- [x] Check for updates action is broken
- [x] Navigating to app pages is busted. Should close dialog
- [ ] Something about window title when scrolling?
- [ ] What's New should probably be a subpage instead of a dialog here?