### PR TITLE
FlatpakBackend: reduce path/file conversions

### DIFF
--- a/src/Core/FlatpakBackend.vala
+++ b/src/Core/FlatpakBackend.vala
@@ -1197,16 +1197,10 @@ public class AppCenterCore.FlatpakBackend : Object, Backend {
                 debug ("Appstream updated: %s", success.to_string ());
             }
 
-            var metadata_location = remote.get_appstream_dir (null).get_path ();
-            var metadata_folder_file = File.new_for_path (metadata_location);
-
-            var metadata_path = Path.build_filename (metadata_location, "appstream.xml.gz");
-            var metadata_file = File.new_for_path (metadata_path);
-
+            var appstream_dir = remote.get_appstream_dir (null);
+            var metadata_file = appstream_dir.get_child ("appstream.xml.gz");
             if (metadata_file.query_exists ()) {
-                var dest_file = dest_folder.get_child (origin_name + ".xml.gz");
-
-                perform_xml_fixups (origin_name, metadata_file, dest_file);
+                perform_xml_fixups (origin_name, metadata_file, dest_path);
 
                 var local_icons_path = dest_folder.get_child ("icons");
                 if (!local_icons_path.query_exists ()) {
@@ -1218,7 +1212,7 @@ public class AppCenterCore.FlatpakBackend : Object, Backend {
                     }
                 }
 
-                var remote_icons_folder = metadata_folder_file.get_child ("icons");
+                var remote_icons_folder = appstream_dir.get_child ("icons");
                 if (!remote_icons_folder.query_exists ()) {
                     continue;
                 }
@@ -1479,7 +1473,7 @@ public class AppCenterCore.FlatpakBackend : Object, Backend {
         }
     }
 
-    private static void perform_xml_fixups (string origin_name, File src_file, File dest_file) {
+    private static void perform_xml_fixups (string origin_name, File src_file, string dest_path) {
         var path = src_file.get_path ();
         Xml.Doc* doc = Xml.Parser.parse_file (path);
         if (doc == null) {
@@ -1570,7 +1564,7 @@ public class AppCenterCore.FlatpakBackend : Object, Backend {
         }
 
         doc->set_compress_mode (7);
-        doc->save_file (dest_file.get_path ());
+        doc->save_file (Path.build_filename (dest_path, origin_name + ".xml.gz"));
 
         delete res;
         delete doc;


### PR DESCRIPTION
We're doing a lot of converting back and forth between files and paths. Try to reduce that